### PR TITLE
feat: add Anything HTML integration

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,7 +3,8 @@
   "identifier": "default",
   "description": "enables the default permissions",
   "windows": [
-    "main"
+    "main",
+    "html-anything"
   ],
   "permissions": [
     "core:default",
@@ -11,6 +12,19 @@
     "core:window:allow-set-title",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",
+    "core:window:allow-hide",
+    "core:window:allow-show",
+    "core:window:allow-create",
+    "core:window:allow-close",
+    "core:window:allow-set-focus",
+    "core:webview:default",
+    "core:webview:allow-create-webview-window",
+    "core:webview:allow-set-webview-size",
+    "core:webview:allow-set-webview-position",
+    "core:webview:allow-webview-close",
+    "core:webview:allow-webview-show",
+    "core:webview:allow-webview-hide",
+    "core:webview:allow-set-webview-focus",
     "dialog:default",
     "dialog:allow-open",
     "dialog:allow-save",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,9 +5,12 @@ use std::{
 
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
 use tauri::Emitter;
-use tauri::Manager;
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 
 struct OpenedPaths(Mutex<Vec<String>>);
+
+const HTML_ANYTHING_URL: &str = "http://localhost:3000";
+const HTML_ANYTHING_IMPORT_KEY: &str = "folia-import-markdown";
 
 #[tauri::command]
 fn pending_opened_paths(app: tauri::AppHandle) -> Vec<String> {
@@ -36,6 +39,84 @@ fn write_opened_document(path: String, content: String) -> Result<(), String> {
   std::fs::write(&path, content).map_err(|error| format!("failed to write document: {error}"))
 }
 
+#[tauri::command]
+fn open_html_anything(
+  app: tauri::AppHandle,
+  content: Option<String>,
+  file_name: Option<String>,
+) -> Result<(), String> {
+  let label = "html-anything";
+  let import_script = html_anything_import_script(content, file_name)?;
+
+  // 如果窗口已存在，直接聚焦
+  if let Some(window) = app.get_webview_window(label) {
+    if let Some(script) = import_script {
+      window
+        .eval(script)
+        .map_err(|e| format!("failed to import markdown into html-anything: {e}"))?;
+    }
+    let _ = window.show();
+    let _ = window.set_focus();
+    return Ok(());
+  }
+
+  // 创建新窗口加载 localhost:3000
+  let mut builder = WebviewWindowBuilder::new(
+    &app,
+    label,
+    WebviewUrl::External(HTML_ANYTHING_URL.parse().unwrap()),
+  )
+  .title("Anything HTML")
+  .inner_size(1200.0, 800.0);
+
+  if let Some(script) = import_script {
+    builder = builder.initialization_script(script);
+  }
+
+  builder
+    .build()
+    .map_err(|e| format!("failed to open html-anything: {e}"))?;
+
+  Ok(())
+}
+
+fn html_anything_import_script(
+  content: Option<String>,
+  file_name: Option<String>,
+) -> Result<Option<String>, String> {
+  let Some(content) = content else {
+    return Ok(None);
+  };
+
+  if content.is_empty() {
+    return Ok(None);
+  }
+
+  let payload = serde_json::json!({
+    "source": "folia",
+    "content": content,
+    "fileName": file_name.filter(|name| !name.trim().is_empty()).unwrap_or_else(|| "Folia Markdown".into()),
+  });
+  let payload_json = serde_json::to_string(&payload)
+    .map_err(|e| format!("failed to encode html-anything import payload: {e}"))?;
+  let key_json = serde_json::to_string(HTML_ANYTHING_IMPORT_KEY)
+    .map_err(|e| format!("failed to encode html-anything import key: {e}"))?;
+
+  Ok(Some(format!(
+    r#"(function () {{
+  if (window.location.origin !== {origin}) return;
+  var payload = {payload};
+  payload.importedAt = new Date().toISOString();
+  localStorage.setItem({key}, JSON.stringify(payload));
+  window.dispatchEvent(new CustomEvent({key}, {{ detail: payload }}));
+}})();"#,
+    origin = serde_json::to_string(HTML_ANYTHING_URL)
+      .map_err(|e| format!("failed to encode html-anything origin: {e}"))?,
+    key = key_json,
+    payload = payload_json,
+  )))
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
@@ -47,8 +128,15 @@ pub fn run() {
     .invoke_handler(tauri::generate_handler![
       pending_opened_paths,
       read_opened_document,
-      write_opened_document
+      write_opened_document,
+      open_html_anything
     ])
+    .on_window_event(|window, event| {
+      if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+        api.prevent_close();
+        let _ = window.hide();
+      }
+    })
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -693,6 +693,7 @@ export function AppLayout() {
     <div className="app-layout" data-theme={settings.theme} style={appStyle}>
       <Toolbar
         dirty={file.dirty}
+        fileContent={file.content}
         fileName={file.name}
         editorMode={editorMode}
         wordPreviewVisible={rightPanelMode === 'word'}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -2,6 +2,7 @@ import {
   BookOpenText,
   Braces,
   FolderOpen,
+  Globe,
   Newspaper,
   RefreshCw,
   Save,
@@ -9,6 +10,7 @@ import {
   SlidersHorizontal,
 } from 'lucide-react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
+import { invoke } from '@tauri-apps/api/core';
 import { useSettings } from '../hooks/useSettings';
 import { translate } from '../services/i18n';
 import { handleTitlebarMouseDown } from '../services/titlebarDrag';
@@ -23,6 +25,7 @@ type UpdateToolbarStatus = {
 type ToolbarProps = {
   dirty: boolean;
   fileName: string;
+  fileContent: string;
   editorMode: EditorMode;
   wordPreviewVisible: boolean;
   wechatPreviewVisible: boolean;
@@ -40,7 +43,7 @@ type ToolbarProps = {
 };
 
 export function Toolbar({
-  dirty, fileName,
+  dirty, fileName, fileContent,
   editorMode, wordPreviewVisible, wechatPreviewVisible, editingDisabled, onToggleEditorMode, onToggleWordPreview, onToggleWechatPreview,
   onOpen, onSave, onSaveAs, onOpenSettings, onPreloadSettings, updateStatus, onRestartUpdate,
 }: ToolbarProps) {
@@ -143,6 +146,18 @@ export function Toolbar({
             aria-label={t('toolbarWechatPreviewLabel')}
           >
             <Newspaper size={iconSize} strokeWidth={strokeWidth} />
+          </button>
+          <button
+            data-no-window-drag="true"
+            onClick={() => invoke('open_html_anything', {
+              content: fileContent,
+              fileName,
+            }).catch((e) => console.warn('Failed to open Anything HTML:', e))}
+            disabled={editingDisabled}
+            title="把当前 Markdown 发送到 Anything HTML（需先启动 localhost:3000）"
+            aria-label="Anything HTML"
+          >
+            <Globe size={iconSize} strokeWidth={strokeWidth} />
           </button>
         </div>
         <div className="toolbar-group toolbar-navigation-actions" aria-label={t('toolbarNavGroup')}>


### PR DESCRIPTION
## Summary
- add a toolbar entry that opens the current Markdown document in Anything HTML
- add a Tauri command and capability entries for creating the local preview webview
- keep the integration local-only and require Anything HTML to be running at localhost:3000

## Test Plan
- Not run in this step; branch boundary was checked with `git diff --check`.
