### PR TITLE
feat(settings): 添加导出预设选择器 Settings 页面

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -3,11 +3,13 @@ import type { OpenedFile, TocItem } from '../types/document';
 import { createEmptyFile } from '../types/document';
 import { openFile, saveFile, saveFileAs } from '../services/fileService';
 import { exportToWord } from '../services/wordExportService';
+import { getExportPreset } from '../services/settingsService';
 import { Toolbar } from '../components/Toolbar';
 import { EditorPane } from '../components/EditorPane';
 import { PreviewPane } from '../components/PreviewPane';
 import { DocxPreviewPane } from '../components/DocxPreviewPane';
 import { StatusBar } from '../components/StatusBar';
+import { SettingsPage } from '../components/SettingsPage';
 import { readTextFile, readFile } from '@tauri-apps/plugin-fs';
 import { convertDocxToHtml } from '../services/docxPreviewService';
 
@@ -29,6 +31,7 @@ export function AppLayout() {
   const [file, setFile] = useState<OpenedFile>(createEmptyFile());
   const [toc, setToc] = useState<TocItem[]>([]);
   const [tocVisible, setTocVisible] = useState(true);
+  const [settingsVisible, setSettingsVisible] = useState(false);
 
   const handleOpen = useCallback(async () => {
     const opened = await openFile();
@@ -66,7 +69,7 @@ export function AppLayout() {
   const handleExportWord = useCallback(async () => {
     if (!file.path) return;
     try {
-      await exportToWord(file.content, file.name);
+      await exportToWord(file.content, file.name, getExportPreset());
     } catch (e) {
       console.error('Export failed:', e);
     }
@@ -139,6 +142,14 @@ export function AppLayout() {
     );
   }, [toc, tocVisible]);
 
+  if (settingsVisible) {
+    return (
+      <div className="app-layout">
+        <SettingsPage onClose={() => setSettingsVisible(false)} />
+      </div>
+    );
+  }
+
   return (
     <div className="app-layout">
       <Toolbar
@@ -150,6 +161,7 @@ export function AppLayout() {
         onSave={handleSave}
         onSaveAs={handleSaveAs}
         onExportWord={handleExportWord}
+        onOpenSettings={() => setSettingsVisible(true)}
       />
       <div className="main-content split-layout">
         {file.fileType === 'docx' ? (

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { ExportSection } from './settings/ExportSection';
+
+type SettingsSection = 'export';
+
+interface SettingsPageProps {
+  onClose: () => void;
+}
+
+export function SettingsPage({ onClose }: SettingsPageProps) {
+  const [activeSection, setActiveSection] = useState<SettingsSection>('export');
+
+  return (
+    <div className="settings-page">
+      <div className="settings-sidebar">
+        <button className="settings-back" onClick={onClose}>
+          ← 返回
+        </button>
+        <h2 className="settings-title">Settings</h2>
+        <nav className="settings-nav">
+          <button
+            className={`settings-nav-item ${activeSection === 'export' ? 'active' : ''}`}
+            onClick={() => setActiveSection('export')}
+          >
+            导出
+          </button>
+        </nav>
+      </div>
+      <div className="settings-content">
+        {activeSection === 'export' && <ExportSection />}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -7,11 +7,12 @@ type ToolbarProps = {
   onSave: () => void;
   onSaveAs: () => void;
   onExportWord: () => void;
+  onOpenSettings: () => void;
 };
 
 export function Toolbar({
   dirty, fileName, tocVisible, onToggleToc,
-  onOpen, onSave, onSaveAs, onExportWord,
+  onOpen, onSave, onSaveAs, onExportWord, onOpenSettings,
 }: ToolbarProps) {
   return (
     <div className="app-toolbar">
@@ -25,6 +26,9 @@ export function Toolbar({
       <div className="toolbar-right">
         <button className={tocVisible ? 'active' : ''} onClick={onToggleToc}>
           大纲
+        </button>
+        <button className="toolbar-settings-btn" onClick={onOpenSettings} title="设置">
+          ⚙
         </button>
       </div>
     </div>

--- a/src/components/settings/ExportSection.tsx
+++ b/src/components/settings/ExportSection.tsx
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+import { getExportPreset, setExportPreset } from '../../services/settingsService';
+import { listPresets } from '../../services/word/config';
+import type { PresetId } from '../../services/word/types';
+
+export function ExportSection() {
+  const [selected, setSelected] = useState<PresetId>(getExportPreset());
+  const presets = listPresets();
+
+  useEffect(() => {
+    setSelected(getExportPreset());
+  }, []);
+
+  const handleChange = (id: PresetId) => {
+    setSelected(id);
+    setExportPreset(id);
+  };
+
+  return (
+    <div className="settings-section">
+      <h3 className="settings-section-title">导出预设</h3>
+      <div className="settings-preset-list">
+        {presets.map((preset) => (
+          <label
+            key={preset.id}
+            className={`settings-preset-item ${selected === preset.id ? 'active' : ''}`}
+          >
+            <input
+              type="radio"
+              name="export-preset"
+              value={preset.id}
+              checked={selected === preset.id}
+              onChange={() => handleChange(preset.id)}
+              className="settings-preset-radio"
+            />
+            <span className="settings-preset-indicator" />
+            <span className="settings-preset-content">
+              <span className="settings-preset-name">{preset.name}</span>
+              <span className="settings-preset-desc">{preset.description}</span>
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -178,3 +178,174 @@ html, body, #root {
   color: #e67e22;
   font-weight: 500;
 }
+
+/* ===== Settings Page ===== */
+
+.settings-page {
+  display: flex;
+  flex: 1;
+  height: 100%;
+  overflow: hidden;
+}
+
+.settings-sidebar {
+  width: 200px;
+  flex-shrink: 0;
+  background: var(--surface, #fff);
+  border-right: 1px solid var(--border, #e8e8e8);
+  padding-top: 16px;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-back {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 20px 16px;
+  font-size: 12px;
+  color: var(--muted, #666);
+  cursor: pointer;
+  transition: color 0.1s;
+  background: none;
+  border: none;
+  font-family: var(--font-body, -apple-system, BlinkMacSystemFont, sans-serif);
+}
+
+.settings-back:hover {
+  color: var(--accent, #a0522d);
+}
+
+.settings-title {
+  font-family: var(--font-display, 'Iowan Old Style', 'Charter', Georgia, serif);
+  font-size: 20px;
+  font-weight: 400;
+  padding: 0 20px 16px;
+  letter-spacing: -0.01em;
+  color: var(--fg, #333);
+}
+
+.settings-nav {
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-nav-item {
+  padding: 6px 20px;
+  font-size: 13px;
+  color: var(--muted, #666);
+  background: none;
+  border: none;
+  border-inline-start: 2px solid transparent;
+  cursor: pointer;
+  text-align: start;
+  transition: color 0.1s, border-color 0.1s, background 0.1s;
+  font-family: var(--font-body, -apple-system, BlinkMacSystemFont, sans-serif);
+}
+
+.settings-nav-item:hover {
+  color: var(--fg, #333);
+}
+
+.settings-nav-item.active {
+  color: var(--fg, #333);
+  border-inline-start-color: var(--accent, #a0522d);
+  background: oklch(58% 0.16 35 / 0.04);
+}
+
+.settings-content {
+  flex: 1;
+  padding: 36px 44px;
+  overflow-y: auto;
+  background: var(--bg, #faf9f7);
+}
+
+.settings-section {
+  max-width: 560px;
+}
+
+.settings-section-title {
+  font-family: var(--font-display, 'Iowan Old Style', 'Charter', Georgia, serif);
+  font-size: 17px;
+  font-weight: 400;
+  margin-bottom: 16px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border, #e8e8e8);
+  letter-spacing: -0.01em;
+  color: var(--fg, #333);
+}
+
+.settings-preset-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.settings-preset-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 9px 0;
+  border-bottom: 1px solid oklch(89% 0.012 80 / 0.4);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.settings-preset-item:last-child {
+  border-bottom: none;
+}
+
+.settings-preset-radio {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.settings-preset-indicator {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border, #e0ddd8);
+  margin-top: 2px;
+  transition: border-color 0.15s, background 0.15s;
+  position: relative;
+}
+
+.settings-preset-item:hover .settings-preset-indicator {
+  border-color: var(--muted, #666);
+}
+
+.settings-preset-item.active .settings-preset-indicator {
+  border-color: var(--accent, #a0522d);
+  background: var(--accent, #a0522d);
+  box-shadow: inset 0 0 0 2.5px var(--bg, #faf9f7);
+}
+
+.settings-preset-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.settings-preset-name {
+  font-size: 13px;
+  color: var(--fg, #333);
+}
+
+.settings-preset-desc {
+  font-size: 11px;
+  color: var(--muted, #666);
+  margin-top: 2px;
+}
+
+.settings-preset-item.active .settings-preset-name {
+  color: var(--accent, #a0522d);
+}
+
+/* Toolbar settings button */
+.toolbar-settings-btn {
+  font-size: 14px !important;
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary

Closes #2

- 新增 Settings 页面（左侧导航 + 右侧内容区），与编辑器页面互斥显示
- 导出预设选择器：5 个预设（法律文书 / 学术论文 / 公文报告 / 法律服务方案 / 简约通用）以单选列表展示，选中后通过 `setExportPreset()` 持久化到 localStorage
- Toolbar 添加 ⚙ 设置按钮，点击进入 Settings 页面
- 导出 Word 时读取用户选择的预设（`getExportPreset()`），替换原来硬编码的 `'legal'`
- 所有样式遵循 DESIGN.md 规范：CSS 变量、oklch 色彩、display 字体、2-5px 圆角、无投影

## 变更文件

**新增：**
- `src/components/SettingsPage.tsx` — Settings 页面主组件（左侧导航 + 返回按钮）
- `src/components/settings/ExportSection.tsx` — 导出预设选择区块（radio list）

**修改：**
- `src/app/AppLayout.tsx` — 添加 `settingsVisible` 状态，Settings 与编辑器互斥显示，导出时读取用户预设
- `src/components/Toolbar.tsx` — 添加 `onOpenSettings` prop 和 ⚙ 按钮
- `src/styles/app.css` — 添加 Settings 页面完整样式（侧边栏、导航项、预设选择器、返回按钮）

## Test plan

- [ ] 点击 Toolbar ⚙ 按钮，Settings 页面全屏显示，编辑器隐藏
- [ ] 点击「← 返回」按钮，回到编辑器页面
- [ ] 5 个预设显示名称 + 描述，选中态用 accent 色高亮
- [ ] 切换预设后关闭 Settings，导出 Word 使用新选择的预设
- [ ] 刷新应用后预设选择持久化（localStorage）
- [ ] TypeScript 类型检查通过（`npx tsc --noEmit`）