### PR TITLE
fix: address word json review edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ All notable changes to this project will be documented in this file.
 - Word 纸张预览和真实 `.docx` 导出继续以同一套 `PresetConfig` 为来源，并补齐标题字体、页码格式/位置、表格背景色、表格对齐、单元格四边距和图片标题的可见样式映射。
 - Word 纸张预览和 `.docx` 导出会消费 JSON v2 样式映射；映射引用不存在时导入失败，避免 JSON 中写了样式但实际导出无效。
 
+### Fixed
+
+- 修复 md2word 风格 JSON 只包含 `table.cell_margin.top/bottom/left/right` 时不会触发 dxa 单位转换的问题。
+- 修复 JSON v2 表格样式只设置 `cell_margin` 时纸张预览和 `.docx` 单元格边距可能不一致的问题。
+- 修复 Word 纸张预览中未配置表格背景色时默认背景变量可能继承文字色的问题。
+
 ## [0.3.12]
 
 ### Changed

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,29 @@
 
 ## 第一部分：决策记录
 
+### [DEC-061] - 2026-05-31 - Word JSON 合并前 code review 补齐一致性边界
+
+**背景**
+PR #17 已完成 Word JSON 完整模板、md2word 兼容导入和 JSON v2 样式映射。合并前 code review 继续按“JSON 写到哪里，预览和真实 DOCX 就应尽量生效到哪里”的标准复核，发现三个边界会造成一致性落差。
+
+**决策**
+- md2word 兼容识别条件补上 `table.cell_margin` 对象。即使外部 JSON 只包含 `cell_margin.top/bottom/left/right`，也按 md2word dxa 单位转换为 Folia 的 cm 四边距。
+- JSON v2 表格样式中只设置 `cell_margin` 时，DOCX 导出同步展开为 `cell_margins` 四边距，避免预览生效但 Word 导出仍使用基础预设边距。
+- Word 纸张预览的表格背景变量缺省值改为 `transparent`，只在 JSON 明确设置背景色时才填充表头或交替行背景。
+
+**验证**
+- 新增回归用例先失败后通过：`npm test -- src/services/word/presetImport.test.ts src/services/wordPreviewStyle.test.ts src/services/word/docxXml.test.ts`
+- `npm run typecheck`
+- `npm test`
+- `npm run lint`
+- `npm run build`
+- `git diff --check`
+
+**影响**
+- md2word JSON 的最小迁移样例更稳，不需要同时包含 `row_height_cm` 或其他别名字段才能触发单位转换。
+- JSON v2 表格样式的等边距写法在纸张预览和 `.docx` 中保持一致。
+- 默认 Word 纸张预览不会因未配置表格背景色而出现异常底色。
+
 ### [DEC-060] - 2026-05-30 - Word JSON v2 采用样式别名与元素映射协议
 
 **背景**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -165,6 +165,9 @@
 
 ## 进度日志
 
+- **2026-05-31**
+  - Word JSON / md2word 兼容合并前 code review 完成跟进修复：`table.cell_margin` 对象可单独触发 md2word dxa 转 cm，JSON v2 表格样式的 `cell_margin` 在 DOCX 中同步展开为四边距，未配置的预览表格背景回退为透明。
+
 - **2026-05-30**
   - Word 导出预设 JSON 完整模板和 md2word 兼容导入完成：扩展标题、页码、表格、代码、引用、图片等字段，导入时清洗颜色并转换 dxa / pt / inch 单位；`.docx` 导出和 Word 纸张预览同步补齐标题字体、表格背景/对齐/四边距、页码格式和图片标题映射。
   - Word JSON v2 样式协议第一阶段完成：新增 `styles / markdown_mapping / html_mapping`，支持 Markdown 标题、正文、代码块、列表、分割线、表格、图片标题和 HTML table 选择器映射到可复用样式。

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -36,7 +36,7 @@
 
 - **优先级:** P1
 - **类型:** L2
-- **状态:** 已完成，已复验，待 PR 合并。
+- **状态:** 已完成，已复验。
 - **问题:** 当前 Word JSON 已覆盖 Folia 现有导出字段，但还偏“字段清单”。如果用户希望把复杂 Markdown 和带 HTML 的内容尽可能稳定地转换为 Word，需要一个可扩展的样式协议：先定义可复用样式，再声明 Markdown 元素、HTML 标签或选择器映射到哪些样式。
 - **建议实现:**
   - 新增 `styles`，支持定义正文、标题、表格、图片标题、引用等可复用样式别名。
