### PR TITLE
feat: statusbar path double-click copy

### DIFF
--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StatusBar } from './StatusBar';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const writeTextMock = vi.fn();
+let writeTextRejection: Error | null = null;
+
+vi.mock('../services/clipboardService', () => ({
+  writeText: (text: string) => {
+    writeTextMock(text);
+    if (writeTextRejection) {
+      return Promise.reject(writeTextRejection);
+    }
+    return Promise.resolve('native' as const);
+  },
+}));
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, 0);
+  });
+}
+
+describe('StatusBar', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    writeTextMock.mockReset();
+    writeTextRejection = null;
+    host = document.createElement('div');
+    document.body.append(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.clearAllTimers();
+  });
+
+  function render(props: { filePath: string; dirty?: boolean }) {
+    act(() => {
+      root.render(<StatusBar filePath={props.filePath} dirty={props.dirty ?? false} />);
+    });
+  }
+
+  it('renders the file path and the dirty marker when dirty is true', () => {
+    render({ filePath: '/Users/demo/case.md', dirty: true });
+
+    const path = host.querySelector<HTMLSpanElement>('.status-path');
+    expect(path?.textContent).toBe('/Users/demo/case.md');
+    expect(path?.getAttribute('data-copy-state')).toBe('idle');
+
+    const dirty = host.querySelector<HTMLSpanElement>('.status-dirty');
+    expect(dirty?.textContent).toBe('未保存');
+  });
+
+  it('hides the dirty marker when dirty is false', () => {
+    render({ filePath: '/Users/demo/case.md' });
+    expect(host.querySelector('.status-dirty')).toBeNull();
+  });
+
+  it('shows the placeholder and disables double-click copy when no file is open', () => {
+    render({ filePath: '' });
+
+    const path = host.querySelector<HTMLSpanElement>('.status-path');
+    expect(path?.textContent).toBe('未打开文件');
+    expect(path?.getAttribute('data-copy-state')).toBe('idle');
+    expect(path?.onclick).toBeNull();
+    expect(path?.ondblclick).toBeNull();
+
+    act(() => {
+      const event = new MouseEvent('dblclick', { bubbles: true });
+      path?.dispatchEvent(event);
+    });
+    expect(writeTextMock).not.toHaveBeenCalled();
+  });
+
+  it('copies the file path on double-click and flashes a "已复制" feedback', async () => {
+    render({ filePath: '/Users/demo/case.md' });
+
+    const path = host.querySelector<HTMLSpanElement>('.status-path');
+    expect(path).not.toBeNull();
+
+    await act(async () => {
+      const event = new MouseEvent('dblclick', { bubbles: true });
+      path!.dispatchEvent(event);
+      await flushPromises();
+    });
+
+    expect(writeTextMock).toHaveBeenCalledWith('/Users/demo/case.md');
+
+    const feedback = host.querySelector<HTMLSpanElement>('.status-copy-feedback');
+    expect(feedback?.textContent).toBe('已复制');
+    expect(feedback?.getAttribute('data-copy-state')).toBe('copied');
+    expect(path?.getAttribute('data-copy-state')).toBe('copied');
+  });
+
+  it('keeps the dirty marker untouched by the copy feedback', async () => {
+    render({ filePath: '/Users/demo/case.md', dirty: true });
+
+    const path = host.querySelector<HTMLSpanElement>('.status-path');
+    await act(async () => {
+      const event = new MouseEvent('dblclick', { bubbles: true });
+      path!.dispatchEvent(event);
+      await flushPromises();
+    });
+
+    expect(host.querySelector<HTMLSpanElement>('.status-dirty')?.textContent).toBe('未保存');
+  });
+
+  it('shows a "复制失败" feedback when writeText rejects', async () => {
+    writeTextRejection = new Error('permission denied');
+    render({ filePath: '/Users/demo/blocked.md' });
+
+    const path = host.querySelector<HTMLSpanElement>('.status-path');
+    await act(async () => {
+      const event = new MouseEvent('dblclick', { bubbles: true });
+      path!.dispatchEvent(event);
+      await flushPromises();
+    });
+
+    const feedback = host.querySelector<HTMLSpanElement>('.status-copy-feedback');
+    expect(feedback?.textContent).toBe('复制失败');
+    expect(feedback?.getAttribute('data-copy-state')).toBe('failed');
+  });
+
+  it('clears the feedback after the timeout elapses', async () => {
+    render({ filePath: '/Users/demo/case.md' });
+    const path = host.querySelector<HTMLSpanElement>('.status-path');
+
+    await act(async () => {
+      const event = new MouseEvent('dblclick', { bubbles: true });
+      path!.dispatchEvent(event);
+      await flushPromises();
+    });
+    expect(host.querySelector('.status-copy-feedback')).not.toBeNull();
+
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 1300));
+    });
+    expect(host.querySelector('.status-copy-feedback')).toBeNull();
+    expect(host.querySelector('.status-path')?.getAttribute('data-copy-state')).toBe('idle');
+  });
+});

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,12 +1,84 @@
+import { useEffect, useRef, useState } from 'react';
+import { writeText } from '../services/clipboardService';
+
 type StatusBarProps = {
   filePath: string;
   dirty: boolean;
 };
 
