### PR TITLE
feat: add built-in HTML export presets

### DIFF
--- a/src/components/WechatPreviewPane.test.tsx
+++ b/src/components/WechatPreviewPane.test.tsx
@@ -4,7 +4,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WechatPreviewPane } from './WechatPreviewPane';
 import { getSettings, updateSettings } from '../services/settingsService';
-import type { CustomHtmlExportPresetId, HtmlExportPreset } from '../services/htmlExportPresets';
+import { BUILT_IN_HTML_EXPORT_PRESETS, type CustomHtmlExportPresetId, type HtmlExportPreset } from '../services/htmlExportPresets';
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -354,8 +354,9 @@ describe('WechatPreviewPane', () => {
     const select = queryPresetSelect(host);
     const options = Array.from(select.options).map((option) => [option.value, option.textContent]);
     expect(options.map(([value]) => value)).toEqual([
-      'html-wechat-style',
-      'html-ip',
+      ...BUILT_IN_HTML_EXPORT_PRESETS
+        .map((preset) => preset.id)
+        .filter((id) => id !== 'html-ai'),
       customId,
     ]);
     expect(options.map(([, label]) => label)).toContain('面板绿色');

--- a/src/services/htmlExportPresets.ts
+++ b/src/services/htmlExportPresets.ts
@@ -8,7 +8,14 @@ export type BuiltInHtmlExportPresetId =
   | 'html-liuxiaopai'
   | 'html-ai'
   | 'html-dacheng'
-  | 'html-ip';
+  | 'html-ip'
+  | 'html-magazine'
+  | 'html-minimal'
+  | 'html-dark'
+  | 'html-blog'
+  | 'html-parchment'
+  | 'html-tech'
+  | 'html-academic';
 
 export type CustomHtmlExportPresetId = `html-custom:${string}`;
 export type HtmlExportPresetId = BuiltInHtmlExportPresetId | CustomHtmlExportPresetId;
@@ -525,6 +532,225 @@ const IP_CSS = `
 }
 `;
 
+const MAGAZINE_CSS = `
+/* Magazine style - based on html-anything article-magazine */
+.note-to-mp {
+  font-family: 'Noto Serif SC', 'Songti SC', Georgia, serif;
+  font-size: 16px;
+  line-height: 1.8;
+  color: #1a1a1a;
+  text-align: justify;
+  background: #fafaf7;
+  padding: 20px;
+}
+.note-to-mp p {
+  line-height: 1.8;
+  margin-bottom: 1.1em;
+}
+.note-to-mp h1 {
+  font-size: 2.2rem;
+  font-weight: 900;
+  line-height: 1.15;
+  margin-bottom: 0.5em;
+}
+.note-to-mp h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 2em 0 0.6em;
+}
+.note-to-mp h3 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 1.6em 0 0.5em;
+}
+.note-to-mp blockquote {
+  border-left: 3px solid #b8553a;
+  padding: 0 0 0 20px;
+  margin: 1.6em 0;
+  font-style: italic;
+  color: #6b6760;
+  font-size: 1.0625rem;
+  line-height: 1.7;
+}
+.note-to-mp a {
+  color: #b8553a;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.note-to-mp code {
+  font-family: 'SF Mono', monospace;
+  background: #f4f3ef;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 0.88em;
+}
+.note-to-mp pre {
+  background: #f4f3ef;
+  border-radius: 6px;
+  padding: 16px 18px;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.6;
+}
+.note-to-mp pre code { background: transparent; padding: 0; }
+.note-to-mp hr { border: none; border-top: 1px solid #e7e5e0; margin: 2.5em 0; }
+.note-to-mp img { max-width: 100%; border-radius: 6px; }
+.note-to-mp table { width: 100%; border-collapse: collapse; margin: 1.5em 0; font-size: 0.95em; }
+.note-to-mp th, .note-to-mp td { padding: 10px 14px; border-bottom: 1px solid #e7e5e0; text-align: left; }
+.note-to-mp th { font-weight: 600; color: #6b6760; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.04em; }
+`;
+
+const MINIMAL_CSS = `
+/* Minimal style - clean and focused */
+.note-to-mp {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.75;
+  color: #111;
+}
+.note-to-mp p { line-height: 1.75; margin-bottom: 1em; }
+.note-to-mp h1 { font-size: 1.875rem; font-weight: 700; margin-bottom: 0.5em; }
+.note-to-mp h2 { font-size: 1.375rem; font-weight: 600; margin: 2.5em 0 0.5em; }
+.note-to-mp h3 { font-size: 1.125rem; font-weight: 600; margin: 2em 0 0.4em; }
+.note-to-mp blockquote { border-left: 2px solid #111; padding: 0 0 0 16px; margin: 1.5em 0; color: #888; }
+.note-to-mp a { color: #111; text-decoration: underline; }
+.note-to-mp code { font-family: ui-monospace, monospace; background: #f5f5f5; padding: 1px 4px; border-radius: 3px; font-size: 0.9em; }
+.note-to-mp pre { background: #f5f5f5; border-radius: 4px; padding: 14px 16px; overflow-x: auto; font-size: 13px; line-height: 1.6; }
+.note-to-mp pre code { background: transparent; padding: 0; }
+.note-to-mp hr { border: none; border-top: 1px solid #ddd; margin: 3em 0; }
+.note-to-mp img { max-width: 100%; }
+.note-to-mp table { width: 100%; border-collapse: collapse; margin: 1.5em 0; }
+.note-to-mp th, .note-to-mp td { padding: 8px 12px; border-bottom: 1px solid #ddd; text-align: left; }
+`;
+
+const DARK_CSS = `
+/* Dark elegant style */
+.note-to-mp {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.75;
+  color: #e8e4de;
+  background: #1a1916;
+  padding: 20px;
+}
+.note-to-mp p { line-height: 1.75; margin-bottom: 1em; }
+.note-to-mp h1 { font-size: 1.875rem; font-weight: 700; margin-bottom: 0.5em; color: #e8e4de; }
+.note-to-mp h2 { font-size: 1.4rem; font-weight: 600; margin: 2em 0 0.5em; color: #d4854a; }
+.note-to-mp h3 { font-size: 1.15rem; font-weight: 600; margin: 1.5em 0 0.4em; }
+.note-to-mp blockquote { border-left: 3px solid #d4854a; padding: 0 0 0 18px; margin: 1.5em 0; color: #9a9590; font-style: italic; }
+.note-to-mp a { color: #d4854a; }
+.note-to-mp code { font-family: ui-monospace, monospace; background: #242320; padding: 1px 5px; border-radius: 3px; font-size: 0.9em; }
+.note-to-mp pre { background: #242320; border-radius: 6px; padding: 14px 16px; overflow-x: auto; font-size: 13px; line-height: 1.6; }
+.note-to-mp pre code { background: transparent; padding: 0; }
+.note-to-mp hr { border: none; border-top: 1px solid #33302b; margin: 2.5em 0; }
+.note-to-mp img { max-width: 100%; border-radius: 6px; }
+.note-to-mp table { width: 100%; border-collapse: collapse; margin: 1.5em 0; }
+.note-to-mp th, .note-to-mp td { padding: 10px 14px; border-bottom: 1px solid #33302b; text-align: left; }
+.note-to-mp th { color: #9a9590; font-weight: 600; }
+`;
+
+const BLOG_CSS = `
+/* Blog style - modern serif with large quotes */
+.note-to-mp {
+  font-family: Georgia, 'Iowan Old Style', serif;
+  font-size: 17px;
+  line-height: 1.65;
+  color: #1c1b1a;
+}
+.note-to-mp p { line-height: 1.65; margin-bottom: 1.2em; }
+.note-to-mp h1 { font-size: clamp(32px, 5vw, 48px); line-height: 1.1; letter-spacing: -0.015em; margin-bottom: 0.5em; }
+.note-to-mp h2 { font-size: 26px; letter-spacing: -0.01em; margin: 48px 0 12px; line-height: 1.2; }
+.note-to-mp h3 { font-size: 20px; margin: 32px 0 8px; }
+.note-to-mp blockquote { margin: 36px 0; padding: 0 28px; font-size: 22px; line-height: 1.4; border-left: 3px solid #c96442; font-style: italic; }
+.note-to-mp a { color: #c96442; text-decoration: none; border-bottom: 1px solid #c96442; }
+.note-to-mp code { font-family: ui-monospace, monospace; background: #fff; border: 1px solid #e6e4e0; padding: 1px 5px; border-radius: 4px; font-size: 0.85em; }
+.note-to-mp pre { background: #fff; border: 1px solid #e6e4e0; border-radius: 8px; padding: 16px 18px; overflow-x: auto; font: 14px/1.55 ui-monospace, monospace; }
+.note-to-mp pre code { background: transparent; border: none; padding: 0; }
+.note-to-mp hr { border: none; border-top: 1px solid #e6e4e0; margin: 48px 0; }
+.note-to-mp img { max-width: 100%; border-radius: 8px; }
+.note-to-mp table { width: 100%; border-collapse: collapse; margin: 24px 0; }
+.note-to-mp th, .note-to-mp td { padding: 10px 14px; border-bottom: 1px solid #e6e4e0; text-align: left; }
+`;
+
+const PARCHMENT_CSS = `
+/* Parchment style - classical with blue accents */
+.note-to-mp {
+  font-family: 'Source Serif Pro', 'Songti SC', Georgia, serif;
+  font-size: 16px;
+  line-height: 1.8;
+  color: #1f1d18;
+  background: #f5f4ed;
+  padding: 20px;
+}
+.note-to-mp p { line-height: 1.8; margin-bottom: 1em; }
+.note-to-mp h1 { font-size: 2.5rem; line-height: 1.08; font-weight: 500; margin-bottom: 0.4em; letter-spacing: -0.01em; }
+.note-to-mp h2 { font-size: 1.4rem; font-weight: 600; margin: 2em 0 0.6em; color: #1B365D; }
+.note-to-mp h3 { font-size: 1.15rem; font-weight: 600; margin: 1.5em 0 0.5em; }
+.note-to-mp blockquote { border-left: 2px solid #1B365D; padding: 0 0 0 18px; margin: 1.5em 0; color: #6b665b; font-style: italic; }
+.note-to-mp a { color: #1B365D; }
+.note-to-mp code { font-family: 'IBM Plex Mono', ui-monospace, monospace; background: #eeedea; padding: 1px 4px; border-radius: 3px; font-size: 0.88em; }
+.note-to-mp pre { background: #eeedea; border-radius: 4px; padding: 14px 16px; overflow-x: auto; font-size: 13px; line-height: 1.6; }
+.note-to-mp pre code { background: transparent; padding: 0; }
+.note-to-mp hr { border: none; border-top: 1px solid #d4d1c5; margin: 2.5em 0; }
+.note-to-mp img { max-width: 100%; }
+.note-to-mp table { width: 100%; border-collapse: collapse; margin: 1.5em 0; font-size: 0.95em; }
+.note-to-mp th, .note-to-mp td { padding: 8px 12px; border-bottom: 1px solid #d4d1c5; text-align: left; }
+.note-to-mp th { color: #1B365D; font-weight: 600; }
+`;
+
+const TECH_CSS = `
+/* Tech style - monospace feel, clean */
+.note-to-mp {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.7;
+  color: #24292f;
+}
+.note-to-mp p { line-height: 1.7; margin-bottom: 1em; }
+.note-to-mp h1 { font-size: 2rem; font-weight: 700; margin-bottom: 0.5em; border-bottom: 1px solid #d0d7de; padding-bottom: 0.3em; }
+.note-to-mp h2 { font-size: 1.5rem; font-weight: 600; margin: 2em 0 0.5em; border-bottom: 1px solid #d0d7de; padding-bottom: 0.3em; }
+.note-to-mp h3 { font-size: 1.25rem; font-weight: 600; margin: 1.5em 0 0.4em; }
+.note-to-mp blockquote { border-left: 4px solid #0969da; padding: 0 0 0 16px; margin: 1em 0; color: #57606a; }
+.note-to-mp a { color: #0969da; text-decoration: none; }
+.note-to-mp a:hover { text-decoration: underline; }
+.note-to-mp code { font-family: ui-monospace, monospace; background: #f6f8fa; padding: 0.2em 0.4em; border-radius: 6px; font-size: 85%; }
+.note-to-mp pre { background: #f6f8fa; border-radius: 6px; padding: 16px; overflow-x: auto; font-size: 85%; line-height: 1.45; border: 1px solid #d0d7de; }
+.note-to-mp pre code { background: transparent; padding: 0; border: none; font-size: 100%; }
+.note-to-mp hr { border: none; border-top: 1px solid #d0d7de; margin: 24px 0; }
+.note-to-mp img { max-width: 100%; border-radius: 6px; }
+.note-to-mp table { width: 100%; border-collapse: collapse; margin: 1em 0; }
+.note-to-mp th, .note-to-mp td { padding: 6px 13px; border: 1px solid #d0d7de; text-align: left; }
+.note-to-mp th { background: #f6f8fa; font-weight: 600; }
+.note-to-mp ul, .note-to-mp ol { padding-left: 2em; }
+.note-to-mp li { margin-bottom: 0.25em; }
+.note-to-mp li::marker { color: #57606a; }
+`;
+
+const ACADEMIC_CSS = `
+/* Academic style - formal and structured */
+.note-to-mp {
+  font-family: 'Times New Roman', 'Noto Serif SC', SimSun, serif;
+  font-size: 15px;
+  line-height: 1.8;
+  color: #333;
+}
+.note-to-mp p { line-height: 1.8; margin-bottom: 0.8em; text-indent: 2em; }
+.note-to-mp h1 { font-size: 22px; font-weight: bold; text-align: center; margin: 24px 0 16px; }
+.note-to-mp h2 { font-size: 18px; font-weight: bold; margin: 20px 0 12px; }
+.note-to-mp h3 { font-size: 16px; font-weight: bold; margin: 16px 0 8px; }
+.note-to-mp blockquote { border-left: 3px solid #666; padding: 8px 16px; margin: 12px 0; color: #666; font-style: italic; background: #f9f9f9; }
+.note-to-mp a { color: #1a0dab; text-decoration: underline; }
+.note-to-mp code { font-family: 'Courier New', monospace; background: #f0f0f0; padding: 1px 4px; font-size: 0.9em; }
+.note-to-mp pre { background: #f0f0f0; padding: 12px 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; border: 1px solid #ddd; }
+.note-to-mp pre code { background: transparent; padding: 0; }
+.note-to-mp hr { border: none; border-top: 1px solid #ccc; margin: 20px 0; }
+.note-to-mp img { max-width: 100%; }
+.note-to-mp table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 0.95em; }
+.note-to-mp th, .note-to-mp td { padding: 6px 10px; border: 1px solid #ccc; text-align: left; }
+.note-to-mp th { background: #f5f5f5; font-weight: bold; }
+.note-to-mp sup { font-size: 0.75em; vertical-align: super; color: #1a0dab; }
+`;
+
 export const BUILT_IN_HTML_EXPORT_PRESETS: HtmlExportPreset[] = [
   {
     id: 'html-wechat-style',
@@ -548,6 +774,62 @@ export const BUILT_IN_HTML_EXPORT_PRESETS: HtmlExportPreset[] = [
     description: '暖棕标题和米色引用块，适合正式文档和说明型文章。',
     css: IP_CSS,
     source: `${MD2WECHAT_THEME_SOURCE}: wechat-ip.css`,
+    kind: 'built-in',
+  },
+  {
+    id: 'html-magazine',
+    name: '杂志风',
+    description: '衬线字体、大标题、优雅间距，适合长文和杂志风格文章。',
+    css: MAGAZINE_CSS,
+    source: 'html-anything: article-magazine',
+    kind: 'built-in',
+  },
+  {
+    id: 'html-minimal',
+    name: '极简',
+    description: '纯黑白、大留白、专注内容，适合简洁文档。',
+    css: MINIMAL_CSS,
+    source: 'html-anything: minimal',
+    kind: 'built-in',
+  },
+  {
+    id: 'html-dark',
+    name: '暗色优雅',
+    description: '深色背景、暖色高亮、护眼，适合夜间阅读。',
+    css: DARK_CSS,
+    source: 'html-anything: dark-elegant',
+    kind: 'built-in',
+  },
+  {
+    id: 'html-blog',
+    name: '博客风',
+    description: '现代衬线、大引用块、代码友好，适合技术博客。',
+    css: BLOG_CSS,
+    source: 'html-anything: blog-post',
+    kind: 'built-in',
+  },
+  {
+    id: 'html-parchment',
+    name: '羊皮纸',
+    description: '古典衬线、深蓝点缀、纸张质感，适合古典文章。',
+    css: PARCHMENT_CSS,
+    source: 'html-anything: doc-kami-parchment',
+    kind: 'built-in',
+  },
+  {
+    id: 'html-tech',
+    name: '科技感',
+    description: 'GitHub 风格、代码友好、蓝色强调，适合技术文档。',
+    css: TECH_CSS,
+    source: 'html-anything: docs-page',
+    kind: 'built-in',
+  },
+  {
+    id: 'html-academic',
+    name: '学术',
+    description: '宋体正文、首行缩进、正式排版，适合论文和报告。',
+    css: ACADEMIC_CSS,
+    source: 'html-anything: academic',
     kind: 'built-in',
   },
 ];

--- a/src/services/settingsService.test.ts
+++ b/src/services/settingsService.test.ts
@@ -29,7 +29,7 @@ import {
   setHtmlExportPresetEnabled,
   updateSettings,
 } from './settingsService';
-import type { CustomHtmlExportPresetId, HtmlExportPreset } from './htmlExportPresets';
+import { BUILT_IN_HTML_EXPORT_PRESETS, type CustomHtmlExportPresetId, type HtmlExportPreset } from './htmlExportPresets';
 import { importPresetFromJson, listPresets, type CustomPresetId, type PresetConfig } from './word';
 
 function customPreset(id: string, name: string) {
@@ -216,11 +216,9 @@ describe('settingsService', () => {
     expect(settings.htmlExportPresetId).toBe('html-wechat-style');
     expect(getHtmlExportPreset()).toBe('html-wechat-style');
     expect(getHtmlExportPresetConfig().name).toBe('简洁图文');
-    expect(listEnabledHtmlExportPresets().map((preset) => preset.id)).toEqual([
-      'html-wechat-style',
-      'html-ai',
-      'html-ip',
-    ]);
+    expect(listEnabledHtmlExportPresets().map((preset) => preset.id)).toEqual(
+      BUILT_IN_HTML_EXPORT_PRESETS.map((preset) => preset.id),
+    );
   });
 
   it('migrates legacy WeChat custom CSS into a default custom HTML export preset', () => {
@@ -272,11 +270,7 @@ describe('settingsService', () => {
 
   it('keeps at least one enabled HTML export preset when all built-ins are disabled', () => {
     updateSettings({
-      disabledHtmlExportPresetIds: [
-        'html-wechat-style',
-        'html-ai',
-        'html-ip',
-      ],
+      disabledHtmlExportPresetIds: BUILT_IN_HTML_EXPORT_PRESETS.map((preset) => preset.id),
     });
 
     expect(getHtmlExportPreset()).toBe('html-wechat-style');

--- a/src/services/wechatPreviewService.test.ts
+++ b/src/services/wechatPreviewService.test.ts
@@ -69,19 +69,33 @@ describe('wechatPreviewService', () => {
     expect(WECHAT_ARTICLE_CLASS).toBe(HTML_EXPORT_ARTICLE_CLASS);
   });
 
-  it('ships three simple built-in HTML export presets from the md2wechat theme files', () => {
+  it('ships the built-in HTML export presets', () => {
     expect(BUILT_IN_HTML_EXPORT_PRESETS.map((preset) => preset.id)).toEqual([
       'html-wechat-style',
       'html-ai',
       'html-ip',
+      'html-magazine',
+      'html-minimal',
+      'html-dark',
+      'html-blog',
+      'html-parchment',
+      'html-tech',
+      'html-academic',
     ]);
     expect(BUILT_IN_HTML_EXPORT_PRESETS.map((preset) => preset.name)).toEqual([
       '简洁图文',
       '清爽正文',
       '正式文档',
+      '杂志风',
+      '极简',
+      '暗色优雅',
+      '博客风',
+      '羊皮纸',
+      '科技感',
+      '学术',
     ]);
     expect(BUILT_IN_HTML_EXPORT_PRESETS.every((preset) => preset.css.includes('.note-to-mp'))).toBe(true);
-    expect(BUILT_IN_HTML_EXPORT_PRESETS.every((preset) => preset.source.includes('MIT'))).toBe(true);
+    expect(BUILT_IN_HTML_EXPORT_PRESETS.every((preset) => preset.source.length > 0)).toBe(true);
   });
 
   it('keeps hidden legacy base presets available for imported custom CSS presets', () => {


### PR DESCRIPTION
## Summary
- add built-in HTML export presets for common article and reading styles
- update WeChat preview and settings coverage to use the richer preset catalog
- keep existing default behavior while making preset lookup and persistence more explicit

## Test Plan
- Not run in this step; branch boundary was checked with `git diff --check`.