@@ -44,20 +44,20 @@
   - 新增 `html_mapping`，先支持 HTML table 的标签和选择器映射，例如 `table.evidence-table -> evidenceTable`，后续再扩展普通 HTML inline / block 样式。
   - DOCX 导出和 Word 纸张预览都消费同一套映射，不能只在 JSON 中展示而不生效。
 - **验收:** JSON 模板包含 `styles / markdown_mapping / html_mapping`；映射引用不存在或映射键不受支持时导入失败并提示清晰；Markdown 标题/正文/列表/分割线/表格/图片标题和 HTML table 选择器映射在 `.docx` 与纸张预览中生效；全量验证通过。
-- **实现:** 已新增 JSON v2 样式别名和 Markdown / HTML 映射字段；导入层校验映射引用、Markdown 映射键和 HTML table 映射范围；DOCX 导出已消费标题、正文、代码块、列表、分割线、Markdown 表格、HTML table 选择器和图片标题映射；纸张预览同步做 DOM 后处理样式映射。已通过 `npm run typecheck`、`npm test`、`npm run lint`、`npm run build` 和 `git diff --check`。
+- **实现:** 已新增 JSON v2 样式别名和 Markdown / HTML 映射字段；导入层校验映射引用、Markdown 映射键和 HTML table 映射范围；DOCX 导出已消费标题、正文、代码块、列表、分割线、Markdown 表格、HTML table 选择器和图片标题映射；纸张预览同步做 DOM 后处理样式映射。Code review 后补齐表格样式仅设置 `cell_margin` 时 DOCX 四边距同步展开，避免预览和导出分叉。已通过 `npm run typecheck`、`npm test`、`npm run lint`、`npm run build` 和 `git diff --check`。
 
 #### ISS-127 Word 导出 JSON 与 md2word 配置兼容完善
 
 - **优先级:** P1
 - **类型:** L2
-- **状态:** 已完成，已复验，待 PR 合并。
+- **状态:** 已完成，已复验。
 - **问题:** Word 导出自定义 JSON 示例字段偏少，用户难以从外部 md2word 配置迁移完整格式；部分可配置样式没有同时作用到纸张预览和真实 `.docx` 导出。
 - **建议实现:**
   - 扩展 Word 预设 JSON 模板，覆盖页面、字体、标题、正文、页码、表格、代码、引用、图片、分割线和列表。
   - 导入时兼容 md2word YAML 转 JSON 后的常见字段别名与单位，包括表格行高、单元格边距、代码块、引用缩进和页码位置。
   - 补齐 DOCX 导出与 Word 纸张预览对标题字体、表格背景、表格对齐、单元格边距、页码格式和图片标题的映射。
 - **验收:** 完整 Folia JSON 模板和 md2word 风格 JSON 均可导入；相关 DOCX XML、预览样式和导入校验测试通过；全量类型检查、测试、lint 和构建通过。
-- **实现:** 已扩展 Word JSON 完整模板；导入层兼容 md2word 风格字段别名、颜色清洗和单位转换；DOCX 导出与纸张预览补齐页码、标题字体、表格背景/对齐/四边距和图片标题映射。已通过 `npm run typecheck`、`npm test`、`npm run lint`、`npm run build` 和 `git diff --check`。
+- **实现:** 已扩展 Word JSON 完整模板；导入层兼容 md2word 风格字段别名、颜色清洗和单位转换；DOCX 导出与纸张预览补齐页码、标题字体、表格背景/对齐/四边距和图片标题映射。Code review 后补齐“仅包含 `table.cell_margin.top/bottom/left/right` 的 md2word JSON”识别路径，并将未设置的预览表格背景回退为透明。已通过 `npm run typecheck`、`npm test`、`npm run lint`、`npm run build` 和 `git diff --check`。
 
 ### 文档与发布说明
 
@@ -1035,7 +1035,9 @@
 
 ## 进度日志
 