+type CopyOutcome = 'copied' | 'failed';
+type CopyMarker = { path: string; outcome: CopyOutcome } | null;
+
+const COPY_FEEDBACK_RESET_MS = 1200;
+
 export function StatusBar({ filePath, dirty }: StatusBarProps) {
+  const hasPath = filePath.length > 0;
+  const [copyMarker, setCopyMarker] = useState<CopyMarker>(null);
+  const resetTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+        resetTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const scheduleFeedbackReset = () => {
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+    }
+    resetTimerRef.current = window.setTimeout(() => {
+      setCopyMarker(null);
+      resetTimerRef.current = null;
+    }, COPY_FEEDBACK_RESET_MS);
+  };
+
+  const handleDoubleClick = () => {
+    if (!hasPath) return;
+    void writeText(filePath)
+      .then(() => {
+        setCopyMarker({ path: filePath, outcome: 'copied' });
+      })
+      .catch(() => {
+        setCopyMarker({ path: filePath, outcome: 'failed' });
+      })
+      .finally(() => {
+        scheduleFeedbackReset();
+      });
+  };
+
+  const copyState: 'idle' | CopyOutcome =
+    copyMarker && copyMarker.path === filePath && hasPath
+      ? copyMarker.outcome
+      : 'idle';
+
   return (
     <div className="status-bar">
-      <span className="status-path">{filePath || '未打开文件'}</span>
+      <span
+        className="status-path"
+        data-copy-state={copyState}
+        onDoubleClick={hasPath ? handleDoubleClick : undefined}
+        title={hasPath ? '双击复制完整路径' : undefined}
+        style={
+          hasPath ? { cursor: 'text', userSelect: 'text' } : undefined
+        }
+      >
+        {hasPath ? filePath : '未打开文件'}
+      </span>
+      {copyState !== 'idle' && (
+        <span
+          className="status-copy-feedback"
+          data-copy-state={copyState}
+          style={{
+            color: copyState === 'copied' ? 'var(--success)' : 'var(--danger)',
+            fontWeight: 500,
+          }}
+        >
+          {copyState === 'copied' ? '已复制' : '复制失败'}
+        </span>
+      )}
       {dirty && <span className="status-dirty">未保存</span>}
     </div>
   );

--- a/src/services/clipboardService.test.ts
+++ b/src/services/clipboardService.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ClipboardUnavailableError,
+  isClipboardApiAvailable,
+  writeText,
+} from './clipboardService';
+
+type ClipboardWriter = ReturnType<typeof vi.fn>;
+
+function setClipboardApi(available: boolean): ClipboardWriter | null {
+  if (available) {
+    const writer = vi.fn(async (text: string) => {
+      void text;
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: writer },
+    });
+    return writer;
+  }
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: undefined,
+  });
+  return null;
+}
+
+function setExecCommand(
+  implementation: (command: string) => boolean,
+): ReturnType<typeof vi.fn> {
+  const spy = vi.fn(implementation);
+  Object.defineProperty(document, 'execCommand', {
+    configurable: true,
+    writable: true,
+    value: spy,
+  });
+  return spy;
+}
+
+describe('clipboardService', () => {
+  afterEach(() => {
+    setClipboardApi(false);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    document.body.innerHTML = '';
+  });
+
+  it('detects navigator.clipboard.writeText availability', () => {
+    setClipboardApi(true);
+    expect(isClipboardApiAvailable()).toBe(true);
+
+    setClipboardApi(false);
+    expect(isClipboardApiAvailable()).toBe(false);
+  });
+
+  it('uses navigator.clipboard.writeText when available', async () => {
+    const writer = setClipboardApi(true);
+    const channel = await writeText('/tmp/case.md');
+    expect(channel).toBe('native');
+    expect(writer).toHaveBeenCalledWith('/tmp/case.md');
+  });
+
+  it('propagates errors from navigator.clipboard.writeText', async () => {
+    const failure = new Error('permission denied');
+    const writer = setClipboardApi(true);
+    writer.mockImplementation(async () => {
+      throw failure;
+    });
+    await expect(writeText('/tmp/blocked.md')).rejects.toBe(failure);
+  });
+
+  describe('textarea fallback', () => {
+    beforeEach(() => {
+      setClipboardApi(false);
+    });
+
+    it('uses document.execCommand("copy") when navigator.clipboard is missing', async () => {
+      const execCommand = setExecCommand(() => true);
+      const channel = await writeText('/tmp/case.md');
+      expect(channel).toBe('fallback');
+      expect(execCommand).toHaveBeenCalledWith('copy');
+    });
+
+    it('removes the temporary textarea after copying', async () => {
+      setExecCommand(() => true);
+      await writeText('/tmp/case.md');
+      expect(document.querySelectorAll('textarea').length).toBe(0);
+    });
+
+    it('rejects when document.execCommand("copy") returns false', async () => {
+      setExecCommand(() => false);
+      await expect(writeText('/tmp/case.md')).rejects.toBeInstanceOf(
+        ClipboardUnavailableError,
+      );
+      expect(document.querySelectorAll('textarea').length).toBe(0);
+    });
+
+    it('rejects when document.execCommand("copy") throws', async () => {
+      const failure = new Error('boom');
+      setExecCommand(() => {
+        throw failure;
+      });
+      await expect(writeText('/tmp/case.md')).rejects.toBe(failure);
+      expect(document.querySelectorAll('textarea').length).toBe(0);
+    });
+  });
+});

