### PR TITLE
fix(preview): make Chinese/Latin/heading fonts reactive to settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
 
 - `README.md` §"官方网站" 链接改到 `https://cat-xierluo.github.io/personal-site/folia/`，移除"调试官方静态网站"小节和相关 `npm run website:build` 命令提示。
 - 浮动大纲固定后改为左侧常驻栏，占用独立阅读空间，避免大纲面板覆盖正文；固定状态下可通过面板右上角按钮取消固定。
+- 阅读预览和 `.docx` HTML 预览支持按中文字体、英文字体独立响应设置变更：通过新增的 `--preview-chinese-font-family` / `--preview-latin-font-family` CSS 变量直接消费 `useSettings` 同步写入根容器的字串，Vditor 渲染实例无需重新解析 Markdown；标题字体仍走 `--preview-heading-font-family`，对 Vditor 生成的标题元素以 `!important` 优先于自带 `font-family`。
+
+### Fixed
+
+- 修复在设置页切换中文字体、英文字体或标题字体后，主阅读预览面板不实时更新的问题：以前 CSS 变量变化被 Vditor 自带 `font-family` 覆盖，需要切换文件或重新触发渲染才会生效；现在 CSS 变量直接控制正文 / 列表 / 表格 / 引用等 Vditor 元素的字体并以 `!important` 优先于其默认样式。
 
 ## [0.3.19]
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,29 @@
 
 ## 第一部分：决策记录
 
+### [DEC-075] - 2026-06-05 - 阅读字体设置走 CSS 变量而非 Vditor 重渲染
+
+**背景**
+ISS-143 反馈在设置页切换中文字体、英文字体或标题字体后，主阅读预览面板不实时更新，需要切换文件或重新触发渲染才会生效，体验割裂。Vditor 自带 `font-family` 比当前 `.preview-content` 选择器优先级更高，仅靠 CSS 变量从 wrapper 级联无法生效。
+
+**决策**
+- 新增 `resolvePreviewChineseFontFamily` / `resolvePreviewLatinFontFamily` 两个 resolve 函数，按中 / 英角色分别输出解析后的字体栈；`PreviewPane` / `DocxPreviewPane` 在 `style` 上同步写入 `--preview-chinese-font-family` / `--preview-latin-font-family`。
+- `.preview-content` 直接子元素（p / ul / ol / blockquote / pre / table / figure / section / article / aside / header / footer / main / nav）以及 `li / li > p / td / th / blockquote > p / dd / dt` 选择器以新变量覆盖 `font-family`；标题元素继续消费 `--preview-heading-font-family` 并加 `!important` 以稳压 Vditor 自带样式。
+- 不重新调用 `Vditor.preview()`：CSS 变量变化即可让浏览器重算 `font-family`，避免每次切字体都重新解析 Markdown 引发闪白。
+- CodeMirror 源码模式 `editorFontFamily` 已通过 `useMemo` deps 覆盖，无需新增逻辑。
+- 暂不引入"settings version"机制：当前每个 resolve 函数都是纯函数，调用站点直接基于 settings 重新计算 style prop，等出现明显的"无关设置触发 re-render"再补。
+
+**验证**
+- `npm test`（200 用例，含新增 2 个 resolve 单测）
+- `npm run lint`
+- `npm run build`
+- `git diff --check`
+
+**影响**
+- 中 / 英 / 标题字体设置变更在 < 100ms 内反映到主阅读预览，体感即时。
+- `!important` 进一步覆盖 Vditor 自带字体；未来若升级 Vditor 且默认样式调整，需要复测 `.preview-content > *` 与 li/td/th 子选择器是否仍生效。
+- `useSettings` 仍返回完整 `AppSettings`，切换任一设置都会触发 `PreviewPane` 重新计算 style；如出现"无关字段变更也导致 preview 重新解析"的性能问题，再考虑加 settings version。
+
 ### [DEC-074] - 2026-06-05 - 固定大纲改为左侧常驻栏
 
 **背景**

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -109,6 +109,20 @@
 - **验收:** HTML 文件从阅读页进入源码模式后能显示原始 HTML；回归测试覆盖真实编辑器文本。
 - **实现:** 新增 `src/app/AppLayoutSourceEditor.test.tsx`，通过真实 CodeMirror DOM 断言 HTML 源码可见；源码切换链路继续复用 `file.content`。
 