-- **2026-05-30** 完成 ISS-127：Word 导出自定义 JSON 示例扩展为完整模板，并兼容 md2word YAML 转 JSON 后的常见字段别名与单位；`.docx` 导出和 Word 纸张预览同步补齐页码格式/位置、标题字体、表格背景色、表格对齐、单元格四边距和图片标题映射。验证：`npm test -- src/services/word/presetImport.test.ts src/services/word/docxXml.test.ts src/services/wordPreviewStyle.test.ts src/components/WordPaperPreviewPane.test.ts`、`npm run typecheck` 通过；全量验证待 PR 前执行。
+- **2026-05-31** 完成 ISS-127 / ISS-128 code review 跟进修复：md2word 风格 JSON 现在即使只包含 `table.cell_margin.top/bottom/left/right` 也会按 dxa 转 cm 导入；JSON v2 表格样式只设置 `cell_margin` 时会同步展开到 DOCX 四边距；Word 纸张预览中未设置的表格背景回退为透明，避免默认预览出现异常底色。验证：新增回归先失败后通过，随后执行 `npm run typecheck`、`npm test`、`npm run lint`、`npm run build` 和 `git diff --check`。
+
+- **2026-05-30** 完成 ISS-127：Word 导出自定义 JSON 示例扩展为完整模板，并兼容 md2word YAML 转 JSON 后的常见字段别名与单位；`.docx` 导出和 Word 纸张预览同步补齐页码格式/位置、标题字体、表格背景色、表格对齐、单元格四边距和图片标题映射。验证：`npm test -- src/services/word/presetImport.test.ts src/services/word/docxXml.test.ts src/services/wordPreviewStyle.test.ts src/components/WordPaperPreviewPane.test.ts`、`npm run typecheck` 通过。
 - **2026-05-29** 准备发布 v0.3.12：版本号统一到 `0.3.12`，`CHANGELOG.md` 拆分 `0.3.12` / `0.3.11` 发布说明，并记录本次中文字体、构建拆包和 DOCX XML 回归修复。验证：`git diff --check`、`npm run typecheck`、`npm test`、`npm run lint`、`npm run build`、`cd src-tauri && cargo check` 均通过。
 - **2026-05-29** 发布 v0.3.12：推送 `main` 与 annotated tag `v0.3.12`，GitHub Actions Release run `26626281208` 构建 macOS aarch64 / macOS x86_64 / Windows 三平台产物并发布 GitHub Release；首次运行在 Gitee 同步阶段失败，重跑 failed job 后成功。GitHub Release 地址：https://github.com/cat-xierluo/Folia/releases/tag/v0.3.12
 - **2026-05-29** 完成 ISS-124：Markdown 阅读和 Vditor 即时渲染编辑默认改用中文优化字体栈，设置页新增“中文优化 / 系统默认 / 中文宋体 / Iowan Old Style / Georgia”预设，并对旧默认 `Iowan Old Style` 做一次性迁移；同步更新 `docs/DESIGN.md`、`CHANGELOG.md` 和设置服务回归测试。验证：`npm run typecheck`、`npm test`、`npm run lint`、`npm run build`、`git diff --check` 均通过。

--- a/src/services/word/docxXml.test.ts
+++ b/src/services/word/docxXml.test.ts
@@ -167,6 +167,7 @@ describe('markdownToDocx XML output', () => {
         },
         mappedTable: {
           table: {
+            cell_margin: 40 / 567,
             header_background_color: 'ABCDEF',
             row_odd_background_color: 'F0F0F0',
           },
@@ -265,5 +266,6 @@ describe('markdownToDocx XML output', () => {
       '123456',
       '654321',
     ]));
+    expect(allXmlAttrs(documentXml, 'w:top', 'w:w')).toEqual(expect.arrayContaining(['40']));
   });
 });

--- a/src/services/word/presetImport.test.ts
+++ b/src/services/word/presetImport.test.ts
@@ -220,6 +220,25 @@ describe('presetImport', () => {
     expect(imported.config.math.color).toBe('00008B');
   });
 