--- a/src/services/clipboardService.ts
+++ b/src/services/clipboardService.ts
@@ -1,0 +1,73 @@
+export type ClipboardChannel = 'native' | 'fallback';
+
+export class ClipboardUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ClipboardUnavailableError';
+  }
+}
+
+export function isClipboardApiAvailable(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.clipboard?.writeText === 'function'
+  );
+}
+
+export async function writeText(text: string): Promise<ClipboardChannel> {
+  if (isClipboardApiAvailable()) {
+    await navigator.clipboard.writeText(text);
+    return 'native';
+  }
+  return writeTextFallback(text);
+}
+
+function writeTextFallback(text: string): Promise<ClipboardChannel> {
+  return new Promise((resolve, reject) => {
+    if (typeof document === 'undefined' || !document.body) {
+      reject(new ClipboardUnavailableError('document is not available for clipboard fallback'));
+      return;
+    }
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.width = '1px';
+    textarea.style.height = '1px';
+    textarea.style.opacity = '0';
+    textarea.style.pointerEvents = 'none';
+    document.body.appendChild(textarea);
+
+    const selection = document.getSelection();
+    const previousRange =
+      selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+
+    textarea.select();
+    try {
+      const ok = document.execCommand('copy');
+      cleanup();
+      if (ok) {
+        resolve('fallback');
+      } else {
+        reject(
+          new ClipboardUnavailableError('document.execCommand("copy") returned false'),
+        );
+      }
+    } catch (err) {
+      cleanup();
+      reject(err instanceof Error ? err : new ClipboardUnavailableError(String(err)));
+    }
+
+    function cleanup(): void {
+      if (textarea.parentNode) {
+        textarea.parentNode.removeChild(textarea);
+      }
+      if (previousRange && selection) {
+        selection.removeAllRanges();
+        selection.addRange(previousRange);
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- 状态栏文件路径支持双击复制整段到系统剪贴板，复制成功 / 失败均有 1.2s 轻量反馈。

## Why

- 关联 ISS: ISS-133
- 触发场景: 用户希望在终端或文件管理器中快速粘贴当前文档的完整路径进行定位；之前 StatusBar 只是不可交互的 span。

## Test Plan

```text
$ npm run typecheck
$ npm test -- src/components/StatusBar.test.tsx src/services/clipboardService.test.ts
$ npm run lint
```

实际结果:

- `npm run typecheck`: 通过（无输出即成功）。
- `npm test -- src/components/StatusBar.test.tsx src/services/clipboardService.test.ts`: `Test Files 2 passed (2)` / `Tests 14 passed (14)`。
- `npm run lint`: 通过（无 error）。

涉及 UI 时附 `npm run tauri dev` 本地手测结论: 仅实现 + 单测覆盖；未在桌面端手动触发双击（剪贴板写入依赖 WebView 行为，已通过 navigator.clipboard + textarea fallback 双路径覆盖）。

## Risk & Rollback

- 触及的禁用项 / 决策: 无（未触碰 docs/、CHANGELOG.md、package.json、src-tauri、app.css 等 forbidden 文件）。
- 回滚方法: `git revert <commit>` 即可；该改动只影响 StatusBar.tsx 的交互层，不改数据流。
- Tauri 桌面剪贴板: 依赖 `navigator.clipboard.writeText`（Tauri 2 WebView on macOS / Windows 已支持用户手势触发的剪贴板写入）；如未来需独立 Tauri clipboard command，ISS-133 的 Scope 已留口，本次未新增 src-tauri 改动。

## Checklist

- [x] 已读 `CONTRIBUTING.md` §3 / §5
- [ ] `docs/TASKS.md` 中对应任务已勾选或已更新（由 PM 收口）
- [ ] `docs/DECISIONS.md` 已记录本次工作摘要（由 PM 收口）
- [ ] 涉及用户可见变更时 `CHANGELOG.md` 已更新（由 PM 收口）
- [x] 涉及 UI 时已对照 `docs/DESIGN.md`（沿用 status-bar 现有色板与字号，仅新增内联 style / data-attribute）
- [x] 未引入新依赖