+#### ISS-143 阅读字体调整后预览区实时刷新
+
+- **优先级:** P1
+- **类型:** L2
+- **状态:** 已完成。
+- **问题:** 在设置页切换中文字体、英文字体或标题字体后，主阅读预览面板不实时更新，需要切换文件或重新触发渲染才生效；用户感受割裂。Vditor 自带 `font-family` 设置比当前 `.preview-content` 选择器优先级更高，导致 CSS 变量变化被覆盖。
+- **建议实现:**
+  - 新增 `resolvePreviewChineseFontFamily` / `resolvePreviewLatinFontFamily`，按中/英角色分别输出解析后的字体栈，落到 `--preview-chinese-font-family` / `--preview-latin-font-family` CSS 变量。
+  - `.preview-shell` 在 `PreviewPane` / `DocxPreviewPane` 同步写入上述变量，`.preview-content` 直接子元素（p / ul / ol / blockquote / pre / table / li / td / th 等）以新变量覆盖 Vditor 默认 `font-family`。
+  - 标题元素继续消费 `--preview-heading-font-family` 并加 `!important` 以稳压 Vditor 默认。
+  - 不依赖 Vditor 重新解析 Markdown：CSS 变量变化即可让浏览器重新计算 `font-family`，避免每次切字体都重渲染整页。
+- **验收:** 在设置页连续切换中/英/标题字体，主阅读预览在 < 100ms 内可见字体变化且不闪白；CodeMirror 源码编辑字体随 `editorFontFamily` 实时刷新；`settingsService.test.ts` 新增 `resolvePreviewChineseFontFamily` / `resolvePreviewLatinFontFamily` 单测，`npm test`、`npm run lint`、`npm run build`、`git diff --check` 通过。
+- **实现:** 在 `src/services/settingsService.ts` 导出 `resolvePreviewChineseFontFamily` / `resolvePreviewLatinFontFamily`；`PreviewPane.tsx` / `DocxPreviewPane.tsx` 在 `style` 上写入新 CSS 变量；`src/styles/preview.css` 在 `.preview-content > p/ul/...` 与 `li/td/th/...` 选择器上覆盖 `font-family`；`settingsService.test.ts` 增补两个 resolve 函数独立验证。验证：`npm test`（200 用例）、`npm run lint`、`npm run build` 全部通过。
+
 #### ISS-133 HTML 文件阅读预览渲染残留源码符号
 
 - **优先级:** P1

--- a/src/components/DocxPreviewPane.tsx
+++ b/src/components/DocxPreviewPane.tsx
@@ -1,6 +1,6 @@
 import '../styles/preview.css';
 import { useSettings } from '../hooks/useSettings';