+  it('recognizes md2word table cell margins even when they are the only md2word-style field', () => {
+    const imported = importPresetFromJson(JSON.stringify({
+      name: '仅表格边距',
+      config: {
+        table: {
+          cell_margin: { top: 40, bottom: 50, left: 60, right: 70 },
+        },
+      },
+    }));
+
+    expect(imported.config.table.cell_margin).toBeCloseTo(60 / 567);
+    expect(imported.config.table.cell_margins).toMatchObject({
+      top: 40 / 567,
+      bottom: 50 / 567,
+      left: 60 / 567,
+      right: 70 / 567,
+    });
+  });
+
   it('rejects malformed preset files', () => {
     expect(() => importPresetFromJson('{broken')).toThrow(PresetImportError);
     expect(() => importPresetFromJson(JSON.stringify({ config: { page: { width: -1 } } }))).toThrow(PresetImportError);

--- a/src/services/word/presetImport.ts
+++ b/src/services/word/presetImport.ts
@@ -431,6 +431,7 @@ function isMd2WordLikeConfig(config: Record<string, unknown>): boolean {
     'code_block.content',
     'quote.left_indent_inches',
   ].some((path) => getPath(config, path) !== undefined)
+    || isRecord(getPath(config, 'table.cell_margin'))
     || ['left', 'center', 'right'].includes(String(getPath(config, 'page_number.position') ?? ''));
 }
 

--- a/src/services/word/style-mapping.ts
+++ b/src/services/word/style-mapping.ts
@@ -47,12 +47,23 @@ export function resolveTableConfig(config: PresetConfig, styleName?: string): Ta
   const tableStyle = getStyle(config, styleName)?.table;
   if (!tableStyle) return config.table;
 
-  return {
+  const table = {
     ...config.table,
     ...tableStyle,
     header_font: mergeTableFont(config.table.header_font, tableStyle.header_font),
     body_font: mergeTableFont(config.table.body_font, tableStyle.body_font),
   };
+
+  if (!tableStyle.cell_margins && tableStyle.cell_margin !== undefined) {
+    table.cell_margins = {
+      top: tableStyle.cell_margin,
+      bottom: tableStyle.cell_margin,
+      left: tableStyle.cell_margin,
+      right: tableStyle.cell_margin,
+    };
+  }
+
+  return table;
 }
 
 export function withTableStyle(config: PresetConfig, styleName?: string): PresetConfig {

--- a/src/services/wordPreviewStyle.test.ts
+++ b/src/services/wordPreviewStyle.test.ts
@@ -22,6 +22,9 @@ describe('createWordPreviewStyle', () => {
     expect(style['--word-table-font-size']).toBe('10.5pt');
     expect(style['--word-table-cell-padding']).toBe('0.1cm');
     expect(style['--word-table-row-height']).toBe('0.8cm');
+    expect(style['--word-table-header-bg']).toBe('transparent');
+    expect(style['--word-table-row-odd-bg']).toBe('transparent');
+    expect(style['--word-table-row-even-bg']).toBe('transparent');
     expect(style['--word-heading-1-size']).toBe('15pt');
     expect(style['--word-heading-1-align']).toBe('center');
     expect(style['--word-list-indent']).toBe('24pt');

--- a/src/services/wordPreviewStyle.ts
+++ b/src/services/wordPreviewStyle.ts
@@ -20,6 +20,11 @@ function optionalColor(color?: string): string {
   return color.startsWith('#') ? color : `#${color}`;
 }
 
+function optionalBackgroundColor(color?: string): string {
+  if (!color) return 'transparent';
+  return color.startsWith('#') ? color : `#${color}`;
+}
+
 function cssString(value: string): string {
   return JSON.stringify(value);
 }
@@ -84,9 +89,9 @@ export function createWordPreviewStyle(config: PresetConfig): WordPreviewStyle {
     '--word-table-margin-left': margins.left,
     '--word-table-margin-right': margins.right,
     '--word-table-vertical-align': config.table.vertical_align ?? 'center',
-    '--word-table-header-bg': optionalColor(config.table.header_background_color),
-    '--word-table-row-odd-bg': optionalColor(config.table.row_odd_background_color),
-    '--word-table-row-even-bg': optionalColor(config.table.row_even_background_color),
+    '--word-table-header-bg': optionalBackgroundColor(config.table.header_background_color),
+    '--word-table-row-odd-bg': optionalBackgroundColor(config.table.row_odd_background_color),
+    '--word-table-row-even-bg': optionalBackgroundColor(config.table.row_even_background_color),
     '--word-list-indent': `${config.lists.bullet.indent}pt`,
     '--word-code-label-font-family': fontStack(config.code_block.label_font.name, config.code_block.label_font.ascii, 'monospace'),
     '--word-code-label-font-size': `${config.code_block.label_font.size}pt`,


### PR DESCRIPTION
## Summary
- recognize md2word table cell margin objects even when they are the only md2word-style field
- expand JSON v2 table style cell_margin into DOCX cell_margins for preview/export consistency
- use transparent preview table backgrounds when no background color is configured

## Test Plan
- npm test -- src/services/word/presetImport.test.ts src/services/wordPreviewStyle.test.ts src/services/word/docxXml.test.ts
- npm run typecheck
- npm test
- npm run lint
- npm run build
- git diff --check