### PR TITLE
perf(editor): 修复超长 Markdown 文件白屏与编辑卡顿 (ISS-159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Performance
+
+- 显著改善超长 Markdown 文件（数 MB / 数千行）打开时的白屏与编辑卡顿（ISS-159 / DEC-091）。**打开阶段**：Rust `read_opened_document` 由返回 `Vec<u8>`（被 Tauri 序列化成 JSON 数字数组，10MB 文件膨胀为 30-40MB、内存峰值达原始文件数倍并卡死 WebView）改为返回原始字节 `tauri::ipc::Response`，前端 `invoke` 直接拿到 `ArrayBuffer`，序列化膨胀消除、内存峰值降到约原始文件一倍。**编辑阶段**：`handleContentChange` 中的大纲（TOC）全文正则提取改为 150ms 防抖（文件内容仍每键同步保存）；active-heading 的 `MutationObserver` 不再依赖 `file.content`，避免每次按键都 `disconnect` 后重新 `observe` 整棵 DOM。
+
+### Fixed
+
+- 超大文件（>10MB）在 Rust 后端用 `metadata` 读取前拦截并返回明确错误，前端弹出原生「该文件过大（超过 10MB），暂不支持打开」提示（中 / 英 / 日三语），避免超大文件撑爆内存（ISS-159）。
+
 ## [0.3.22] - 2026-06-13
 
 ### Changed

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,14 +16,41 @@ fn pending_opened_paths(app: tauri::AppHandle) -> Vec<String> {
   std::mem::take(&mut *paths)
 }
 
-#[tauri::command]
-fn read_opened_document(path: String) -> Result<Vec<u8>, String> {
-  let path = PathBuf::from(path);
-  if !is_openable_document_path(&path) {
+/// 单个受支持文档允许打开的最大字节数（ISS-159）。
+///
+/// 10MB Markdown 已远超常规长文档；超长文件此前会把 `Vec<u8>` 经 Tauri 序列化成
+/// JSON 数字数组，造成数倍内存峰值并卡死 WebView。这里在读取前用 metadata 拦截，
+/// 避免超大文件直接 OOM。如需放宽，调整该常量即可。
+const MAX_OPENED_DOCUMENT_BYTES: u64 = 10 * 1024 * 1024;
+
+/// 校验、限额并读取受支持文档的全部字节。返回 `Vec<u8>` 以便单测断言内容；
+/// `read_opened_document` 命令再将其包成原始字节 [`tauri::ipc::Response`]，
+/// 避免 `Vec<u8>` 被序列化成 JSON 数字数组导致的 IPC 内存膨胀。
+fn read_opened_document_bytes(path: &Path) -> Result<Vec<u8>, String> {
+  if !is_openable_document_path(path) {
     return Err("unsupported document type".into());
   }
 
-  std::fs::read(&path).map_err(|error| format!("failed to read document: {error}"))
+  // 先用 metadata 拦截超大文件，避免读入后才发现 OOM。
+  let metadata = std::fs::metadata(path)
+    .map_err(|error| format!("failed to read document: {error}"))?;
+  if metadata.len() > MAX_OPENED_DOCUMENT_BYTES {
+    return Err(format!(
+      "file too large: {} bytes exceeds the {} byte limit",
+      metadata.len(),
+      MAX_OPENED_DOCUMENT_BYTES
+    ));
+  }
+
+  std::fs::read(path).map_err(|error| format!("failed to read document: {error}"))
+}
+
+#[tauri::command]
+fn read_opened_document(path: String) -> Result<tauri::ipc::Response, String> {
+  let path = PathBuf::from(path);
+  // 用 tauri::ipc::Response 返回原始字节，前端 invoke 直接拿到 ArrayBuffer，
+  // 跳过 JSON 数字数组序列化，内存峰值从原始文件的数倍降到约一倍（ISS-159）。
+  Ok(tauri::ipc::Response::new(read_opened_document_bytes(&path)?))
 }
 
 #[tauri::command]
@@ -152,7 +179,7 @@ mod tests {
     let path = temp_path("opened.md");
     std::fs::write(&path, b"# opened").unwrap();
 
-    let bytes = read_opened_document(path.to_string_lossy().to_string()).unwrap();
+    let bytes = read_opened_document_bytes(&path).unwrap();
 
     assert_eq!(bytes, b"# opened");
     let _ = std::fs::remove_file(path);
@@ -163,9 +190,36 @@ mod tests {
     let path = temp_path("secret.txt");
     std::fs::write(&path, b"secret").unwrap();
 
-    let error = read_opened_document(path.to_string_lossy().to_string()).unwrap_err();
+    let error = read_opened_document_bytes(&path).unwrap_err();
 
     assert!(error.contains("unsupported document type"));
+    let _ = std::fs::remove_file(path);
+  }
+
+  #[test]
+  fn read_opened_document_rejects_oversized_files() {
+    // 超过 MAX_OPENED_DOCUMENT_BYTES 的文件在读取前就应被拦截（ISS-159）。
+    let path = temp_path("oversized.md");
+    std::fs::write(&path, vec![0u8; MAX_OPENED_DOCUMENT_BYTES as usize + 1]).unwrap();
+
+    let error = read_opened_document_bytes(&path).unwrap_err();
+
+    assert!(
+      error.contains("file too large"),
+      "expected size-limit error, got: {error}"
+    );
+    let _ = std::fs::remove_file(path);
+  }
+
+  #[test]
+  fn read_opened_document_accepts_file_at_size_limit() {
+    // 恰好等于上限的文件应可正常读取（边界：> 才拒绝）。
+    let path = temp_path("at-limit.md");
+    std::fs::write(&path, vec![0u8; MAX_OPENED_DOCUMENT_BYTES as usize]).unwrap();
+
+    let bytes = read_opened_document_bytes(&path).unwrap();
+
+    assert_eq!(bytes.len(), MAX_OPENED_DOCUMENT_BYTES as usize);
     let _ = std::fs::remove_file(path);
   }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,6 +35,8 @@ fn read_opened_document_bytes(path: &Path) -> Result<Vec<u8>, String> {
   let metadata = std::fs::metadata(path)
     .map_err(|error| format!("failed to read document: {error}"))?;
   if metadata.len() > MAX_OPENED_DOCUMENT_BYTES {
+    // 该文案被前端 fileService 的 OVERSIZED_FILE_PATTERN 匹配以决定是否弹原生提示；
+    // 改文案时需同步 src/services/fileService.test.ts 的 BACKEND_OVERSIZED_FILE_ERROR（ISS-159）。
     return Err(format!(
       "file too large: {} bytes exceeds the {} byte limit",
       metadata.len(),

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -110,6 +110,10 @@ function SettingsPageFallback() {
   );
 }
 
+// TOC 提取是对全文的正则扫描；编辑超长文档时每键都跑会卡顿，
+// 故把 TOC 刷新防抖到输入停顿后执行（ISS-159）。文件内容本身仍每键同步落盘/保存。
+const TOC_REFRESH_DEBOUNCE_MS = 150;
+
 function extractToc(content: string): TocItem[] {
   const headings: TocItem[] = [];
   const regex = /^(#{1,6})\s+(.+)$/gm;
@@ -138,6 +142,8 @@ export function AppLayout() {
   const autoUpdateCheckStarted = useRef(false);
   const updateDownloadVersionRef = useRef<string | null>(null);
   const mainContentRef = useRef<HTMLDivElement>(null);
+  // 防抖挂起的 TOC 刷新定时器；卸载时清掉，避免 stale setToc（ISS-159）。
+  const tocRefreshTimerRef = useRef<number | null>(null);
   const [file, setFile] = useState<OpenedFile>(createEmptyFile());
   const [toc, setToc] = useState<TocItem[]>([]);
   const [tocSessionPinned, setTocSessionPinned] = useState(false);
@@ -157,6 +163,16 @@ export function AppLayout() {
     document.documentElement.dataset.theme = settings.theme;
     document.documentElement.style.colorScheme = settings.theme;
   }, [settings.theme]);
+
+  // 卸载时取消挂起的 TOC 防抖，避免离开后仍触发 stale setToc（ISS-159）。
+  useEffect(() => {
+    return () => {
+      if (tocRefreshTimerRef.current !== null) {
+        window.clearTimeout(tocRefreshTimerRef.current);
+        tocRefreshTimerRef.current = null;
+      }
+    };
+  }, []);
 
   useEffect(() => {
     /* Kick off the settings chunk immediately on mount so the modal is fully
@@ -227,7 +243,14 @@ export function AppLayout() {
       content: value,
       dirty: value !== prev.lastSavedContent,
     }));
-    setToc(extractToc(value));
+    // extractToc 是全文正则扫描，超长文档每键都跑会卡顿；防抖到输入停顿后刷新（ISS-159）。
+    if (tocRefreshTimerRef.current !== null) {
+      window.clearTimeout(tocRefreshTimerRef.current);
+    }
+    tocRefreshTimerRef.current = window.setTimeout(() => {
+      tocRefreshTimerRef.current = null;
+      setToc(extractToc(value));
+    }, TOC_REFRESH_DEBOUNCE_MS);
   }, []);
 
   const handleToggleEditorMode = useCallback(() => {
@@ -600,7 +623,9 @@ export function AppLayout() {
       window.removeEventListener('resize', scheduleUpdate);
       observer?.disconnect();
     };
-  }, [editorMode, file.content, resolveTocHeading, toc, rightPanelMode]);
+    // 故意不含 file.content：内容变化通过上面的 MutationObserver 实时感知，
+    // 不应每键都 disconnect + 重新 observe 整棵 DOM（ISS-159）。toc 变化时重建即可。
+  }, [editorMode, resolveTocHeading, toc, rightPanelMode]);
 
   const editorPane = isDocx ? (
     <div className="editor-pane readonly-pane">

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -144,6 +144,13 @@ export function AppLayout() {
   const mainContentRef = useRef<HTMLDivElement>(null);
   // 防抖挂起的 TOC 刷新定时器；卸载时清掉，避免 stale setToc（ISS-159）。
   const tocRefreshTimerRef = useRef<number | null>(null);
+  // 取消挂起的 TOC 防抖刷新：打开新文件 / 卸载时调用，避免上一个文件的过期 setToc 覆盖新文件大纲（ISS-159）。
+  const cancelPendingTocRefresh = useCallback(() => {
+    if (tocRefreshTimerRef.current !== null) {
+      window.clearTimeout(tocRefreshTimerRef.current);
+      tocRefreshTimerRef.current = null;
+    }
+  }, []);
   const [file, setFile] = useState<OpenedFile>(createEmptyFile());
   const [toc, setToc] = useState<TocItem[]>([]);
   const [tocSessionPinned, setTocSessionPinned] = useState(false);
@@ -166,13 +173,8 @@ export function AppLayout() {
 
   // 卸载时取消挂起的 TOC 防抖，避免离开后仍触发 stale setToc（ISS-159）。
   useEffect(() => {
-    return () => {
-      if (tocRefreshTimerRef.current !== null) {
-        window.clearTimeout(tocRefreshTimerRef.current);
-        tocRefreshTimerRef.current = null;
-      }
-    };
-  }, []);
+    return () => cancelPendingTocRefresh();
+  }, [cancelPendingTocRefresh]);
 
   useEffect(() => {
     /* Kick off the settings chunk immediately on mount so the modal is fully
@@ -186,6 +188,7 @@ export function AppLayout() {
     const opened = await openFile(settings.defaultEncoding);
     if (opened) {
       setFile(opened);
+      cancelPendingTocRefresh();
       setToc(extractToc(opened.content));
       if (opened.path) setLastOpenedPath(opened.path);
       setHtmlPresentationVisible(false);
@@ -195,12 +198,13 @@ export function AppLayout() {
         setEditorMode('wysiwyg');
       }
     }
-  }, [settings.defaultEncoding]);
+  }, [settings.defaultEncoding, cancelPendingTocRefresh]);
 
   const handleOpenPath = useCallback(async (path: string) => {
     const { openPath } = await import('../services/fileService');
     const opened = await openPath(path, settings.defaultEncoding);
     setFile(opened);
+    cancelPendingTocRefresh();
     setToc(opened.fileType === 'docx' ? [] : extractToc(opened.content));
     setLastOpenedPath(path);
     setHtmlPresentationVisible(false);
@@ -209,7 +213,7 @@ export function AppLayout() {
     } else {
       setEditorMode('wysiwyg');
     }
-  }, [settings.defaultEncoding]);
+  }, [settings.defaultEncoding, cancelPendingTocRefresh]);
 
   const handleSave = useCallback(async () => {
     if (file.fileType === 'docx') return;

--- a/src/services/fileService.test.ts
+++ b/src/services/fileService.test.ts
@@ -21,6 +21,12 @@ function bytesOf(value: string): number[] {
   return Array.from(new TextEncoder().encode(value));
 }
 
+// 后端 read_opened_document 现以 tauri::ipc::Response 返回原始字节，
+// 前端 invoke 拿到的是 ArrayBuffer（ISS-159）。
+function arrayBufferOf(value: string): ArrayBuffer {
+  return new TextEncoder().encode(value).buffer;
+}
+
 describe('fileService', () => {
   afterEach(() => {
     delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
@@ -32,7 +38,7 @@ describe('fileService', () => {
       configurable: true,
       value: {},
     });
-    tauriCoreMock.invoke.mockResolvedValue(bytesOf('# 双击打开\n正文'));
+    tauriCoreMock.invoke.mockResolvedValue(arrayBufferOf('# 双击打开\n正文'));
     tauriFsMock.readTextFile.mockRejectedValue(new Error('frontend fs scope denied'));
 
     const opened = await openPath('/Users/demo/双击打开.md', 'UTF-8');
@@ -49,6 +55,19 @@ describe('fileService', () => {
       lastSavedContent: '# 双击打开\n正文',
       fileType: 'markdown',
     });
+  });
+
+  it('still decodes legacy number-array responses for robustness', async () => {
+    // 后端现已返回 ArrayBuffer；这里防御性地覆盖 number[] 旧形态仍能正确解码（ISS-159）。
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    });
+    tauriCoreMock.invoke.mockResolvedValue(bytesOf('# legacy\n正文'));
+
+    const opened = await openPath('/Users/demo/legacy.md', 'UTF-8');
+
+    expect(opened.content).toBe('# legacy\n正文');
   });
 
   it('keeps browser/test fallback on the filesystem plugin outside Tauri runtime', async () => {

--- a/src/services/fileService.test.ts
+++ b/src/services/fileService.test.ts
@@ -17,6 +17,30 @@ vi.mock('@tauri-apps/api/core', () => tauriCoreMock);
 
 vi.mock('@tauri-apps/plugin-fs', () => tauriFsMock);
 
+// 与 src-tauri/src/lib.rs 中 read_opened_document_bytes 的超限错误文案保持一致；
+// 前端 fileService 用 OVERSIZED_FILE_PATTERN 匹配该串以决定是否弹原生提示。
+// 修改 Rust 端文案时必须同步更新本常量与下面的匹配断言（ISS-159 契约守卫）。
+const BACKEND_OVERSIZED_FILE_ERROR =
+  'file too large: 12345678 bytes exceeds the 10485760 byte limit';
+
+const dialogMock = vi.hoisted(() => ({
+  message: vi.fn().mockResolvedValue(undefined),
+  open: vi.fn(),
+  save: vi.fn(),
+}));
+
+const settingsMock = vi.hoisted(() => ({
+  getSettings: vi.fn(() => ({ locale: 'zh-CN' })),
+}));
+
+const i18nMock = vi.hoisted(() => ({
+  translate: vi.fn((_locale: unknown, key: unknown) => `__tr:${String(key)}`),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => dialogMock);
+vi.mock('./settingsService', () => settingsMock);
+vi.mock('./i18n', () => i18nMock);
+
 function bytesOf(value: string): number[] {
   return Array.from(new TextEncoder().encode(value));
 }
@@ -105,5 +129,33 @@ describe('fileService', () => {
     expect(tauriFsMock.writeTextFile).not.toHaveBeenCalled();
     expect(saved.dirty).toBe(false);
     expect(saved.lastSavedContent).toBe('# 修改后');
+  });
+
+  it('shows a native prompt when the backend rejects an oversized file', async () => {
+    // 契约守卫：后端超限错误文案必须被前端 OVERSIZED_FILE_PATTERN 命中（ISS-159）。
+    // 修改 lib.rs 文案时同步更新 BACKEND_OVERSIZED_FILE_ERROR，此断言即第一道防线。
+    expect(/file too large/i.test(BACKEND_OVERSIZED_FILE_ERROR)).toBe(true);
+
+    Object.defineProperty(window, '__TAURI_INTERNALS__', { configurable: true, value: {} });
+    tauriCoreMock.invoke.mockRejectedValue(new Error(BACKEND_OVERSIZED_FILE_ERROR));
+
+    await expect(openPath('/Users/demo/huge.md', 'UTF-8')).rejects.toThrow(BACKEND_OVERSIZED_FILE_ERROR);
+
+    expect(settingsMock.getSettings).toHaveBeenCalledTimes(1);
+    expect(i18nMock.translate).toHaveBeenCalledWith('zh-CN', 'openFileTooLargeMessage');
+    expect(dialogMock.message).toHaveBeenCalledTimes(1);
+    expect(dialogMock.message).toHaveBeenCalledWith('__tr:openFileTooLargeMessage', {
+      title: 'huge.md',
+      kind: 'warning',
+    });
+  });
+
+  it('does not show the oversized prompt for unrelated read errors', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', { configurable: true, value: {} });
+    tauriCoreMock.invoke.mockRejectedValue(new Error('failed to read document: permission denied'));
+
+    await expect(openPath('/Users/demo/perm.md', 'UTF-8')).rejects.toThrow();
+
+    expect(dialogMock.message).not.toHaveBeenCalled();
   });
 });

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -11,14 +11,18 @@ function fileNameFromPath(path: string): string {
   return path.split(/[\\/]/).pop() || '未命名';
 }
 
-function bytesToUint8Array(data: number[] | Uint8Array): Uint8Array {
-  return data instanceof Uint8Array ? data : new Uint8Array(data);
+function bytesToUint8Array(data: ArrayBuffer | Uint8Array | number[]): Uint8Array {
+  if (data instanceof Uint8Array) return data;
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  return new Uint8Array(data);
 }
 
 async function readDocumentBytes(path: string): Promise<Uint8Array> {
   if (isTauriRuntime()) {
     const { invoke } = await import('@tauri-apps/api/core');
-    const data = await invoke<number[] | Uint8Array>('read_opened_document', { path });
+    // 后端 read_opened_document 现以 tauri::ipc::Response 返回原始字节，
+    // invoke 解析为 ArrayBuffer，避免 Vec<u8> 经 JSON 数字数组序列化的内存膨胀（ISS-159）。
+    const data = await invoke<ArrayBuffer | Uint8Array | number[]>('read_opened_document', { path });
     return bytesToUint8Array(data);
   }
 
@@ -34,6 +38,28 @@ function toArrayBuffer(data: Uint8Array): ArrayBuffer {
   const copy = new Uint8Array(data.byteLength);
   copy.set(data);
   return copy.buffer;
+}
+
+// 后端 read_opened_document 拒绝超大文件时返回的错误特征（ISS-159）。
+const OVERSIZED_FILE_PATTERN = /file too large/i;
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// 命中超大文件错误时弹出原生提示，让用户知道为何打开失败（而非静默吞掉）。
+async function notifyOversizedFileIfApplicable(error: unknown, name: string): Promise<void> {
+  if (!isTauriRuntime()) return;
+  if (!OVERSIZED_FILE_PATTERN.test(describeError(error))) return;
+  const [{ getSettings }, { translate }, { message }] = await Promise.all([
+    import('./settingsService'),
+    import('./i18n'),
+    import('@tauri-apps/plugin-dialog'),
+  ]);
+  await message(translate(getSettings().locale, 'openFileTooLargeMessage'), {
+    title: name,
+    kind: 'warning',
+  });
 }
 
 export async function readTextWithEncoding(path: string, encoding: DefaultEncoding): Promise<string> {
@@ -70,17 +96,23 @@ export async function openPath(path: string, encoding: DefaultEncoding = 'UTF-8'
   const name = fileNameFromPath(path);
   const ext = path.split('.').pop()?.toLowerCase();
 
-  if (ext === 'docx') {
-    const data = await readDocumentBytes(path);
-    const { convertDocxToHtml } = await import('./docxPreviewService');
-    const docxHtml = await convertDocxToHtml(toArrayBuffer(data));
-    return { path, name, content: '', dirty: false, lastSavedContent: '', fileType: 'docx', docxHtml };
+  try {
+    if (ext === 'docx') {
+      const data = await readDocumentBytes(path);
+      const { convertDocxToHtml } = await import('./docxPreviewService');
+      const docxHtml = await convertDocxToHtml(toArrayBuffer(data));
+      return { path, name, content: '', dirty: false, lastSavedContent: '', fileType: 'docx', docxHtml };
+    }
+
+    const content = await readTextWithEncoding(path, encoding);
+    const fileType = ext === 'html' || ext === 'htm' ? 'html' as const : 'markdown' as const;
+
+    return { path, name, content, dirty: false, lastSavedContent: content, fileType };
+  } catch (error) {
+    // 超大文件由后端在读取前拒绝；这里给出可见提示后再向上抛出（ISS-159）。
+    await notifyOversizedFileIfApplicable(error, name);
+    throw error;
   }
-
-  const content = await readTextWithEncoding(path, encoding);
-  const fileType = ext === 'html' || ext === 'htm' ? 'html' as const : 'markdown' as const;
-
-  return { path, name, content, dirty: false, lastSavedContent: content, fileType };
 }
 
 export async function saveFile(file: OpenedFile): Promise<OpenedFile> {

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -41,6 +41,7 @@ function toArrayBuffer(data: Uint8Array): ArrayBuffer {
 }
 
 // 后端 read_opened_document 拒绝超大文件时返回的错误特征（ISS-159）。
+// 与 lib.rs 的超限文案一一对应；契约守卫见 fileService.test.ts 的 BACKEND_OVERSIZED_FILE_ERROR。
 const OVERSIZED_FILE_PATTERN = /file too large/i;
 
 function describeError(error: unknown): string {

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -121,6 +121,7 @@ const zhCN = {
   exportWordLabel: '导出 Word',
   closePreviewTitle: '关闭',
   closePreviewLabel: '关闭预览',
+  openFileTooLargeMessage: '该文件过大（超过 10MB），暂不支持打开。',
 };
 
 type I18nKey = keyof typeof zhCN;
@@ -240,6 +241,7 @@ const enUS: Record<I18nKey, string> = {
   exportWordLabel: 'Export Word',
   closePreviewTitle: 'Close',
   closePreviewLabel: 'Close preview',
+  openFileTooLargeMessage: 'This file is too large (over 10 MB) and cannot be opened.',
 };
 
 const jaJP: Record<I18nKey, string> = {
@@ -357,6 +359,7 @@ const jaJP: Record<I18nKey, string> = {
   exportWordLabel: 'Word に書き出し',
   closePreviewTitle: '閉じる',
   closePreviewLabel: 'プレビューを閉じる',
+  openFileTooLargeMessage: 'このファイルは大きすぎます（10MB 超）ため、開けません。',
 };
 
 const dictionaries: Record<AppLocale, Record<I18nKey, string>> = {


### PR DESCRIPTION
## 背景

用户复测反馈：超长 Markdown 文件（数 MB / 数千行）打开后长时间**白屏**，打开后编辑明显**卡顿**。根因与 v0.3.21 的偶发白屏（ISS-158，资源路径 / chunk 拆分）不同，是一组独立的性能瓶颈，已在真实代码中逐一确认。

## 根因

| 阶段 | 瓶颈 | 代码位置 |
|------|------|----------|
| 打开（白屏，P0） | `read_opened_document` 返回 `Vec<u8>`，Tauri 序列化成 JSON 数字数组，10MB 文件膨胀为 30-40MB、内存峰值达原始文件数倍，WebView 主线程卡死 | `src-tauri/src/lib.rs` / `src/services/fileService.ts` |
| 编辑（卡顿，P0） | `handleContentChange` 每键同步 `setToc(extractToc(value))`，全文正则扫描 | `src/app/AppLayout.tsx` |
| 编辑（卡顿，P1） | active-heading `MutationObserver` effect 依赖 `file.content`，每键 disconnect + 重新 observe 整棵 DOM | `src/app/AppLayout.tsx` |

## 改动

1. **治本（IPC）**：`read_opened_document` 返回 `Result<tauri::ipc::Response, String>`，用 `Response::new(bytes)` 返回原始字节，前端 `invoke` 直接拿到 `ArrayBuffer`，彻底消除 JSON 数字数组膨胀。校验 + 读取逻辑抽成可测的 `read_opened_document_bytes(&Path)`。
2. **防御层**：`MAX_OPENED_DOCUMENT_BYTES = 10MB` 常量 + `metadata` 预检；`openPath` 捕获「file too large」并用原生 `message()` 对话框提示（i18n `openFileTooLargeMessage` 三语）。
3. **TOC 防抖**：`handleContentChange` 的 `setToc` 加 150ms 防抖（卸载清理），`setFile` 仍同步更新保证内容不丢。
4. **Observer 去依赖**：active-heading MutationObserver effect 移除 `file.content`，仅 `editorMode`/`toc`/`rightPanelMode` 变化时重建。

## 验证

- Rust：`cd src-tauri && cargo test opened_document` → **6/6 通过**（新增「拒绝超大文件」「恰好等于上限可读」两个边界用例）。
- 前端：`npm test` → **36 文件 / 211 用例通过**（`fileService.test.ts` 改为 mock `ArrayBuffer` 验证新契约，保留 `number[]` 防御分支）。
- `npm run typecheck` / `npm run lint` / `npm run build` 通过。
- 实操验证：探针脚本在预热 Vite dev 上加载 `/`，`.vditor-reset` 正常渲染、`error-pane` 计数 0、控制台 0 错误，确认改动无运行时回归。

## 说明（既有 flake，非本次引入）

本机环境下 Vditor 在 headless Chromium + Vite 冷 deps 缓存下冷启动约 13s，超过 `editor-no-whitescreen` / `wysiwyg-bold-marker` 的 5-10s 超时。该 flake 在 **baseline（本次改动 stash 后）同样复现**，与 ISS-159 无关。建议作为独立测试基建项（放宽编辑器 e2e 的 Vditor 就绪超时）跟进，不在本 PR 处理。

> IPC 治本 + 大小护栏已在 Rust / TS 契约层各验证；Tauri 原生窗口打开真实大文件的最终眼见为实，建议合入后在桌面包复测一次。

Refs: ISS-159 / DEC-091