### PR TITLE
feat: Settings 改为弹窗浮层 + 补充设计稿缺失设置项

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -144,14 +144,6 @@ export function AppLayout() {
 
   const zoomLevel = getSettings().zoomLevel;
 
-  if (settingsVisible) {
-    return (
-      <div className="app-layout" style={{ fontSize: `${zoomLevel}%` }}>
-        <SettingsPage onClose={() => setSettingsVisible(false)} />
-      </div>
-    );
-  }
-
   return (
     <div className="app-layout" style={{ fontSize: `${zoomLevel}%` }}>
       <Toolbar
@@ -183,6 +175,7 @@ export function AppLayout() {
         </div>
       </div>
       <StatusBar filePath={file.path} dirty={file.dirty} />
+      {settingsVisible && <SettingsPage onClose={() => setSettingsVisible(false)} />}
     </div>
   );
 }

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,17 +1,19 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { GeneralSection } from './settings/GeneralSection';
 import { EditorSection } from './settings/EditorSection';
 import { PreviewSection } from './settings/PreviewSection';
 import { AppearanceSection } from './settings/AppearanceSection';
 import { ShortcutsSection } from './settings/ShortcutsSection';
 import { ExportSection } from './settings/ExportSection';
 
-type SettingsSection = 'editor' | 'preview' | 'appearance' | 'shortcuts' | 'export';
+type SettingsSection = 'general' | 'editor' | 'preview' | 'appearance' | 'shortcuts' | 'export';
 
 interface SettingsPageProps {
   onClose: () => void;
 }
 
 const NAV_ITEMS: { id: SettingsSection; label: string }[] = [
+  { id: 'general', label: '通用' },
   { id: 'editor', label: '编辑器' },
   { id: 'preview', label: '预览' },
   { id: 'appearance', label: '外观' },
@@ -20,33 +22,51 @@ const NAV_ITEMS: { id: SettingsSection; label: string }[] = [
 ];
 
 export function SettingsPage({ onClose }: SettingsPageProps) {
-  const [activeSection, setActiveSection] = useState<SettingsSection>('editor');
+  const [activeSection, setActiveSection] = useState<SettingsSection>('general');
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  }, [onClose]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
 
   return (
-    <div className="settings-page">
-      <div className="settings-sidebar">
-        <button className="settings-back" onClick={onClose}>
-          ← 返回
-        </button>
-        <h2 className="settings-title">Settings</h2>
-        <nav className="settings-nav">
-          {NAV_ITEMS.map((item) => (
-            <button
-              key={item.id}
-              className={`settings-nav-item ${activeSection === item.id ? 'active' : ''}`}
-              onClick={() => setActiveSection(item.id)}
-            >
-              {item.label}
-            </button>
-          ))}
-        </nav>
-      </div>
-      <div className="settings-content">
-        {activeSection === 'editor' && <EditorSection />}
-        {activeSection === 'preview' && <PreviewSection />}
-        {activeSection === 'appearance' && <AppearanceSection />}
-        {activeSection === 'shortcuts' && <ShortcutsSection />}
-        {activeSection === 'export' && <ExportSection />}
+    <div className="settings-overlay" onClick={handleOverlayClick}>
+      <div className="settings-modal">
+        <div className="settings-modal-sidebar">
+          <h2 className="settings-title">Settings</h2>
+          <nav className="settings-nav">
+            {NAV_ITEMS.map((item) => (
+              <button
+                key={item.id}
+                className={`settings-nav-item ${activeSection === item.id ? 'active' : ''}`}
+                onClick={() => setActiveSection(item.id)}
+              >
+                {item.label}
+              </button>
+            ))}
+          </nav>
+        </div>
+        <div className="settings-modal-content">
+          {activeSection === 'general' && <GeneralSection />}
+          {activeSection === 'editor' && <EditorSection />}
+          {activeSection === 'preview' && <PreviewSection />}
+          {activeSection === 'appearance' && <AppearanceSection />}
+          {activeSection === 'shortcuts' && <ShortcutsSection />}
+          {activeSection === 'export' && <ExportSection />}
+        </div>
       </div>
     </div>
   );

--- a/src/components/settings/EditorSection.tsx
+++ b/src/components/settings/EditorSection.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { getSettings, updateSettings } from '../../services/settingsService';
+import type { EditorFontFamily } from '../../services/settingsService';
 
 const FONT_SIZES = [12, 13, 14, 15, 16, 18];
 const TAB_SIZES = [2, 4, 8];
+const FONT_FAMILIES: EditorFontFamily[] = ['IBM Plex Mono', 'JetBrains Mono', 'SF Mono', 'System Default'];
 
 export function EditorSection() {
   const [settings, setSettings] = useState(() => getSettings());
@@ -15,6 +17,21 @@ export function EditorSection() {
   return (
     <div className="settings-section">
       <h3 className="settings-section-title">编辑器</h3>
+
+      <div className="settings-row">
+        <div>
+          <div className="settings-label">字体</div>
+        </div>
+        <select
+          className="settings-select"
+          value={settings.editorFontFamily}
+          onChange={(e) => handleChange({ editorFontFamily: e.target.value })}
+        >
+          {FONT_FAMILIES.map((f) => (
+            <option key={f} value={f}>{f}</option>
+          ))}
+        </select>
+      </div>
 
       <div className="settings-row">
         <div>
@@ -48,6 +65,16 @@ export function EditorSection() {
 
       <div className="settings-row">
         <div>
+          <div className="settings-label">行号显示</div>
+        </div>
+        <button
+          className={`toggle-switch ${settings.editorLineNumbers ? 'on' : ''}`}
+          onClick={() => handleChange({ editorLineNumbers: !settings.editorLineNumbers })}
+        />
+      </div>
+
+      <div className="settings-row">
+        <div>
           <div className="settings-label">自动换行</div>
         </div>
         <button
@@ -58,11 +85,11 @@ export function EditorSection() {
 
       <div className="settings-row">
         <div>
-          <div className="settings-label">行号显示</div>
+          <div className="settings-label">拼写检查</div>
         </div>
         <button
-          className={`toggle-switch ${settings.editorLineNumbers ? 'on' : ''}`}
-          onClick={() => handleChange({ editorLineNumbers: !settings.editorLineNumbers })}
+          className={`toggle-switch ${settings.editorSpellCheck ? 'on' : ''}`}
+          onClick={() => handleChange({ editorSpellCheck: !settings.editorSpellCheck })}
         />
       </div>
     </div>

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { getSettings, updateSettings } from '../../services/settingsService';
+import type { DefaultEncoding } from '../../services/settingsService';
+
+const ENCODINGS: DefaultEncoding[] = ['UTF-8', 'GBK', 'GB18030'];
+
+export function GeneralSection() {
+  const [settings, setSettings] = useState(() => getSettings());
+
+  const handleChange = (patch: Record<string, unknown>) => {
+    updateSettings(patch);
+    setSettings(getSettings());
+  };
+
+  return (
+    <div className="settings-section">
+      <h3 className="settings-section-title">通用</h3>
+
+      <div className="settings-row">
+        <div>
+          <div className="settings-label">自动保存</div>
+          <div className="settings-desc">修改后自动保存文件</div>
+        </div>
+        <button
+          className={`toggle-switch ${settings.autoSave ? 'on' : ''}`}
+          onClick={() => handleChange({ autoSave: !settings.autoSave })}
+        />
+      </div>
+
+      <div className="settings-row">
+        <div>
+          <div className="settings-label">默认编码</div>
+        </div>
+        <select
+          className="settings-select"
+          value={settings.defaultEncoding}
+          onChange={(e) => handleChange({ defaultEncoding: e.target.value })}
+        >
+          {ENCODINGS.map((enc) => (
+            <option key={enc} value={enc}>{enc}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="settings-row">
+        <div>
+          <div className="settings-label">重新打开上次文件</div>
+          <div className="settings-desc">恢复上次会话</div>
+        </div>
+        <button
+          className={`toggle-switch ${settings.reopenLastFile ? 'on' : ''}`}
+          onClick={() => handleChange({ reopenLastFile: !settings.reopenLastFile })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/PreviewSection.tsx
+++ b/src/components/settings/PreviewSection.tsx
@@ -1,8 +1,11 @@
 import { useState } from 'react';
 import { getSettings, updateSettings } from '../../services/settingsService';
+import type { PreviewFontFamily, PreviewWidth } from '../../services/settingsService';
 
 const FONT_SIZES = [13, 14, 15, 16, 18];
 const LINE_HEIGHTS = [1.5, 1.6, 1.7, 1.8, 2.0, 2.5];
+const PREVIEW_FONTS: PreviewFontFamily[] = ['Iowan Old Style', 'Georgia', 'System Default'];
+const PREVIEW_WIDTHS: PreviewWidth[] = [640, 680, 720, 800];
 
 export function PreviewSection() {
   const [settings, setSettings] = useState(() => getSettings());
@@ -15,6 +18,36 @@ export function PreviewSection() {
   return (
     <div className="settings-section">
       <h3 className="settings-section-title">预览</h3>
+
+      <div className="settings-row">
+        <div>
+          <div className="settings-label">预览字体</div>
+        </div>
+        <select
+          className="settings-select"
+          value={settings.previewFontFamily}
+          onChange={(e) => handleChange({ previewFontFamily: e.target.value })}
+        >
+          {PREVIEW_FONTS.map((f) => (
+            <option key={f} value={f}>{f}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="settings-row">
+        <div>
+          <div className="settings-label">预览宽度</div>
+        </div>
+        <select
+          className="settings-select"
+          value={settings.previewWidth}
+          onChange={(e) => handleChange({ previewWidth: Number(e.target.value) })}
+        >
+          {PREVIEW_WIDTHS.map((w) => (
+            <option key={w} value={w}>{w}px</option>
+          ))}
+        </select>
+      </div>
 
       <div className="settings-row">
         <div>

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -3,30 +3,50 @@ import type { PresetId } from './word';
 const STORAGE_KEY = 'folia-settings';
 const LEGACY_KEY = 'folia-export-settings';
 
+export type EditorFontFamily = 'IBM Plex Mono' | 'JetBrains Mono' | 'SF Mono' | 'System Default';
+export type PreviewFontFamily = 'Iowan Old Style' | 'Georgia' | 'System Default';
+export type DefaultEncoding = 'UTF-8' | 'GBK' | 'GB18030';
+export type PreviewWidth = 640 | 680 | 720 | 800;
+
 export interface AppSettings {
+  // 通用
+  autoSave: boolean;
+  defaultEncoding: DefaultEncoding;
+  reopenLastFile: boolean;
   // 导出
   exportPresetId: PresetId;
   // 编辑器
+  editorFontFamily: EditorFontFamily;
   editorFontSize: number;
   editorTabSize: number;
   editorWordWrap: boolean;
   editorLineNumbers: boolean;
+  editorSpellCheck: boolean;
   // 预览
+  previewFontFamily: PreviewFontFamily;
   previewFontSize: number;
   previewLineHeight: number;
+  previewWidth: PreviewWidth;
   // 外观
   theme: 'light' | 'dark';
   zoomLevel: number;
 }
 
 const defaults: AppSettings = {
+  autoSave: false,
+  defaultEncoding: 'UTF-8',
+  reopenLastFile: true,
   exportPresetId: 'legal',
+  editorFontFamily: 'IBM Plex Mono',
   editorFontSize: 13,
   editorTabSize: 4,
   editorWordWrap: true,
   editorLineNumbers: true,
+  editorSpellCheck: false,
+  previewFontFamily: 'Iowan Old Style',
   previewFontSize: 15,
   previewLineHeight: 1.7,
+  previewWidth: 680,
   theme: 'light',
   zoomLevel: 100,
 };

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -257,41 +257,37 @@ html, body, #root {
   font-weight: 500;
 }
 
-/* ===== Settings Page ===== */
+/* ===== Settings Overlay & Modal ===== */
 
-.settings-page {
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: oklch(20% 0.02 60 / 0.35);
   display: flex;
-  flex: 1;
-  height: 100%;
-  overflow: hidden;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
 }
 
-.settings-sidebar {
-  width: 200px;
+.settings-modal {
+  width: 640px;
+  max-height: 75vh;
+  display: flex;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  overflow: hidden;
+  box-shadow: 0 6px 32px oklch(20% 0.02 60 / 0.18);
+}
+
+.settings-modal-sidebar {
+  width: 180px;
   flex-shrink: 0;
   background: var(--surface);
   border-right: 1px solid var(--border);
-  padding-top: 16px;
+  padding: 20px 0;
   display: flex;
   flex-direction: column;
-}
-
-.settings-back {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0 20px 16px;
-  font-size: 12px;
-  color: var(--muted);
-  cursor: pointer;
-  transition: color 0.1s;
-  background: none;
-  border: none;
-  font-family: var(--font-body);
-}
-
-.settings-back:hover {
-  color: var(--accent);
 }
 
 .settings-title {
@@ -331,15 +327,15 @@ html, body, #root {
   background: oklch(58% 0.16 35 / 0.04);
 }
 
-.settings-content {
+.settings-modal-content {
   flex: 1;
-  padding: 36px 44px;
+  padding: 24px 32px;
   overflow-y: auto;
   background: var(--bg);
 }
 
 .settings-section {
-  max-width: 560px;
+  max-width: 420px;
 }
 
 .settings-section-title {


### PR DESCRIPTION
## Summary

- 将 SettingsPage 从全屏替换改为居中弹窗面板（半透明遮罩 + ESC 关闭 + 点击遮罩关闭）
- 弹窗内部保持左右布局（左侧导航 + 右侧内容），640px 宽，圆角 5px，box-shadow
- Settings 作为 overlay 层叠在主布局上方，不再替换整个 app-layout
- 新增 General 分组：Auto-save（默认关）、Default encoding（UTF-8 / GBK / GB18030）、Reopen last file（默认开）
- 编辑器补充：Font family（IBM Plex Mono / JetBrains Mono / SF Mono / System Default）、Spell check（默认关）
- 预览补充：Preview font（Iowan Old Style / Georgia / System Default）、Preview width（640px / 680px / 720px / 800px）
- settingsService 新增对应设置项的类型定义和默认值

## 涉及文件

- `src/components/SettingsPage.tsx` — 重构为弹窗组件（含遮罩层 + ESC 关闭）
- `src/services/settingsService.ts` — 新增 7 个设置项到 AppSettings 接口
- `src/components/settings/GeneralSection.tsx` — 新建通用设置分组
- `src/components/settings/EditorSection.tsx` — 补充 font family 和 spell check
- `src/components/settings/PreviewSection.tsx` — 补充 preview font 和 preview width
- `src/app/AppLayout.tsx` — Settings 作为 overlay 渲染
- `src/styles/app.css` — 弹窗/遮罩样式，参照 Command Palette 设计

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)