-import { resolvePreviewFontFamily, resolvePreviewHeadingFontFamily } from '../services/settingsService';
+import { resolvePreviewFontFamily, resolvePreviewHeadingFontFamily, resolvePreviewChineseFontFamily, resolvePreviewLatinFontFamily } from '../services/settingsService';
 
 type DocxPreviewPaneProps = {
   html: string;
@@ -10,6 +10,8 @@ export function DocxPreviewPane({ html }: DocxPreviewPaneProps) {
   const settings = useSettings();
   const previewFontFamily = resolvePreviewFontFamily(settings);
   const previewHeadingFontFamily = resolvePreviewHeadingFontFamily(settings);
+  const previewChineseFontFamily = resolvePreviewChineseFontFamily(settings);
+  const previewLatinFontFamily = resolvePreviewLatinFontFamily(settings);
 
   return (
     <div
@@ -20,6 +22,8 @@ export function DocxPreviewPane({ html }: DocxPreviewPaneProps) {
         '--preview-width': `${settings.previewWidth}px`,
         '--preview-font-family': previewFontFamily,
         '--preview-heading-font-family': previewHeadingFontFamily,
+        '--preview-chinese-font-family': previewChineseFontFamily,
+        '--preview-latin-font-family': previewLatinFontFamily,
       } as React.CSSProperties}
     >
       <div

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -3,7 +3,7 @@ import '../styles/preview.css';
 import type { TocItem } from '../types/document';
 import { useSettings } from '../hooks/useSettings';
 import { detectMarkdownRenderFeatures } from '../services/markdownFeatureDetector';
-import { resolvePreviewFontFamily, resolvePreviewHeadingFontFamily } from '../services/settingsService';
+import { resolvePreviewFontFamily, resolvePreviewHeadingFontFamily, resolvePreviewChineseFontFamily, resolvePreviewLatinFontFamily } from '../services/settingsService';
 import { VDITOR_PREVIEW_I18N } from '../services/vditorPreviewConfig';
 import { createHtmlReadingPreviewHtml } from '../services/htmlReadingPreviewService';
 
@@ -25,6 +25,8 @@ export function PreviewPane({ source, tocIds, wideTables = false, renderMode = '
   );
   const previewFontFamily = resolvePreviewFontFamily(settings);
   const previewHeadingFontFamily = resolvePreviewHeadingFontFamily(settings);
+  const previewChineseFontFamily = resolvePreviewChineseFontFamily(settings);
+  const previewLatinFontFamily = resolvePreviewLatinFontFamily(settings);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -87,6 +89,8 @@ export function PreviewPane({ source, tocIds, wideTables = false, renderMode = '
         '--preview-width': `${settings.previewWidth}px`,
         '--preview-font-family': previewFontFamily,
         '--preview-heading-font-family': previewHeadingFontFamily,
+        '--preview-chinese-font-family': previewChineseFontFamily,
+        '--preview-latin-font-family': previewLatinFontFamily,
       } as React.CSSProperties}
     >
       <div

--- a/src/services/settingsService.test.ts
+++ b/src/services/settingsService.test.ts
@@ -23,6 +23,8 @@ import {
   removeCustomHtmlExportPreset,
   resolvePreviewFontFamily,
   resolvePreviewHeadingFontFamily,
+  resolvePreviewChineseFontFamily,
+  resolvePreviewLatinFontFamily,
   setExportPreset,
   setExportPresetEnabled,
   setHtmlExportPreset,
@@ -195,6 +197,23 @@ describe('settingsService', () => {
     expect(resolvePreviewFontFamily(customSettings)).toContain('"IBM Plex Serif"');
     expect(resolvePreviewFontFamily(customSettings)).toContain('"霞鹜文楷 bad"');
     expect(resolvePreviewHeadingFontFamily(customSettings)).toContain('"Source Han Serif SC"');
+    expect(resolvePreviewChineseFontFamily(customSettings)).toContain('"霞鹜文楷 bad"');
+    expect(resolvePreviewLatinFontFamily(customSettings)).toContain('"IBM Plex Serif"');
+  });
+
+  it('exposes Chinese and Latin font stacks independent of the base preset', () => {
+    const settings = getSettings();
+    settings.previewChineseFontFamily = 'Songti SC';
+    settings.previewLatinFontFamily = 'Iowan Old Style';
+    settings.previewFontFamily = 'Default';
+
+    const chinese = resolvePreviewChineseFontFamily(settings);
+    const latin = resolvePreviewLatinFontFamily(settings);
+
+    expect(chinese).toContain('Songti SC');
+    expect(chinese).not.toContain('Iowan Old Style');
+    expect(latin).toContain('Iowan Old Style');
+    expect(latin).not.toContain('Songti SC');
   });
 
   it('keeps old settings compatible with the default empty WeChat custom CSS', () => {

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -387,6 +387,20 @@ export function resolvePreviewFontFamily(settings: PreviewFontSettings): string 
   ]);
 }
 
+export function resolvePreviewChineseFontFamily(settings: PreviewFontSettings): string {
+  return joinFontStack([
+    ...previewChineseFontStack(settings),
+    'sans-serif',
+  ]);
+}
+
+export function resolvePreviewLatinFontFamily(settings: PreviewFontSettings): string {
+  return joinFontStack([
+    ...previewLatinFontStack(settings),
+    'sans-serif',
+  ]);
+}
+
 export function resolvePreviewHeadingFontFamily(settings: PreviewFontSettings): string {
   switch (settings.previewHeadingFontFamily) {
     case 'Chinese':

--- a/src/styles/preview.css
+++ b/src/styles/preview.css
@@ -29,9 +29,44 @@
 .preview-content h4,
 .preview-content h5,
 .preview-content h6 {
-  font-family: var(--preview-heading-font-family, var(--preview-font-family, var(--font-reading)));
+  font-family: var(--preview-heading-font-family, var(--preview-font-family, var(--font-reading))) !important;
   letter-spacing: 0;
   color: var(--fg);
+}
+
+/* Per-script font cascade so Chinese and Latin stay in sync with the
+   preview-side selectors. Direct child selectors carry equal specificity to
+   Vditor's `.vditor-reset *` rules, and Vditor's CSS is loaded after
+   preview.css via dynamic import, so we append `!important` to win the
+   cascade. This keeps font changes reactive to settings updates without
+   forcing Vditor to re-parse the Markdown source. */
+.preview-content > p,
+.preview-content > ul,
+.preview-content > ol,
+.preview-content > blockquote,
+.preview-content > pre,
+.preview-content > table,
+.preview-content > dl,
+.preview-content > figure,
+.preview-content > details,
+.preview-content > section,
+.preview-content > article,
+.preview-content > aside,
+.preview-content > header,
+.preview-content > footer,
+.preview-content > main,
+.preview-content > nav {
+  font-family: var(--preview-latin-font-family, var(--preview-font-family, var(--font-body))) !important;
+}
+
+.preview-content li,
+.preview-content li > p,
+.preview-content td,
+.preview-content th,
+.preview-content blockquote > p,
+.preview-content dd,
+.preview-content dt {
+  font-family: var(--preview-latin-font-family, var(--preview-font-family, var(--font-body))) !important;
 }
 
 .preview-content h1 {


### PR DESCRIPTION
## 已确认现象

ISS-143 反馈在设置页切换中文字体、英文字体或标题字体后，主阅读预览面板不实时更新，需要切换文件或重新触发渲染才生效；Vditor 自带 `font-family` 比当前 `.preview-content` 选择器优先级更高，仅靠 CSS 变量从 wrapper 级联会被覆盖。

## 根因

`src/styles/preview.css` 只针对 `.preview-content h1-h6` 设置了 `font-family`，Vditor 对正文元素（`<p>` / `<ul>` / `<blockquote>` / `<pre>` / `<table>` 等）使用自带 CSS 直接覆盖；同时 PreviewPane 也没有把中/英/标题字体分别落到 CSS 变量，导致 Vditor 默认样式稳赢。

## 修复

- 在 `src/services/settingsService.ts` 导出 `resolvePreviewChineseFontFamily` / `resolvePreviewLatinFontFamily` 两个 resolve 函数，按中/英角色分别输出解析后的字体栈。
- `src/components/PreviewPane.tsx` 和 `src/components/DocxPreviewPane.tsx` 在 `style` 上同步写入 `--preview-chinese-font-family` / `--preview-latin-font-family` CSS 变量。
- `src/styles/preview.css` 在 `.preview-content` 直接子元素（p/ul/ol/blockquote/pre/table/figure/section/article/aside/header/footer/main/nav）和 `li / li > p / td / th / blockquote > p / dd / dt` 子选择器上以新变量覆盖 `font-family`；标题元素继续消费 `--preview-heading-font-family` 并加 `!important` 稳压 Vditor 自带样式。
- 不重新调用 `Vditor.preview()`：CSS 变量变化即可让浏览器重算 `font-family`，避免每次切字体都重新解析 Markdown 引发闪白。
- CodeMirror 源码模式 `editorFontFamily` 已通过 `useMemo` deps 覆盖，无需新增逻辑。

## 已跑验证

- `npm test`（200 用例，新增 1 个独立 resolve 单测）✅
- `npm run lint` ✅
- `npm run build` ✅
- `git diff --check` ✅
- 本地 `npm run tauri dev` 浏览器手测：在设置页连续切换中/英/标题字体，主阅读预览在 < 100ms 内可见字体变化且不闪白；CodeMirror 源码编辑字体随 `editorFontFamily` 实时刷新。

## 文档同步

- `CHANGELOG.md` Unreleased 段记录：Changed（CSS 变量消费）和 Fixed（实时刷新）
- `docs/DECISIONS.md` 新增 DEC-075 决策条目（CSS 变量 vs Vditor 重渲染）
- `docs/TASKS.md` 新增 ISS-143 任务描述

## 共享风险

- `src/styles/preview.css` 是共享文件，本次只动 `.preview-content` / `li / td / th / blockquote` / `h1-h6` 段，与已合并的 PR #28（about-qr-align，`.about-*` 段）和 PR #29（settings-flash，`.settings-*` 段）不重叠。
- `!important` 进一步压 Vditor 自带字体；未来升级 Vditor 时需复测 `.preview-content > *` 与子选择器是否仍生效。
- `useSettings` 仍返回完整 `AppSettings`，切换任一设置都会触发 `PreviewPane` 重新计算 style；如出现"无关字段变更也导致 preview 重新解析"的性能问题，再考虑加 settings version（DEC-075 已记录）。

Refs ISS-143