### PR TITLE
feat(v0.4): 多标签页地基（阶段一：标签页 + 草稿持久化）

### DIFF
--- a/docs/plans/2026-06-14-tabs-recent-files-design.md
+++ b/docs/plans/2026-06-14-tabs-recent-files-design.md
@@ -1,0 +1,123 @@
+# Folia 多标签页 + 最近文件首页 设计
+
+> 日期：2026-06-14
+> 对应 ROADMAP：v0.4 文档管理（最近文件、多文件）
+> 决策记录：[DEC-092]
+> 状态：设计已与用户确认，进入实现
+
+## 1. 背景与目标
+
+Folia 当前是「单文档覆盖式」架构：`AppLayout.tsx:154` 持有单个 `OpenedFile`（被引用 44 处），`openFile()` 直接整体替换，无法同时保留多个文档。本设计实现两个能力：
+
+1. **标签页**：同时打开多个文件，以标签页切换，不互相覆盖；标签页连同未保存草稿跨应用重启持久化。
+2. **最近文件首页**：启动无可恢复会话时显示最近文件列表，便捷打开。
+
+对应 ROADMAP v0.4「文档管理」阶段（⚪ 未开始）。
+
+## 2. 关键决策（已与用户 brainstorming 确认）
+
+| 决策点 | 选择 | 理由 |
+|---|---|---|
+| 标签页持久化范围 | 跨重启 + 恢复未保存草稿 | 用户选最完整方案；草稿 = 会话快照（含内容） |
+| 启动行为 | 有草稿就恢复、无则显示首页 | 不打扰已会话用户，保留首次入口 |
+| 标签栏位置 | 独立一行（Toolbar 下方） | 不重构现有 Toolbar 拖拽逻辑，风险最低 |
+| 最近文件数据源 | 独立路径历史（不与草稿重叠） | 职责清晰：草稿存内容，最近文件存路径 |
+| 存储介质 | localStorage（沿用 settingsService） | 无新 fs 依赖，与现有存储一致 |
+
+## 3. 数据模型与会话管理
+
+核心：把 AppLayout 的「单个当前文档」升级为「多文档会话」。
+
+```ts
+// 新增 src/types/session.ts（或并入 document.ts）
+interface Tab {
+  id: string;              // 稳定唯一 id（React key + 持久化关联）
+  file: OpenedFile;        // 复用现有 OpenedFile（path/name/content/dirty/fileType/...）
+  editorMode: EditorMode;  // 按标签记忆
+  rightPanelMode: RightPanelMode; // 按标签记忆
+  draftPersisted: boolean; // 草稿是否已落盘（大文件降级时为 false）
+}
+interface SessionState {
+  tabs: Tab[];
+  activeTabId: string;
+}
+```
+
+- AppLayout 顶层 state 从 `file` 升级为 `session`（通过新 hook `useSession` 管理）。
+- 对外派生 `activeFile = tabs.find(t => t.id === activeTabId)?.file ?? emptyFile`。
+- 44 处 `file` 引用统一收口到 `activeFile`（读）与 `updateActiveFile(updater)`（写），改动集中、可审查、便于单测。
+- **复用 OpenedFile**：fileService 的 open/save/saveAs、Toc、Word/HTML 预览、导出全部依赖 `OpenedFile`，复用即零成本接入现有管线，把改动隔离在 `useSession` 内，不污染现有 service。
+- **编辑态记忆**：`editorMode`、`rightPanelMode` 按标签记忆（切标签存取）；`toc`/滚动位置等次要状态切回重算，控制复杂度（第一版）。
+
+## 4. 标签栏 UI + 最近文件首页
+
+### 标签栏 TabBar（独立一行组件，`src/components/TabBar.tsx`）
+
+- 位置：Toolbar 下方、编辑区上方；纯交互、**不兼窗口拖拽**（避免与 titlebarDrag 冲突）。
+- 标签单元：文件名（或「未命名」）+ dirty 圆点 + 关闭 `×`；末尾 `+` 新建；溢出横向滚动。
+- 交互：点击切换、`×`/中键关闭、右键菜单（关闭 / 关闭其他 / 关闭右侧 / 全部关闭）、`Cmd+W` 关当前。
+- 脏检查：关闭有未保存改动的标签时弹「保存 / 不保存 / 取消」。
+
+### 最近文件首页 RecentFilesPage（`src/components/RecentFilesPage.tsx`）
+
+- 触发：启动无可恢复会话（首次 / 上次全关）自动显示；会话中关空所有标签也回到此页。
+- 内容：标题 + `打开文件` + `新建` 两个主按钮 + 最近文件列表（文件名 / 路径 / 修改时间 / 类型图标），点列表项 → 新标签打开。
+- 数据源：独立的**最近文件历史**（只存 `path + name + openedAt`，上限 20 条），与标签页草稿快照分开维护。
+- 空状态：无历史时显示欢迎语 + 两个主按钮。
+
+## 5. 草稿持久化 + 启动恢复 + 错误处理
+
+### 存储层（`src/services/sessionStore.ts`，纯新增）
+
+- 沿用 `localStorage`；key `folia.session.v1`。
+- 结构：
+  ```json
+  {
+    "version": 1,
+    "tabs": [{ "id", "file": {OpenedFile}, "editorMode", "rightPanelMode", "draftPersisted" }],
+    "activeTabId": "...",
+    "recentFiles": [{ "path", "name", "openedAt" }]
+  }
+  ```
+- 写时机：标签增删 / 切换、内容变更（**debounce 800ms**，避免高频写）、dirty 变化。
+- **大文件降级（呼应 ISS-159）**：单标签 `file.content` 超 256KB → 不持久化草稿内容、只存 path（下次从磁盘重读），标签标记 `draftPersisted=false` 并在 tooltip / 状态栏提示「草稿未自动保存」。
+- **总量上限**：标签数上限 12，超出 LRU 关最旧非激活标签（先过脏检查）。
+
+### 启动恢复
+
+- 启动读 session：有非空 tabs → 恢复进入编辑（草稿内容直接用；纯 path 标签校验文件存在性）；空 → 显示首页。
+- **文件失效处理**：磁盘文件被删 / 移动 → 草稿内容仍可用（草稿优先），标记 path 失效，保存时走「另存为」。纯 path（无草稿）标签若文件失效 → 标记「文件已丢失」，内容保留最后一次或为空。
+
+### 错误兜底
+
+- localStorage 写失败（超限 / 隐私模式）→ 降级仅内存（本会话有效）+ 状态栏提示「草稿自动保存不可用」，不崩溃。
+- 恢复数据损坏 / 版本不匹配 → schema 校验 + try/catch，损坏则丢弃会话进首页，`console.error` 记录。
+- 草稿与磁盘不一致 → 以草稿为权威（用户最近编辑），`file.dirty` 保留，提示可覆盖磁盘。
+
+## 6. 落地路径（worktree + PR 并行）
+
+**工程现实**：AppLayout「单文档→多文档」是关键路径，所有 UI 都要接它。同时开多个 worktree 改同一文件会冲突地狱。故并行发生在地基打好之后。
+
+### 阶段一（串行，1 个 worktree，TDD 打地基）→ 1 个 PR
+
+1. `sessionStore` service（持久化，纯新增，可独立单测）
+2. `useSession` hook + `SessionState` 模型
+3. AppLayout `file → session` 改造 + 收口 44 处引用
+4. TabBar 基础组件（切换 / 新建 / 关闭 / 脏检查）
+5. typecheck + vitest + lint 全绿 + `tauri dev` 实操验证
+
+### 阶段一合并后 → 阶段二（并行，文件基本不重叠）→ 4 个 PR
+
+- (a) RecentFilesPage + recent history
+- (b) 标签右键菜单 + 快捷键（`Cmd+W` 等）
+- (c) 启动恢复 + 失效文件处理 + 大文件降级
+- (d) 标签编辑态记忆（editorMode / rightPanel 按标签）
+
+## 7. 验证计划
+
+- **单测（vitest）**：
+  - `sessionStore`：正常读写、损坏数据丢弃、大文件降级（>256KB 只存 path）、localStorage 写失败降级、版本迁移。
+  - `useSession`：openInNewTab / switchTab / closeTab（含脏检查）/ updateActiveFile / 编辑态记忆。
+  - `TabBar`：渲染、切换、关闭、脏检查弹窗。
+- **静态**：`npm run typecheck`、`npm run lint` 通过。
+- **实操（必填，呼应全局完成标准）**：`npm run tauri dev`，Playwright MCP 截图验证：开 2 个文件标签切换、关闭脏检查弹窗、改内容后重启恢复草稿、打开 >256KB 大文件标签降级提示。证据写入 RESULT。

--- a/docs/plans/2026-06-14-tabs-session-foundation-plan.md
+++ b/docs/plans/2026-06-14-tabs-session-foundation-plan.md
@@ -1,0 +1,843 @@
+# 多标签页地基（阶段一）实现计划
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 把 Folia 的单文档覆盖式架构升级为多标签会话模型，并持久化草稿跨重启恢复。
+
+**Architecture:** 单 `OpenedFile` state → `SessionState{tabs,activeTabId}`。新增 `sessionStore`（localStorage 持久化，schema 校验 + 大文件降级）、`useSession` hook（tabs CRUD + 脏检查）、`TabBar` 组件（独立一行）。AppLayout 的 44 处 `file` 引用收口到 `activeFile` / `updateActiveFile`，复用 fileService / Toc / 预览 / 导出现有管线。
+
+**Tech Stack:** React 19 + TypeScript + Vite 8 + vitest（jsdom）+ localStorage。
+
+**对应设计:** `docs/plans/2026-06-14-tabs-recent-files-design.md`，决策 [DEC-092]。
+
+**阶段一范围（不含）：** 最近文件首页（阶段二a）、右键菜单 + 快捷键（阶段二b）、标签拖拽排序。无持久化 tabs 时，阶段一退化为现有空编辑器行为（首页留阶段二a接入）。
+
+**全程在 worktree** `.worktrees/v0.4-tabs-session-foundation`（分支 `feat/v0.4-tabs-session-foundation`）操作，所有命令在此目录下执行。`node_modules` 已 symlink 主仓库，无需 `npm install`。
+
+---
+
+## Task 1: SessionState 类型定义
+
+**Files:**
+- Create: `src/types/session.ts`
+
+**Step 1: 写类型文件**
+
+```ts
+// src/types/session.ts
+import type { OpenedFile } from './document';
+
+export type EditorMode = 'wysiwyg' | 'source';
+export type RightPanelMode = 'none' | 'word' | 'wechat' | 'html';
+
+export interface Tab {
+  id: string;
+  file: OpenedFile;
+  editorMode: EditorMode;
+  rightPanelMode: RightPanelMode;
+  /** 草稿是否已落盘。大文件（>256KB）降级时为 false，仅内存。 */
+  draftPersisted: boolean;
+}
+
+export interface RecentFileEntry {
+  path: string;
+  name: string;
+  openedAt: number;
+}
+
+export interface SessionState {
+  tabs: Tab[];
+  activeTabId: string;
+  recentFiles: RecentFileEntry[];
+}
+
+export interface PersistedSession {
+  version: 1;
+  tabs: Array<Omit<Tab, 'draftPersisted'> & { draftPersisted: boolean }>;
+  activeTabId: string;
+  recentFiles: RecentFileEntry[];
+}
+
+/** 单标签草稿内容超过此阈值（256KB）不持久化内容，只存 path。呼应 ISS-159。 */
+export const DRAFT_PERSIST_MAX_BYTES = 256 * 1024;
+/** 标签总数上限，超出 LRU 关最旧非激活标签。 */
+export const MAX_TABS = 12;
+/** 最近文件历史上限。 */
+export const MAX_RECENT_FILES = 20;
+```
+
+**注意：** `EditorMode` / `RightPanelMode` 当前在 `AppLayout.tsx` 内部定义（见 `Toolbar.tsx` 的 `export type EditorMode`）。Task 1 先在此声明，Task 4 改造时让 AppLayout 改为从 `types/session` import，删除重复定义。
+
+**Step 2: typecheck**
+
+Run: `npm run typecheck`
+Expected: 通过（新文件未被引用，不影响现有）。
+
+**Step 3: Commit**
+
+```bash
+git add src/types/session.ts
+git commit -m "feat(v0.4): 新增 SessionState/Tab 类型定义"
+```
+
+---
+
+## Task 2: sessionStore 持久化 service（TDD）
+
+**Files:**
+- Create: `src/services/sessionStore.ts`
+- Test: `src/services/sessionStore.test.ts`
+
+### Step 1: 写失败测试
+
+```ts
+// src/services/sessionStore.test.ts
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  loadSession,
+  saveSession,
+  clearSession,
+  SESSION_STORAGE_KEY,
+} from './sessionStore';
+import type { SessionState, PersistedSession } from '../types/session';
+import { createEmptyFile } from '../types/document';
+
+function makeTab(id: string, content = 'hello'): SessionState['tabs'][number] {
+  return {
+    id,
+    file: { ...createEmptyFile(), name: `${id}.md`, content, path: `/tmp/${id}.md` },
+    editorMode: 'wysiwyg',
+    rightPanelMode: 'none',
+    draftPersisted: true,
+  };
+}
+
+function emptySession(): SessionState {
+  return { tabs: [], activeTabId: '', recentFiles: [] };
+}
+
+beforeEach(() => { localStorage.clear(); });
+afterEach(() => { localStorage.clear(); });
+
+describe('sessionStore.loadSession', () => {
+  it('无存储时返回空会话', () => {
+    expect(loadSession()).toEqual(emptySession());
+  });
+
+  it('正常读取并还原结构', () => {
+    const session: SessionState = {
+      tabs: [makeTab('a')],
+      activeTabId: 'a',
+      recentFiles: [{ path: '/tmp/a.md', name: 'a.md', openedAt: 1000 }],
+    };
+    localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify({ version: 1, ...session }));
+    expect(loadSession()).toEqual(session);
+  });
+
+  it('损坏数据返回空会话且不抛异常', () => {
+    localStorage.setItem(SESSION_STORAGE_KEY, '{ not json');
+    expect(loadSession()).toEqual(emptySession());
+  });
+
+  it('version 不匹配返回空会话', () => {
+    localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify({ version: 99, tabs: [], activeTabId: '', recentFiles: [] }));
+    expect(loadSession()).toEqual(emptySession());
+  });
+
+  it('大文件标签（content > 256KB）降级为只存 path，draftPersisted=false', () => {
+    const big = 'x'.repeat(256 * 1024 + 1);
+    const session: SessionState = { tabs: [makeTab('big', big)], activeTabId: 'big', recentFiles: [] };
+    saveSession(session);
+    const raw = JSON.parse(localStorage.getItem(SESSION_STORAGE_KEY)!) as PersistedSession;
+    expect(raw.tabs[0].draftPersisted).toBe(false);
+    // 降级后内容不落盘（避免 localStorage 爆掉）
+    expect(raw.tabs[0].file.content).toBe('');
+  });
+});
+
+describe('sessionStore.saveSession', () => {
+  it('正常写入', () => {
+    saveSession({ tabs: [makeTab('a')], activeTabId: 'a', recentFiles: [] });
+    const raw = JSON.parse(localStorage.getItem(SESSION_STORAGE_KEY)!) as PersistedSession;
+    expect(raw.version).toBe(1);
+    expect(raw.activeTabId).toBe('a');
+  });
+
+  it('localStorage 写失败（超限）降级为不抛异常', () => {
+    const original = localStorage.setItem;
+    localStorage.setItem = () => { throw new DOMException('quota', 'QuotaExceededError'); };
+    expect(() => saveSession({ tabs: [makeTab('a')], activeTabId: 'a', recentFiles: [] })).not.toThrow();
+    localStorage.setItem = original;
+  });
+});
+
+describe('sessionStore.clearSession', () => {
+  it('清除存储', () => {
+    localStorage.setItem(SESSION_STORAGE_KEY, '{}');
+    clearSession();
+    expect(localStorage.getItem(SESSION_STORAGE_KEY)).toBeNull();
+  });
+});
+```
+
+### Step 2: 运行测试验证失败
+
+Run: `npx vitest run src/services/sessionStore.test.ts`
+Expected: FAIL（`sessionStore` 模块不存在 / 导出未定义）。
+
+### Step 3: 写最小实现
+
+```ts
+// src/services/sessionStore.ts
+import type { SessionState, PersistedSession, Tab } from '../types/session';
+import { DRAFT_PERSIST_MAX_BYTES } from '../types/session';
+
+export const SESSION_STORAGE_KEY = 'folia.session.v1';
+
+function emptySession(): SessionState {
+  return { tabs: [], activeTabId: '', recentFiles: [] };
+}
+
+function isPersistedSession(value: unknown): value is PersistedSession {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return v.version === 1 && Array.isArray(v.tabs) && typeof v.activeTabId === 'string' && Array.isArray(v.recentFiles);
+}
+
+export function loadSession(): SessionState {
+  try {
+    const raw = localStorage.getItem(SESSION_STORAGE_KEY);
+    if (!raw) return emptySession();
+    const parsed: unknown = JSON.parse(raw);
+    if (!isPersistedSession(parsed)) return emptySession();
+    return {
+      tabs: parsed.tabs as Tab[],
+      activeTabId: parsed.activeTabId,
+      recentFiles: parsed.recentFiles,
+    };
+  } catch {
+    // 损坏数据：丢弃，进空会话，不崩溃。
+    return emptySession();
+  }
+}
+
+function toPersisted(session: SessionState): PersistedSession {
+  return {
+    version: 1,
+    activeTabId: session.activeTabId,
+    recentFiles: session.recentFiles,
+    tabs: session.tabs.map((tab) => {
+      const oversized = tab.file.content.length > DRAFT_PERSIST_MAX_BYTES;
+      return {
+        ...tab,
+        draftPersisted: tab.draftPersisted && !oversized,
+        // 超限时不持久化内容，只保留 path（下次从磁盘重读）。
+        file: oversized ? { ...tab.file, content: '', lastSavedContent: '' } : tab.file,
+      };
+    }),
+  };
+}
+
+export function saveSession(session: SessionState): void {
+  try {
+    localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(toPersisted(session)));
+  } catch {
+    // 超限 / 隐私模式：降级仅内存，不崩溃（调用方可在状态栏提示）。
+  }
+}
+
+export function clearSession(): void {
+  try {
+    localStorage.removeItem(SESSION_STORAGE_KEY);
+  } catch {
+    // 忽略。
+  }
+}
+```
+
+### Step 4: 运行测试验证通过
+
+Run: `npx vitest run src/services/sessionStore.test.ts`
+Expected: PASS（全部用例）。
+
+### Step 5: Commit
+
+```bash
+git add src/services/sessionStore.ts src/services/sessionStore.test.ts
+git commit -m "feat(v0.4): sessionStore 持久化 service（localStorage + 大文件降级）"
+```
+
+---
+
+## Task 3: useSession hook（TDD）
+
+**Files:**
+- Create: `src/hooks/useSession.ts`
+- Test: `src/hooks/useSession.test.ts`
+
+`useSession` 封装 tabs 管理 + 持久化。API：
+
+```ts
+const {
+  tabs, activeTabId, activeFile, activeTab,
+  openInNewTab, switchTab, closeTab, updateActiveFile, updateActiveTabMeta,
+  recordRecentFile,
+} = useSession();
+```
+
+### Step 1: 写失败测试（用 @testing-library/react 的 renderHook）
+
+```ts
+// src/hooks/useSession.test.ts
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSession } from './useSession';
+import { SESSION_STORAGE_KEY } from '../services/sessionStore';
+import { createEmptyFile } from '../types/document';
+
+beforeEach(() => { localStorage.clear(); });
+afterEach(() => { localStorage.clear(); });
+
+describe('useSession', () => {
+  it('初始为空会话（首次使用）', () => {
+    const { result } = renderHook(() => useSession());
+    expect(result.current.tabs).toEqual([]);
+    expect(result.current.activeFile.name).toBe('未命名');
+  });
+
+  it('openInNewTab 增加标签并激活', () => {
+    const { result } = renderHook(() => useSession());
+    act(() => {
+      result.current.openInNewTab({ ...createEmptyFile(), name: 'a.md', content: 'A' });
+    });
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.activeFile.content).toBe('A');
+  });
+
+  it('switchTab 切换激活标签', () => {
+    const { result } = renderHook(() => useSession());
+    act(() => {
+      result.current.openInNewTab({ ...createEmptyFile(), name: 'a.md', content: 'A' });
+      result.current.openInNewTab({ ...createEmptyFile(), name: 'b.md', content: 'B' });
+    });
+    const firstId = result.current.tabs[0].id;
+    act(() => result.current.switchTab(firstId));
+    expect(result.current.activeFile.content).toBe('A');
+  });
+
+  it('updateActiveFile 修改当前标签内容并标记 dirty', () => {
+    const { result } = renderHook(() => useSession());
+    act(() => result.current.openInNewTab({ ...createEmptyFile(), name: 'a.md', content: 'A' }));
+    act(() => result.current.updateActiveFile((f) => ({ ...f, content: 'A2' })));
+    expect(result.current.activeFile.content).toBe('A2');
+    expect(result.current.activeFile.dirty).toBe(true);
+  });
+
+  it('closeTab 干净标签直接关闭', () => {
+    const { result } = renderHook(() => useSession());
+    act(() => result.current.openInNewTab({ ...createEmptyFile(), name: 'a.md', content: 'A' }));
+    const id = result.current.tabs[0].id;
+    act(() => result.current.closeTab(id));
+    expect(result.current.tabs).toEqual([]);
+  });
+
+  it('closeTab dirty 标签需确认（回调返回 false 则取消）', () => {
+    const { result } = renderHook(() => useSession());
+    act(() => result.current.openInNewTab({ ...createEmptyFile(), name: 'a.md', content: 'A' }));
+    act(() => result.current.updateActiveFile((f) => ({ ...f, content: 'A2' })));
+    const id = result.current.tabs[0].id;
+    act(() => result.current.closeTab(id, { confirmDirty: () => false }));
+    expect(result.current.tabs).toHaveLength(1); // 取消，未关闭
+  });
+
+  it('持久化：变更后写入 localStorage', () => {
+    const { result } = renderHook(() => useSession());
+    act(() => result.current.openInNewTab({ ...createEmptyFile(), name: 'a.md', content: 'A' }));
+    expect(JSON.parse(localStorage.getItem(SESSION_STORAGE_KEY)!).tabs).toHaveLength(1);
+  });
+});
+```
+
+> **注意依赖：** `@testing-library/react` 是否已装？检查 `package.json` —— 若未装，先 `npm install -D @testing-library/react`（在 worktree 会写主仓库 node_modules，需谨慎）。**替代方案：** 若不想新增依赖，用 `react-dom/test-utils` 的 `act` + 手动渲染。Task 3 开始前先确认；本计划默认用 `@testing-library/react`，如未装则改用最小手写 harness（见 Step 3 备注）。
+
+### Step 2: 运行测试验证失败
+
+Run: `npx vitest run src/hooks/useSession.test.ts`
+Expected: FAIL（`useSession` 不存在）。
+
+### Step 3: 写实现
+
+```ts
+// src/hooks/useSession.ts
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { OpenedFile } from '../types/document';
+import type { SessionState, Tab, EditorMode, RightPanelMode, RecentFileEntry } from '../types/session';
+import { MAX_TABS, MAX_RECENT_FILES } from '../types/session';
+import { loadSession, saveSession } from '../services/sessionStore';
+import { createEmptyFile } from '../types/document';
+
+function newTabId(): string {
+  return (globalThis.crypto?.randomUUID?.() ?? `tab-${Date.now()}-${Math.random()}`);
+}
+
+function makeTabFromFile(file: OpenedFile): Tab {
+  return { id: newTabId(), file, editorMode: 'wysiwyg', rightPanelMode: 'none', draftPersisted: true };
+}
+
+export interface CloseOptions {
+  /** 关闭 dirty 标签前的确认回调；返回 false 取消关闭。无此回调时直接关闭。 */
+  confirmDirty?: () => boolean;
+}
+
+export function useSession() {
+  const [session, setSession] = useState<SessionState>(() => loadSession());
+  // 首次加载若无 tabs，给一个空标签占位（保持「编辑器始终可用」）。
+  const [session] = useState<SessionState>(() => {
+    const loaded = loadSession();
+    return loaded.tabs.length > 0 ? loaded : { ...loaded, tabs: [makeTabFromFile(createEmptyFile())], activeTabId: '' };
+  });
+  // ↑ 注意：上面两行有重复声明，实现时合并为单个 useState（见下方修正）。
+```
+
+> **实现修正（合并 state 初始化，避免重复声明）：**
+
+```ts
+// src/hooks/useSession.ts（最终版）
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { OpenedFile } from '../types/document';
+import { createEmptyFile } from '../types/document';
+import type { SessionState, Tab, EditorMode, RightPanelMode, RecentFileEntry } from '../types/session';
+import { MAX_TABS, MAX_RECENT_FILES } from '../types/session';
+import { loadSession, saveSession } from '../services/sessionStore';
+
+function newTabId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `tab-${Date.now()}-${Math.random()}`;
+}
+
+function makeTabFromFile(file: OpenedFile): Tab {
+  return { id: newTabId(), file, editorMode: 'wysiwyg', rightPanelMode: 'none', draftPersisted: true };
+}
+
+function bootstrap(): SessionState {
+  const loaded = loadSession();
+  if (loaded.tabs.length > 0) {
+    const activeId = loaded.tabs.some((t) => t.id === loaded.activeTabId) ? loaded.activeTabId : loaded.tabs[0].id;
+    return { ...loaded, activeTabId: activeId };
+  }
+  // 首次使用 / 上次全关：给一个空标签占位，编辑器始终可用（首页接入在阶段二a）。
+  const placeholder = makeTabFromFile(createEmptyFile());
+  return { tabs: [placeholder], activeTabId: placeholder.id, recentFiles: loaded.recentFiles };
+}
+
+export interface CloseOptions {
+  confirmDirty?: () => boolean;
+}
+
+export function useSession() {
+  const [session, setSession] = useState<SessionState>(bootstrap);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const persist = useCallback((next: SessionState) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => saveSession(next), 800);
+  }, []);
+
+  useEffect(() => () => { if (debounceRef.current) clearTimeout(debounceRef.current); }, []);
+
+  const activeTab = session.tabs.find((t) => t.id === session.activeTabId) ?? session.tabs[0];
+  const activeFile = activeTab?.file ?? createEmptyFile();
+
+  const update = useCallback((updater: (prev: SessionState) => SessionState) => {
+    setSession((prev) => {
+      const next = updater(prev);
+      persist(next);
+      return next;
+    });
+  }, [persist]);
+
+  const openInNewTab = useCallback((file: OpenedFile) => {
+    update((prev) => {
+      let tabs = [...prev.tabs, makeTabFromFile(file)];
+      // LRU：超上限关最旧非激活标签（dirty 标签保留，避免丢草稿）。
+      while (tabs.length > MAX_TABS) {
+        const idx = tabs.findIndex((t) => t.id !== prev.activeTabId && !t.file.dirty);
+        if (idx === -1) break;
+        tabs = tabs.filter((_, i) => i !== idx);
+      }
+      const newId = tabs[tabs.length - 1].id;
+      return { ...prev, tabs, activeTabId: newId };
+    });
+  }, [update]);
+
+  const switchTab = useCallback((id: string) => {
+    update((prev) => prev.tabs.some((t) => t.id === id) ? { ...prev, activeTabId: id } : prev);
+  }, [update]);
+
+  const closeTab = useCallback((id: string, options?: CloseOptions) => {
+    let cancelled = false;
+    update((prev) => {
+      const tab = prev.tabs.find((t) => t.id === id);
+      if (!tab) return prev;
+      if (tab.file.dirty && options?.confirmDirty && !options.confirmDirty()) {
+        cancelled = true;
+        return prev;
+      }
+      const tabs = prev.tabs.filter((t) => t.id !== id);
+      if (tabs.length === 0) {
+        const placeholder = makeTabFromFile(createEmptyFile());
+        return { ...prev, tabs: [placeholder], activeTabId: placeholder.id };
+      }
+      const activeTabId = prev.activeTabId === id ? tabs[tabs.length - 1].id : prev.activeTabId;
+      return { ...prev, tabs, activeTabId };
+    });
+    return !cancelled;
+  }, [update]);
+
+  const updateActiveFile = useCallback((updater: (f: OpenedFile) => OpenedFile) => {
+    update((prev) => ({
+      ...prev,
+      tabs: prev.tabs.map((t) =>
+        t.id === prev.activeTabId ? { ...t, file: updater(t.file) } : t
+      ),
+    }));
+  }, [update]);
+
+  const updateActiveTabMeta = useCallback((meta: Partial<Pick<Tab, 'editorMode' | 'rightPanelMode'>>) => {
+    update((prev) => ({
+      ...prev,
+      tabs: prev.tabs.map((t) => (t.id === prev.activeTabId ? { ...t, ...meta } : t)),
+    }));
+  }, [update]);
+
+  const recordRecentFile = useCallback((file: OpenedFile) => {
+    if (!file.path) return;
+    update((prev) => {
+      const entry: RecentFileEntry = { path: file.path, name: file.name, openedAt: Date.now() };
+      const filtered = prev.recentFiles.filter((r) => r.path !== entry.path);
+      return { ...prev, recentFiles: [entry, ...filtered].slice(0, MAX_RECENT_FILES) };
+    });
+  }, [update]);
+
+  return {
+    tabs: session.tabs,
+    activeTabId: session.activeTabId,
+    activeTab,
+    activeFile,
+    recentFiles: session.recentFiles,
+    openInNewTab,
+    switchTab,
+    closeTab,
+    updateActiveFile,
+    updateActiveTabMeta,
+    recordRecentFile,
+  };
+}
+```
+
+### Step 4: 运行测试验证通过
+
+Run: `npx vitest run src/hooks/useSession.test.ts`
+Expected: PASS。
+
+### Step 5: Commit
+
+```bash
+git add src/hooks/useSession.ts src/hooks/useSession.test.ts
+git commit -m "feat(v0.4): useSession hook（tabs CRUD + 脏检查 + 防抖持久化）"
+```
+
+---
+
+## Task 4: AppLayout file→session 改造（重构，非纯 TDD）
+
+> 这是关键路径重构。策略：把 `const [file, setFile]` 替换为 `useSession()`，所有读 `file.*` 改读 `activeFile.*`，所有 `setFile(...)` 改走 `updateActiveFile` / `openInNewTab`。现有功能必须在 active tab 上继续工作。
+
+**Files:**
+- Modify: `src/app/AppLayout.tsx`（state 定义 154、handleOpen 190、handleOpenPath 206、handleSave/SaveAs 219-232、handleContentChange 235-245、docx 守卫 219/227/261/267/273、reopenLastFile 461-486、autoSave 502-510、title 514-518、render 传参 630-753）
+- Modify: `src/types/document.ts` 无需改（OpenedFile 复用）
+
+### Step 1: 先跑现有 AppLayout 测试建立基线
+
+Run: `npx vitest run src/app/AppLayout`
+Expected: 现有测试通过（改造后必须仍通过）。
+
+### Step 2: 替换 state 定义（AppLayout.tsx:154 附近）
+
+把：
+```ts
+const [file, setFile] = useState<OpenedFile>(createEmptyFile());
+```
+改为：
+```ts
+const session = useSession();
+const { activeFile: file, updateActiveFile, openInNewTab, switchTab, closeTab, updateActiveTabMeta, recordRecentFile } = session;
+```
+
+> **关键技巧：** 解构时把 `activeFile` 别名为 `file`，这样下方 44 处读 `file.*` **无需逐个改名**，只改写操作（`setFile`）。把改动量降到最小、可审查。
+
+`editorMode` / `rightPanelMode` 改为从 active tab 派生 + 通过 `updateActiveTabMeta` 写：
+```ts
+const editorMode = session.activeTab?.editorMode ?? 'wysiwyg';
+const rightPanelMode = session.activeTab?.rightPanelMode ?? 'none';
+// setEditorMode(x) → updateActiveTabMeta({ editorMode: x })
+// setRightPanelMode(x) → updateActiveTabMeta({ rightPanelMode: x })
+```
+
+### Step 3: 改写操作（setFile → updateActiveFile / openInNewTab）
+
+| 现有（行号） | 改为 |
+|---|---|
+| `setFile(opened)` in handleOpen (190) | `openInNewTab(opened); recordRecentFile(opened);` |
+| `setFile(opened)` in handleOpenPath (206) | `openInNewTab(opened); recordRecentFile(opened);` |
+| `const updated = await saveFile(file); setFile(updated);` (221-222) | `const updated = await saveFile(file); updateActiveFile(() => updated);` |
+| `saveFileAs` (229-230) | 同上模式 |
+| `handleContentChange` `setFile(prev => ({...prev, content, dirty}))` (245) | `updateActiveFile((f) => ({ ...f, content, dirty }));` |
+| autoSave (505-506) | `saveFile(file).then((updated) => updateActiveFile(() => updated));` |
+
+### Step 4: 处理 reopenLastFile（461-486）兼容
+
+阶段一策略：**session 有持久化 tabs 时，跳过 reopenLastFile**（session 已恢复）；**无持久化 tabs（首次/上次全关，bootstrap 给了空占位标签）时，保留 reopenLastFile 行为**。
+
+在 reopenLastFile effect 前置条件加判断：
+```ts
+// 仅当 session 是空占位（无真实持久化内容）时走旧的重开逻辑
+const sessionWasEmpty = session.tabs.length === 1 && !session.tabs[0].file.path && !session.tabs[0].file.content;
+if (!sessionWasEmpty) return; // session 已恢复，不重开
+if (!systemOpenChecked || !settings.reopenLastFile || file.path || reopenAttempted.current) return;
+// ... 原有重开逻辑
+```
+
+### Step 5: docx 守卫保持
+
+`if (file.fileType === 'docx') return;` 等读操作不变（`file` 已是 `activeFile` 别名）。
+
+### Step 6: document title（514-518）
+
+读 `file.dirty` / `file.name` 不变（已是 activeFile）。
+
+### Step 7: render 传参（630-753）
+
+读 `file.content/path/name/dirty/docxHtml` 不变（activeFile 别名）。
+
+### Step 8: 跑全部测试 + typecheck
+
+Run: `npm run typecheck && npx vitest run src/app`
+Expected: 通过（现有 AppLayout 测试不应回归）。
+
+> 若现有 AppLayout 测试直接断言 `setFile` 或 mock 了 `useState`，需相应调整为 mock `useSession`。检查 `src/app/AppLayout*.test.tsx` 是否依赖 `file` 内部实现。
+
+### Step 9: Commit
+
+```bash
+git add src/app/AppLayout.tsx
+git commit -m "refactor(v0.4): AppLayout 单文档→多标签会话（file 收口为 activeFile）"
+```
+
+---
+
+## Task 5: TabBar 组件（TDD）
+
+**Files:**
+- Create: `src/components/TabBar.tsx`
+- Test: `src/components/TabBar.test.tsx`
+
+### Step 1: 写失败测试
+
+```tsx
+// src/components/TabBar.test.tsx
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TabBar } from './TabBar';
+import type { Tab } from '../types/session';
+import { createEmptyFile } from '../types/document';
+
+function tab(id: string, name: string, dirty = false): Tab {
+  return { id, file: { ...createEmptyFile(), name, path: `/tmp/${name}`, dirty }, editorMode: 'wysiwyg', rightPanelMode: 'none', draftPersisted: true };
+}
+
+describe('TabBar', () => {
+  it('渲染所有标签 + 新建按钮', () => {
+    render(<TabBar tabs={[tab('a', 'a.md'), tab('b', 'b.md')]} activeTabId="a" onSelect={() => {}} onClose={() => {}} onNew={() => {}} />);
+    expect(screen.getByText('a.md')).toBeTruthy();
+    expect(screen.getByText('b.md')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /新建/ })).toBeTruthy();
+  });
+
+  it('点击标签触发 onSelect', () => {
+    const onSelect = vi.fn();
+    render(<TabBar tabs={[tab('a', 'a.md')]} activeTabId="a" onSelect={onSelect} onClose={() => {}} onNew={() => {}} />);
+    fireEvent.click(screen.getByText('a.md'));
+    expect(onSelect).toHaveBeenCalledWith('a');
+  });
+
+  it('点击关闭触发 onClose', () => {
+    const onClose = vi.fn();
+    render(<TabBar tabs={[tab('a', 'a.md')]} activeTabId="a" onSelect={() => {}} onClose={onClose} onNew={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /关闭 a\.md/ }));
+    expect(onClose).toHaveBeenCalledWith('a');
+  });
+
+  it('dirty 标签显示圆点标记', () => {
+    render(<TabBar tabs={[tab('a', 'a.md', true)]} activeTabId="a" onSelect={() => {}} onClose={() => {}} onNew={() => {}} />);
+    expect(screen.getByText('a.md').closest('[data-tab]')?.querySelector('[data-dirty]')).toBeTruthy();
+  });
+});
+```
+
+### Step 2: 运行测试验证失败
+
+Run: `npx vitest run src/components/TabBar.test.tsx`
+Expected: FAIL（TabBar 不存在）。
+
+### Step 3: 写实现
+
+```tsx
+// src/components/TabBar.tsx
+import { translate } from '../services/i18n';
+import { useSettings } from '../hooks/useSettings';
+import type { Tab } from '../types/session';
+
+interface TabBarProps {
+  tabs: Tab[];
+  activeTabId: string;
+  onSelect: (id: string) => void;
+  onClose: (id: string) => void;
+  onNew: () => void;
+}
+
+export function TabBar({ tabs, activeTabId, onSelect, onClose, onNew }: TabBarProps) {
+  const settings = useSettings();
+  const t = (key: Parameters<typeof translate>[1]) => translate(settings.locale, key);
+
+  return (
+    <div className="tabbar" role="tablist">
+      <div className="tabbar-scroll">
+        {tabs.map((tab) => {
+          const active = tab.id === activeTabId;
+          return (
+            <div
+              key={tab.id}
+              data-tab={tab.id}
+              className={`tabbar-tab${active ? ' tabbar-tab--active' : ''}`}
+              role="tab"
+              aria-selected={active}
+              title={tab.file.path || tab.file.name}
+              onClick={() => onSelect(tab.id)}
+            >
+              {tab.file.dirty && <span data-dirty className="tabbar-dirty" />}
+              <span className="tabbar-name">{tab.file.name}</span>
+              <button
+                className="tabbar-close"
+                aria-label={`关闭 ${tab.file.name}`}
+                title={t('close')}
+                onClick={(e) => { e.stopPropagation(); onClose(tab.id); }}
+              >
+                ×
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      <button className="tabbar-new" aria-label={t('newFile')} title={t('newFile')} onClick={onNew}>+</button>
+    </div>
+  );
+}
+```
+
+> **i18n：** 在 `src/services/i18n.ts` 给 `close` / `newFile` 加中/英/日三语条目（参考现有 key 模式）。若 Task 5 时发现缺 key，补上。
+
+### Step 4: 运行测试验证通过
+
+Run: `npx vitest run src/components/TabBar.test.tsx`
+Expected: PASS。
+
+### Step 5: Commit
+
+```bash
+git add src/components/TabBar.tsx src/components/TabBar.test.tsx src/services/i18n.ts
+git commit -m "feat(v0.4): TabBar 标签栏组件（切换/新建/关闭/dirty 标记）"
+```
+
+---
+
+## Task 6: AppLayout 集成 TabBar
+
+**Files:**
+- Modify: `src/app/AppLayout.tsx`（在 Toolbar 下方插入 TabBar；接 onSelect→switchTab、onClose→closeTab(+脏检查)、onNew→新建空标签）
+
+### Step 1: 插入 TabBar 到布局
+
+在 `<Toolbar ... />` 之后、编辑区容器之前插入：
+```tsx
+<TabBar
+  tabs={session.tabs}
+  activeTabId={session.activeTabId}
+  onSelect={switchTab}
+  onClose={(id) => closeTab(id, {
+    confirmDirty: () => {
+      // 阶段一：用 window.confirm；阶段二换原生 message() 对话框 + 三态
+      return window.confirm('该标签有未保存改动，确定关闭？');
+    },
+  })}
+  onNew={() => openInNewTab(createEmptyFile())}
+/>
+```
+
+### Step 2: 快捷键 Cmd+W 关闭当前（在 keydown handler 加）
+
+```ts
+if (e.key === 'w' && !e.shiftKey && !e.altKey) { e.preventDefault(); closeTab(session.activeTabId, { confirmDirty: () => window.confirm('...') }); return; }
+```
+
+### Step 3: typecheck + 全量测试
+
+Run: `npm run typecheck && npm test`
+Expected: 全绿。
+
+### Step 4: Commit
+
+```bash
+git add src/app/AppLayout.tsx
+git commit -m "feat(v0.4): AppLayout 集成 TabBar + Cmd+W 关闭"
+```
+
+---
+
+## Task 7: 实操验证（必填，呼应全局完成标准）
+
+### Step 1: 静态全绿
+
+Run: `npm run typecheck && npm test && npm run lint`
+Expected: 全部通过。
+
+### Step 2: tauri dev 实操（眼见为实）
+
+Run: `npm run tauri dev`（首次需 cargo build，耗时较长）
+
+用 Playwright MCP / 截图验证并记录证据：
+1. 打开文件 A → 标签栏出现 `a.md`
+2. 打开文件 B → 标签栏出现 `b.md`，B 激活；点 `a.md` 切回 A，内容正确切换（**非覆盖**）
+3. 编辑 B 不保存 → 点 `×` 关闭 → 弹确认；取消则保留
+4. 编辑 A 后关闭应用、重开 → A 的草稿内容恢复（**跨重启持久化**）
+5. 打开 >256KB 大文件 → 关闭重开 → 标签标记草稿未持久化（从磁盘重读）
+
+证据（截图 + DOM 断言）写入 RESULT 或 PR 描述。
+
+### Step 3: Push + 开 PR
+
+```bash
+git push -u origin feat/v0.4-tabs-session-foundation
+```
+用 `gh` 或 mcp__github__create_pull_request 开 PR，关联 ROADMAP v0.4、设计文档、DEC-092。PR 合并后进入阶段二（4 个并行 PR）。
+
+---
+
+## 风险与备注
+
+- **`@testing-library/react` 依赖：** Task 3 / 5 用到 `renderHook` / `render`。先 `grep '"@testing-library/react"' package.json` 确认；未装则 `npm install -D @testing-library/react`（写主仓库 node_modules，注意不影响 main），或改用手写 harness。
+- **AppLayout 现有测试依赖：** Task 4 改造后若 `AppLayout*.test.tsx` 断言内部 `file` state，需调整为通过用户行为（打开/编辑）驱动。
+- **Tauri dev 首次 cargo build 慢：** worktree 无 `src-tauri/target`，首次构建 5-15 分钟。可接受，或临时 symlink 主仓库 target（单人非并发时安全）。
+- **阶段一不含：** 最近文件首页、右键菜单、标签拖拽、失效文件高级处理 —— 均在阶段二。

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -1,7 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import type { OpenedFile, TocItem } from '../types/document';
-import { createEmptyFile } from '../types/document';
+import type { TocItem } from '../types/document';
 import {
   getExportPresetConfig,
   getLastOpenedPath,
@@ -22,10 +21,11 @@ import {
 import { scheduleDelayedAutoUpdateCheck } from '../services/autoUpdateScheduler';
 import { translate } from '../services/i18n';
 import type { HtmlTableBlock } from '../services/htmlTableBlockService';
-import { Toolbar, type EditorMode } from '../components/Toolbar';
+import { Toolbar } from '../components/Toolbar';
 import { StatusBar } from '../components/StatusBar';
 import { FloatingToc } from '../components/FloatingToc';
 import type { SourceHeadingScrollRequest } from '../components/EditorPane';
+import { useSession } from '../hooks/useSession';
 
 const EditorPane = lazy(() =>
   import('../components/EditorPane').then((module) => ({ default: module.EditorPane })),
@@ -79,7 +79,6 @@ const HtmlTableViewerOverlay = lazy(() =>
 );
 
 type AvailableUpdate = Extract<UpdateCheckResult, { status: 'available' }>;
-type RightPanelMode = 'none' | 'word' | 'wechat';
 type UpdateInstallState =
   | { phase: 'idle' }
   | { phase: 'downloading'; source: UpdateSource; update: AvailableUpdate }
@@ -151,14 +150,20 @@ export function AppLayout() {
       tocRefreshTimerRef.current = null;
     }
   }, []);
-  const [file, setFile] = useState<OpenedFile>(createEmptyFile());
+  const session = useSession();
+  const {
+    activeFile: file,
+    openInNewTab,
+    updateActiveFile,
+    updateActiveTabMeta,
+  } = session;
   const [toc, setToc] = useState<TocItem[]>([]);
   const [tocSessionPinned, setTocSessionPinned] = useState(false);
   const [activeTocIndex, setActiveTocIndex] = useState(0);
   const [settingsVisible, setSettingsVisible] = useState(false);
-  const [editorMode, setEditorMode] = useState<EditorMode>('wysiwyg');
+  const editorMode = session.editorMode;
   const [sourceHeadingScrollRequest, setSourceHeadingScrollRequest] = useState<SourceHeadingScrollRequest>();
-  const [rightPanelMode, setRightPanelMode] = useState<RightPanelMode>('none');
+  const rightPanelMode = session.rightPanelMode;
   const [rightPanelWidth, setRightPanelWidth] = useState(460);
   const [resizing, setResizing] = useState(false);
   const [htmlPresentationVisible, setHtmlPresentationVisible] = useState(false);
@@ -187,49 +192,39 @@ export function AppLayout() {
     const { openFile } = await import('../services/fileService');
     const opened = await openFile(settings.defaultEncoding);
     if (opened) {
-      setFile(opened);
+      openInNewTab(opened);
       cancelPendingTocRefresh();
       setToc(extractToc(opened.content));
       if (opened.path) setLastOpenedPath(opened.path);
       setHtmlPresentationVisible(false);
-      if (opened.fileType === 'docx') {
-        setRightPanelMode('none');
-      } else {
-        setEditorMode('wysiwyg');
-      }
     }
-  }, [settings.defaultEncoding, cancelPendingTocRefresh]);
+  }, [settings.defaultEncoding, cancelPendingTocRefresh, openInNewTab]);
 
   const handleOpenPath = useCallback(async (path: string) => {
     const { openPath } = await import('../services/fileService');
     const opened = await openPath(path, settings.defaultEncoding);
-    setFile(opened);
+    openInNewTab(opened);
     cancelPendingTocRefresh();
     setToc(opened.fileType === 'docx' ? [] : extractToc(opened.content));
     setLastOpenedPath(path);
     setHtmlPresentationVisible(false);
-    if (opened.fileType === 'docx') {
-      setRightPanelMode('none');
-    } else {
-      setEditorMode('wysiwyg');
-    }
-  }, [settings.defaultEncoding, cancelPendingTocRefresh]);
+  }, [settings.defaultEncoding, cancelPendingTocRefresh, openInNewTab]);
 
   const handleSave = useCallback(async () => {
     if (file.fileType === 'docx') return;
     const { saveFile } = await import('../services/fileService');
     const updated = await saveFile(file);
-    setFile(updated);
+    updateActiveFile(() => updated);
     if (updated.path) setLastOpenedPath(updated.path);
-  }, [file]);
+  }, [file, updateActiveFile]);
 
   const handleSaveAs = useCallback(async () => {
     if (file.fileType === 'docx') return;
     const { saveFileAs } = await import('../services/fileService');
     const updated = await saveFileAs(file);
-    setFile(updated);
+    updateActiveFile(() => updated);
     if (updated.path) setLastOpenedPath(updated.path);
-  }, [file]);
+  }, [file, updateActiveFile]);
 
   const handleExportWord = useCallback(async () => {
     if (!file.path || file.fileType === 'docx') return;
@@ -242,7 +237,7 @@ export function AppLayout() {
   }, [file]);
 
   const handleContentChange = useCallback((value: string) => {
-    setFile(prev => ({
+    updateActiveFile((prev) => ({
       ...prev,
       content: value,
       dirty: value !== prev.lastSavedContent,
@@ -260,20 +255,20 @@ export function AppLayout() {
   const handleToggleEditorMode = useCallback(() => {
     if (file.fileType === 'docx') return;
     setHtmlPresentationVisible(false);
-    setEditorMode((mode) => mode === 'source' ? 'wysiwyg' : 'source');
-  }, [file.fileType]);
+    updateActiveTabMeta({ editorMode: editorMode === 'source' ? 'wysiwyg' : 'source' });
+  }, [file.fileType, editorMode, updateActiveTabMeta]);
 
   const handleToggleWordPreview = useCallback(() => {
     if (file.fileType === 'docx') return;
     setHtmlPresentationVisible(false);
-    setRightPanelMode((mode) => mode === 'word' ? 'none' : 'word');
-  }, [file.fileType]);
+    updateActiveTabMeta({ rightPanelMode: rightPanelMode === 'word' ? 'none' : 'word' });
+  }, [file.fileType, rightPanelMode, updateActiveTabMeta]);
 
   const handleToggleWechatPreview = useCallback(() => {
     if (file.fileType === 'docx') return;
     setHtmlPresentationVisible(false);
-    setRightPanelMode((mode) => mode === 'wechat' ? 'none' : 'wechat');
-  }, [file.fileType]);
+    updateActiveTabMeta({ rightPanelMode: rightPanelMode === 'wechat' ? 'none' : 'wechat' });
+  }, [file.fileType, rightPanelMode, updateActiveTabMeta]);
 
   const handleRightPanelResizerPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     const container = mainContentRef.current;
@@ -458,6 +453,8 @@ export function AppLayout() {
   }, [handleOpenPath, isTauriRuntime]);
 
   useEffect(() => {
+    // session 已恢复持久化标签时，跳过旧的单文件重开逻辑（多标签会话已取代 reopenLastFile）。
+    if (session.tabs.some((t) => t.file.path || t.file.content)) return;
     if (!systemOpenChecked || !settings.reopenLastFile || file.path || reopenAttempted.current) return;
     const lastPath = getLastOpenedPath();
     if (!lastPath) return;
@@ -483,7 +480,7 @@ export function AppLayout() {
         window.cancelIdleCallback(idleId);
       }
     };
-  }, [file.path, handleOpenPath, settings.reopenLastFile, systemOpenChecked]);
+  }, [file.path, handleOpenPath, settings.reopenLastFile, systemOpenChecked, session.tabs]);
 
   useEffect(() => {
     if (!settings.autoUpdateCheck || autoUpdateCheckStarted.current || !isTauriRuntime) return;
@@ -503,11 +500,11 @@ export function AppLayout() {
     const timeout = window.setTimeout(() => {
       void import('../services/fileService')
         .then(({ saveFile }) => saveFile(file))
-        .then((updated) => setFile(updated))
+        .then((updated) => updateActiveFile(() => updated))
         .catch((e) => console.error('Auto-save failed:', e));
     }, 800);
     return () => window.clearTimeout(timeout);
-  }, [file, settings.autoSave]);
+  }, [file, settings.autoSave, updateActiveFile]);
 
   useEffect(() => {
     if (!isTauriRuntime) return;
@@ -664,7 +661,7 @@ export function AppLayout() {
         previewWidth={rightPanelWidth}
         canExport={Boolean(file.path)}
         onExportWord={handleExportWord}
-        onClose={() => setRightPanelMode('none')}
+        onClose={() => updateActiveTabMeta({ rightPanelMode: 'none' })}
         filePath={file.path}
       />
     </Suspense>
@@ -673,7 +670,7 @@ export function AppLayout() {
       <WechatPreviewPane
         source={file.content}
         fileName={file.name}
-        onClose={() => setRightPanelMode('none')}
+        onClose={() => updateActiveTabMeta({ rightPanelMode: 'none' })}
         filePath={file.path}
       />
     </Suspense>

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import type { TocItem } from '../types/document';
+import { createEmptyFile, type TocItem } from '../types/document';
 import {
   getExportPresetConfig,
   getLastOpenedPath,
@@ -24,6 +24,7 @@ import type { HtmlTableBlock } from '../services/htmlTableBlockService';
 import { Toolbar } from '../components/Toolbar';
 import { StatusBar } from '../components/StatusBar';
 import { FloatingToc } from '../components/FloatingToc';
+import { TabBar } from '../components/TabBar';
 import type { SourceHeadingScrollRequest } from '../components/EditorPane';
 import { useSession } from '../hooks/useSession';
 
@@ -250,7 +251,7 @@ export function AppLayout() {
       tocRefreshTimerRef.current = null;
       setToc(extractToc(value));
     }, TOC_REFRESH_DEBOUNCE_MS);
-  }, []);
+  }, [updateActiveFile]);
 
   const handleToggleEditorMode = useCallback(() => {
     if (file.fileType === 'docx') return;
@@ -711,6 +712,13 @@ export function AppLayout() {
         onPreloadSettings={preloadSettingsPageInBackground}
         updateStatus={updateToolbarStatus}
         onRestartUpdate={handleRestartUpdate}
+      />
+      <TabBar
+        tabs={session.tabs}
+        activeTabId={session.activeTabId}
+        onSelect={session.switchTab}
+        onClose={(id) => session.closeTab(id, { confirmDirty: () => window.confirm('该标签有未保存改动，确定关闭。') })}
+        onNew={() => session.openInNewTab(createEmptyFile())}
       />
       <div
         ref={mainContentRef}

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createElement } from 'react';
+import { TabBar, type TabBarProps } from './TabBar';
+import type { Tab } from '../types/session';
+import { createEmptyFile } from '../types/document';
+
+function tab(id: string, name: string, dirty = false): Tab {
+  return {
+    id,
+    file: { ...createEmptyFile(), name, path: `/tmp/${name}`, dirty },
+    editorMode: 'wysiwyg',
+    rightPanelMode: 'none',
+    draftPersisted: true,
+  };
+}
+
+function render(props: TabBarProps): string {
+  return renderToStaticMarkup(createElement(TabBar, props));
+}
+
+const noop = () => {};
+const baseProps = { onSelect: noop, onClose: noop, onNew: noop };
+
+describe('TabBar', () => {
+  it('渲染所有标签名', () => {
+    const html = render({ ...baseProps, tabs: [tab('a', 'a.md'), tab('b', 'b.md')], activeTabId: 'a' });
+    expect(html).toContain('a.md');
+    expect(html).toContain('b.md');
+  });
+
+  it('激活标签带 tabbar-tab--active', () => {
+    const html = render({ ...baseProps, tabs: [tab('a', 'a.md'), tab('b', 'b.md')], activeTabId: 'b' });
+    expect(html).toContain('tabbar-tab--active');
+  });
+
+  it('dirty 标签带 data-dirty 标记', () => {
+    const html = render({ ...baseProps, tabs: [tab('a', 'a.md', true)], activeTabId: 'a' });
+    expect(html).toContain('data-dirty');
+  });
+
+  it('干净标签无 data-dirty 标记', () => {
+    const html = render({ ...baseProps, tabs: [tab('a', 'a.md', false)], activeTabId: 'a' });
+    expect(html).not.toContain('data-dirty');
+  });
+
+  it('含新建按钮（aria-label 新建文件）', () => {
+    const html = render({ ...baseProps, tabs: [tab('a', 'a.md')], activeTabId: 'a' });
+    expect(html).toContain('新建文件');
+  });
+
+  it('每个标签含关闭按钮（aria-label 关闭）', () => {
+    const html = render({ ...baseProps, tabs: [tab('a', 'a.md')], activeTabId: 'a' });
+    expect(html).toContain('关闭');
+  });
+});

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,0 +1,46 @@
+import type { Tab } from '../types/session';
+
+export interface TabBarProps {
+  tabs: Tab[];
+  activeTabId: string;
+  onSelect: (id: string) => void;
+  onClose: (id: string) => void;
+  onNew: () => void;
+}
+
+/** 标签栏：独立一行，纯交互（不兼窗口拖拽）。i18n 三语留阶段二补，暂硬编码中文。 */
+export function TabBar({ tabs, activeTabId, onSelect, onClose, onNew }: TabBarProps) {
+  return (
+    <div className="tabbar" role="tablist">
+      <div className="tabbar-scroll">
+        {tabs.map((tab) => {
+          const active = tab.id === activeTabId;
+          return (
+            <div
+              key={tab.id}
+              data-tab={tab.id}
+              className={`tabbar-tab${active ? ' tabbar-tab--active' : ''}`}
+              role="tab"
+              aria-selected={active}
+              title={tab.file.path || tab.file.name}
+              onClick={() => onSelect(tab.id)}
+            >
+              {tab.file.dirty && <span data-dirty className="tabbar-dirty" />}
+              <span className="tabbar-name">{tab.file.name}</span>
+              <button
+                type="button"
+                className="tabbar-close"
+                aria-label={`关闭 ${tab.file.name}`}
+                title="关闭"
+                onClick={(e) => { e.stopPropagation(); onClose(tab.id); }}
+              >
+                ×
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      <button type="button" className="tabbar-new" aria-label="新建文件" title="新建文件" onClick={onNew}>+</button>
+    </div>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -12,8 +12,7 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import { useSettings } from '../hooks/useSettings';
 import { translate } from '../services/i18n';
 import { handleTitlebarMouseDown } from '../services/titlebarDrag';
-
-export type EditorMode = 'wysiwyg' | 'source';
+import type { EditorMode } from '../types/session';
 
 type UpdateToolbarStatus = {
   phase: 'ready' | 'installing';

--- a/src/hooks/sessionReducer.test.ts
+++ b/src/hooks/sessionReducer.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  sessionReducer,
+  bootstrapSession,
+  makeTabFromFile,
+} from './sessionReducer';
+import type { SessionState } from '../types/session';
+import { MAX_TABS } from '../types/session';
+import { createEmptyFile } from '../types/document';
+
+function file(name: string, content = '', dirty = false, path = `/tmp/${name}`) {
+  return { ...createEmptyFile(), name, content, dirty, path };
+}
+
+function stateWith(tabs: SessionState['tabs'], activeTabId?: string): SessionState {
+  return { tabs, activeTabId: activeTabId ?? tabs[0]?.id ?? '', recentFiles: [] };
+}
+
+describe('bootstrapSession', () => {
+  it('有 tabs 时保留并修正失效的 activeTabId 到首个', () => {
+    const tab = makeTabFromFile(file('a.md'));
+    const loaded: SessionState = { tabs: [tab], activeTabId: '不存在', recentFiles: [] };
+    expect(bootstrapSession(loaded)).toEqual({ tabs: [tab], activeTabId: tab.id, recentFiles: [] });
+  });
+
+  it('无 tabs 时给空占位标签，编辑器始终可用', () => {
+    const result = bootstrapSession({ tabs: [], activeTabId: '', recentFiles: [] });
+    expect(result.tabs).toHaveLength(1);
+    expect(result.activeTabId).toBe(result.tabs[0].id);
+    expect(result.tabs[0].file.name).toBe('未命名');
+  });
+});
+
+describe('sessionReducer.openInNewTab', () => {
+  it('增加标签并激活新标签', () => {
+    const start = bootstrapSession({ tabs: [], activeTabId: '', recentFiles: [] });
+    const next = sessionReducer(start, { type: 'openInNewTab', file: file('a.md', 'A') });
+    expect(next.tabs).toHaveLength(2);
+    expect(next.activeTabId).toBe(next.tabs[1].id);
+    expect(next.tabs[1].file.content).toBe('A');
+  });
+
+  it('超 MAX_TABS 时 LRU 关闭最旧非 dirty 非激活标签', () => {
+    let s = bootstrapSession({ tabs: [], activeTabId: '', recentFiles: [] });
+    for (let i = 0; i < MAX_TABS; i++) {
+      s = sessionReducer(s, { type: 'openInNewTab', file: file(`f${i}.md`, `c${i}`) });
+    }
+    expect(s.tabs).toHaveLength(MAX_TABS);
+    expect(s.activeTabId).toBe(s.tabs[s.tabs.length - 1].id);
+  });
+});
+
+describe('sessionReducer.switchTab', () => {
+  it('切换激活标签', () => {
+    const t1 = makeTabFromFile(file('a.md'));
+    const t2 = makeTabFromFile(file('b.md'));
+    const start = stateWith([t1, t2], t2.id);
+    expect(sessionReducer(start, { type: 'switchTab', id: t1.id }).activeTabId).toBe(t1.id);
+  });
+
+  it('id 不存在时返回同一引用（不变）', () => {
+    const t1 = makeTabFromFile(file('a.md'));
+    const start = stateWith([t1]);
+    expect(sessionReducer(start, { type: 'switchTab', id: '不存在' })).toBe(start);
+  });
+});
+
+describe('sessionReducer.closeTab', () => {
+  it('关闭最后一个标签时补空占位', () => {
+    const t1 = makeTabFromFile(file('a.md'));
+    const start = stateWith([t1], t1.id);
+    const next = sessionReducer(start, { type: 'closeTab', id: t1.id, confirmed: true });
+    expect(next.tabs).toHaveLength(1);
+    expect(next.tabs[0].file.name).toBe('未命名');
+  });
+
+  it('dirty 标签未确认时返回同一引用（取消）', () => {
+    const t1 = makeTabFromFile(file('a.md', 'A', true));
+    const start = stateWith([t1], t1.id);
+    expect(sessionReducer(start, { type: 'closeTab', id: t1.id, confirmed: false })).toBe(start);
+  });
+
+  it('dirty 标签确认后关闭，active 切到剩余末尾', () => {
+    const t1 = makeTabFromFile(file('a.md', 'A', true));
+    const t2 = makeTabFromFile(file('b.md'));
+    const start = stateWith([t1, t2], t1.id);
+    const next = sessionReducer(start, { type: 'closeTab', id: t1.id, confirmed: true });
+    expect(next.tabs).toHaveLength(1);
+    expect(next.activeTabId).toBe(t2.id);
+  });
+});
+
+describe('sessionReducer.updateActiveFile', () => {
+  it('修改当前标签内容', () => {
+    const t1 = makeTabFromFile(file('a.md', 'A'));
+    const start = stateWith([t1], t1.id);
+    const next = sessionReducer(start, { type: 'updateActiveFile', updater: (f) => ({ ...f, content: 'A2', dirty: true }) });
+    expect(next.tabs[0].file.content).toBe('A2');
+    expect(next.tabs[0].file.dirty).toBe(true);
+  });
+
+  it('不影响非激活标签', () => {
+    const t1 = makeTabFromFile(file('a.md', 'A'));
+    const t2 = makeTabFromFile(file('b.md', 'B'));
+    const start = stateWith([t1, t2], t1.id);
+    const next = sessionReducer(start, { type: 'updateActiveFile', updater: (f) => ({ ...f, content: 'X' }) });
+    expect(next.tabs[1].file.content).toBe('B');
+  });
+});
+
+describe('sessionReducer.recordRecentFile', () => {
+  it('记录并按 path 去重', () => {
+    const start = bootstrapSession({ tabs: [], activeTabId: '', recentFiles: [] });
+    const a = sessionReducer(start, { type: 'recordRecentFile', file: file('a.md') });
+    const a2 = sessionReducer(a, { type: 'recordRecentFile', file: file('a.md') });
+    expect(a2.recentFiles).toHaveLength(1);
+  });
+
+  it('无 path 不记录', () => {
+    const start = bootstrapSession({ tabs: [], activeTabId: '', recentFiles: [] });
+    const next = sessionReducer(start, { type: 'recordRecentFile', file: { ...createEmptyFile(), name: 'x' } });
+    expect(next.recentFiles).toHaveLength(0);
+  });
+});

--- a/src/hooks/sessionReducer.test.ts
+++ b/src/hooks/sessionReducer.test.ts
@@ -4,7 +4,7 @@ import {
   bootstrapSession,
   makeTabFromFile,
 } from './sessionReducer';
-import type { SessionState } from '../types/session';
+import type { SessionState, Tab } from '../types/session';
 import { MAX_TABS } from '../types/session';
 import { createEmptyFile } from '../types/document';
 
@@ -47,6 +47,19 @@ describe('sessionReducer.openInNewTab', () => {
     }
     expect(s.tabs).toHaveLength(MAX_TABS);
     expect(s.activeTabId).toBe(s.tabs[s.tabs.length - 1].id);
+  });
+
+  it('LRU 精确关闭最旧非 dirty 标签，保留所有 dirty 与新标签', () => {
+    const dirty = makeTabFromFile(file('dirty.md', 'x', true));
+    const tabs: Tab[] = [dirty];
+    for (let i = 1; i < MAX_TABS; i++) tabs.push(makeTabFromFile(file(`c${i}.md`)));
+    const start: SessionState = { tabs, activeTabId: tabs[MAX_TABS - 1].id, recentFiles: [] };
+    const next = sessionReducer(start, { type: 'openInNewTab', file: file('new.md', 'n') });
+    expect(next.tabs).toHaveLength(MAX_TABS);
+    expect(next.tabs.some((t) => t.file.name === 'dirty.md')).toBe(true);
+    expect(next.tabs.some((t) => t.file.name === 'c1.md')).toBe(false);
+    expect(next.tabs[next.tabs.length - 1].file.name).toBe('new.md');
+    expect(next.activeTabId).toBe(next.tabs[next.tabs.length - 1].id);
   });
 });
 

--- a/src/hooks/sessionReducer.ts
+++ b/src/hooks/sessionReducer.ts
@@ -1,0 +1,78 @@
+import type { OpenedFile } from '../types/document';
+import { createEmptyFile } from '../types/document';
+import type { SessionState, Tab, RecentFileEntry } from '../types/session';
+import { MAX_TABS, MAX_RECENT_FILES } from '../types/session';
+
+/** 生成稳定唯一 tab id。优先 crypto.randomUUID，无则退化为时间戳+随机。 */
+export function newTabId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `tab-${Date.now()}-${Math.random()}`;
+}
+
+export function makeTabFromFile(file: OpenedFile): Tab {
+  return { id: newTabId(), file, editorMode: 'wysiwyg', rightPanelMode: 'none', draftPersisted: true };
+}
+
+/** 启动引导：有持久化 tabs 则恢复（修正失效的 activeTabId），否则给一个空占位标签保证编辑器可用。 */
+export function bootstrapSession(loaded: SessionState): SessionState {
+  if (loaded.tabs.length > 0) {
+    const activeId = loaded.tabs.some((t) => t.id === loaded.activeTabId) ? loaded.activeTabId : loaded.tabs[0].id;
+    return { ...loaded, activeTabId: activeId };
+  }
+  const placeholder = makeTabFromFile(createEmptyFile());
+  return { tabs: [placeholder], activeTabId: placeholder.id, recentFiles: loaded.recentFiles };
+}
+
+export type SessionAction =
+  | { type: 'openInNewTab'; file: OpenedFile }
+  | { type: 'switchTab'; id: string }
+  | { type: 'closeTab'; id: string; confirmed: boolean }
+  | { type: 'updateActiveFile'; updater: (f: OpenedFile) => OpenedFile }
+  | { type: 'updateActiveTabMeta'; meta: Partial<Pick<Tab, 'editorMode' | 'rightPanelMode'>> }
+  | { type: 'recordRecentFile'; file: OpenedFile };
+
+export function sessionReducer(state: SessionState, action: SessionAction): SessionState {
+  switch (action.type) {
+    case 'openInNewTab': {
+      let tabs = [...state.tabs, makeTabFromFile(action.file)];
+      // LRU：超上限时优先关最旧的非 dirty、非激活标签（dirty 标签保留以免丢草稿）。
+      while (tabs.length > MAX_TABS) {
+        const idx = tabs.findIndex((t) => t.id !== state.activeTabId && !t.file.dirty);
+        if (idx === -1) break;
+        tabs = tabs.filter((_, i) => i !== idx);
+      }
+      return { ...state, tabs, activeTabId: tabs[tabs.length - 1].id };
+    }
+    case 'switchTab':
+      return state.tabs.some((t) => t.id === action.id) ? { ...state, activeTabId: action.id } : state;
+    case 'closeTab': {
+      const tab = state.tabs.find((t) => t.id === action.id);
+      if (!tab) return state;
+      if (tab.file.dirty && !action.confirmed) return state;
+      const tabs = state.tabs.filter((t) => t.id !== action.id);
+      if (tabs.length === 0) {
+        const placeholder = makeTabFromFile(createEmptyFile());
+        return { ...state, tabs: [placeholder], activeTabId: placeholder.id };
+      }
+      const activeTabId = state.activeTabId === action.id ? tabs[tabs.length - 1].id : state.activeTabId;
+      return { ...state, tabs, activeTabId };
+    }
+    case 'updateActiveFile':
+      return {
+        ...state,
+        tabs: state.tabs.map((t) => (t.id === state.activeTabId ? { ...t, file: action.updater(t.file) } : t)),
+      };
+    case 'updateActiveTabMeta':
+      return {
+        ...state,
+        tabs: state.tabs.map((t) => (t.id === state.activeTabId ? { ...t, ...action.meta } : t)),
+      };
+    case 'recordRecentFile': {
+      if (!action.file.path) return state;
+      const entry: RecentFileEntry = { path: action.file.path, name: action.file.name, openedAt: Date.now() };
+      const filtered = state.recentFiles.filter((r) => r.path !== entry.path);
+      return { ...state, recentFiles: [entry, ...filtered].slice(0, MAX_RECENT_FILES) };
+    }
+    default:
+      return state;
+  }
+}

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useReducer } from 'react';
+import type { OpenedFile } from '../types/document';
+import { createEmptyFile } from '../types/document';
+import type { Tab, EditorMode, RightPanelMode } from '../types/session';
+import { sessionReducer, bootstrapSession } from './sessionReducer';
+import { loadSession, saveSession } from '../services/sessionStore';
+
+export interface CloseOptions {
+  /** 关闭 dirty 标签前的确认回调；返回 false 取消关闭。无此回调时直接关闭。 */
+  confirmDirty?: () => boolean;
+}
+
+/**
+ * 多标签会话 hook。状态转换走纯函数 sessionReducer（已单测覆盖），
+ * 本 hook 负责：初始化（启动恢复）、debounce 持久化草稿、派生 activeFile/editorMode 等。
+ */
+export function useSession() {
+  const [state, dispatch] = useReducer(sessionReducer, undefined, () =>
+    bootstrapSession(loadSession())
+  );
+
+  // state 变化后 debounce 持久化草稿（含未保存内容）；卸载时清理定时器。
+  useEffect(() => {
+    const timer = setTimeout(() => saveSession(state), 800);
+    return () => clearTimeout(timer);
+  }, [state]);
+
+  const activeTab = state.tabs.find((t) => t.id === state.activeTabId) ?? state.tabs[0];
+  const activeFile = activeTab?.file ?? createEmptyFile();
+
+  const openInNewTab = useCallback((file: OpenedFile) => {
+    dispatch({ type: 'openInNewTab', file });
+    dispatch({ type: 'recordRecentFile', file });
+  }, []);
+
+  const switchTab = useCallback((id: string) => {
+    dispatch({ type: 'switchTab', id });
+  }, []);
+
+  const updateActiveFile = useCallback((updater: (f: OpenedFile) => OpenedFile) => {
+    dispatch({ type: 'updateActiveFile', updater });
+  }, []);
+
+  const updateActiveTabMeta = useCallback(
+    (meta: Partial<Pick<Tab, 'editorMode' | 'rightPanelMode'>>) => {
+      dispatch({ type: 'updateActiveTabMeta', meta });
+    },
+    []
+  );
+
+  const recordRecentFile = useCallback((file: OpenedFile) => {
+    dispatch({ type: 'recordRecentFile', file });
+  }, []);
+
+  const closeTab = useCallback(
+    (id: string, options?: CloseOptions) => {
+      const tab = state.tabs.find((t) => t.id === id);
+      if (!tab) return true;
+      if (tab.file.dirty && options?.confirmDirty && !options.confirmDirty()) return false;
+      dispatch({ type: 'closeTab', id, confirmed: true });
+      return true;
+    },
+    [state.tabs]
+  );
+
+  return {
+    tabs: state.tabs,
+    activeTabId: state.activeTabId,
+    activeTab,
+    activeFile,
+    recentFiles: state.recentFiles,
+    editorMode: (activeTab?.editorMode ?? 'wysiwyg') as EditorMode,
+    rightPanelMode: (activeTab?.rightPanelMode ?? 'none') as RightPanelMode,
+    openInNewTab,
+    switchTab,
+    closeTab,
+    updateActiveFile,
+    updateActiveTabMeta,
+    recordRecentFile,
+  };
+}

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer } from 'react';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
 import type { OpenedFile } from '../types/document';
 import { createEmptyFile } from '../types/document';
 import type { Tab, EditorMode, RightPanelMode } from '../types/session';
@@ -19,11 +19,40 @@ export function useSession() {
     bootstrapSession(loadSession())
   );
 
+  // 始终持有最新 state，供卸载/关窗时的同步 flush 读取（避免闭包时效问题）。
+  const stateRef = useRef(state);
+  useEffect(() => { stateRef.current = state; }, [state]);
+
   // state 变化后 debounce 持久化草稿（含未保存内容）；卸载时清理定时器。
   useEffect(() => {
     const timer = setTimeout(() => saveSession(state), 800);
     return () => clearTimeout(timer);
   }, [state]);
+
+  // 卸载/关窗时同步 flush：debounce 期间若用户 Cmd+Q / 刷新 / 切后台，挂起的 saveSession
+  // 会被 clearTimeout 丢掉。此处监听 pagehide/beforeunload 与 Tauri onCloseRequested，
+  // 同步写一次 localStorage（写是同步的，能赶在进程退出前完成），满足 DEC-092 核心承诺。
+  useEffect(() => {
+    const flush = () => saveSession(stateRef.current);
+    window.addEventListener('pagehide', flush);
+    window.addEventListener('beforeunload', flush);
+    let unlisten: (() => void) | undefined;
+    if ('__TAURI_INTERNALS__' in window) {
+      void import('@tauri-apps/api/window')
+        .then(({ getCurrentWindow }) =>
+          getCurrentWindow()
+            .onCloseRequested(() => { flush(); })
+            .then((fn) => { unlisten = fn; })
+            .catch(() => {}),
+        )
+        .catch(() => {});
+    }
+    return () => {
+      window.removeEventListener('pagehide', flush);
+      window.removeEventListener('beforeunload', flush);
+      unlisten?.();
+    };
+  }, []);
 
   const activeTab = state.tabs.find((t) => t.id === state.activeTabId) ?? state.tabs[0];
   const activeFile = activeTab?.file ?? createEmptyFile();

--- a/src/services/sessionStore.test.ts
+++ b/src/services/sessionStore.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  loadSession,
+  saveSession,
+  clearSession,
+  SESSION_STORAGE_KEY,
+} from './sessionStore';
+import type { SessionState, PersistedSession } from '../types/session';
+import { createEmptyFile } from '../types/document';
+
+function makeTab(id: string, content = 'hello', dirty = false): SessionState['tabs'][number] {
+  return {
+    id,
+    file: { ...createEmptyFile(), name: `${id}.md`, content, path: `/tmp/${id}.md`, dirty },
+    editorMode: 'wysiwyg',
+    rightPanelMode: 'none',
+    draftPersisted: true,
+  };
+}
+
+function emptySession(): SessionState {
+  return { tabs: [], activeTabId: '', recentFiles: [] };
+}
+
+beforeEach(() => { localStorage.clear(); });
+afterEach(() => { localStorage.clear(); });
+
+describe('sessionStore.loadSession', () => {
+  it('无存储时返回空会话', () => {
+    expect(loadSession()).toEqual(emptySession());
+  });
+
+  it('正常读取并还原结构', () => {
+    const session: SessionState = {
+      tabs: [makeTab('a')],
+      activeTabId: 'a',
+      recentFiles: [{ path: '/tmp/a.md', name: 'a.md', openedAt: 1000 }],
+    };
+    localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify({ version: 1, ...session }));
+    expect(loadSession()).toEqual(session);
+  });
+
+  it('损坏数据返回空会话且不抛异常', () => {
+    localStorage.setItem(SESSION_STORAGE_KEY, '{ not json');
+    expect(loadSession()).toEqual(emptySession());
+  });
+
+  it('version 不匹配返回空会话', () => {
+    localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify({ version: 99, tabs: [], activeTabId: '', recentFiles: [] }));
+    expect(loadSession()).toEqual(emptySession());
+  });
+});
+
+describe('sessionStore.saveSession', () => {
+  it('正常写入并可读回', () => {
+    const session: SessionState = { tabs: [makeTab('a')], activeTabId: 'a', recentFiles: [] };
+    saveSession(session);
+    const raw = JSON.parse(localStorage.getItem(SESSION_STORAGE_KEY)!) as PersistedSession;
+    expect(raw.version).toBe(1);
+    expect(raw.activeTabId).toBe('a');
+    expect(loadSession()).toEqual(session);
+  });
+
+  it('大文件标签（content > 256KB）降级：draftPersisted=false、content 清空、path 保留', () => {
+    const big = 'x'.repeat(256 * 1024 + 1);
+    const session: SessionState = { tabs: [makeTab('big', big)], activeTabId: 'big', recentFiles: [] };
+    saveSession(session);
+    const raw = JSON.parse(localStorage.getItem(SESSION_STORAGE_KEY)!) as PersistedSession;
+    expect(raw.tabs[0].draftPersisted).toBe(false);
+    expect(raw.tabs[0].file.content).toBe('');
+    expect(raw.tabs[0].file.path).toBe('/tmp/big.md');
+  });
+
+  it('localStorage 写失败（超限）降级为不抛异常', () => {
+    const original = localStorage.setItem;
+    localStorage.setItem = () => { throw new DOMException('quota', 'QuotaExceededError'); };
+    expect(() => saveSession({ tabs: [makeTab('a')], activeTabId: 'a', recentFiles: [] })).not.toThrow();
+    localStorage.setItem = original;
+  });
+});
+
+describe('sessionStore.clearSession', () => {
+  it('清除存储', () => {
+    localStorage.setItem(SESSION_STORAGE_KEY, '{}');
+    clearSession();
+    expect(localStorage.getItem(SESSION_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/src/services/sessionStore.ts
+++ b/src/services/sessionStore.ts
@@ -46,7 +46,9 @@ function toPersisted(session: SessionState): PersistedSession {
       return {
         ...tab,
         draftPersisted: tab.draftPersisted && !oversized,
-        file: oversized ? { ...tab.file, content: '', lastSavedContent: '' } : tab.file,
+        // 降级只清 content（不存大内容避免 localStorage 爆掉），保留 lastSavedContent
+        // 作为磁盘基准——重启后 dirty 计算与磁盘对比仍正确；内容从 path 重读留阶段二c。
+        file: oversized ? { ...tab.file, content: '' } : tab.file,
       };
     }),
   };

--- a/src/services/sessionStore.ts
+++ b/src/services/sessionStore.ts
@@ -1,0 +1,70 @@
+import type { SessionState, PersistedSession, Tab } from '../types/session';
+import { DRAFT_PERSIST_MAX_BYTES } from '../types/session';
+
+export const SESSION_STORAGE_KEY = 'folia.session.v1';
+
+function emptySession(): SessionState {
+  return { tabs: [], activeTabId: '', recentFiles: [] };
+}
+
+function isPersistedSession(value: unknown): value is PersistedSession {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.version === 1 &&
+    Array.isArray(v.tabs) &&
+    typeof v.activeTabId === 'string' &&
+    Array.isArray(v.recentFiles)
+  );
+}
+
+/** 读取持久化会话；无存储 / 损坏 / 版本不匹配时返回空会话，绝不抛异常。 */
+export function loadSession(): SessionState {
+  try {
+    const raw = localStorage.getItem(SESSION_STORAGE_KEY);
+    if (!raw) return emptySession();
+    const parsed: unknown = JSON.parse(raw);
+    if (!isPersistedSession(parsed)) return emptySession();
+    return {
+      tabs: parsed.tabs as Tab[],
+      activeTabId: parsed.activeTabId,
+      recentFiles: parsed.recentFiles,
+    };
+  } catch {
+    return emptySession();
+  }
+}
+
+/** 把会话转为可持久化结构：超大草稿（>256KB）降级为只存 path，避免 localStorage 爆掉。呼应 ISS-159。 */
+function toPersisted(session: SessionState): PersistedSession {
+  return {
+    version: 1,
+    activeTabId: session.activeTabId,
+    recentFiles: session.recentFiles,
+    tabs: session.tabs.map((tab) => {
+      const oversized = tab.file.content.length > DRAFT_PERSIST_MAX_BYTES;
+      return {
+        ...tab,
+        draftPersisted: tab.draftPersisted && !oversized,
+        file: oversized ? { ...tab.file, content: '', lastSavedContent: '' } : tab.file,
+      };
+    }),
+  };
+}
+
+/** 写入会话；超限 / 隐私模式失败时降级为仅内存（不抛异常，调用方可提示用户）。 */
+export function saveSession(session: SessionState): void {
+  try {
+    localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(toPersisted(session)));
+  } catch {
+    // 降级仅内存。
+  }
+}
+
+export function clearSession(): void {
+  try {
+    localStorage.removeItem(SESSION_STORAGE_KEY);
+  } catch {
+    // 忽略。
+  }
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -229,6 +229,102 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
   opacity: 0.7;
 }
 
+/* ===== Tab Bar ===== */
+.tabbar {
+  display: flex;
+  align-items: stretch;
+  height: 34px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--bg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.tabbar-scroll {
+  display: flex;
+  align-items: stretch;
+  flex: 1 1 auto;
+  overflow-x: auto;
+  overflow-y: hidden;
+  gap: 2px;
+  padding: 4px 4px 0;
+  scrollbar-width: none;
+}
+.tabbar-scroll::-webkit-scrollbar { display: none; }
+
+.tabbar-tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 200px;
+  min-width: 72px;
+  padding: 0 6px 0 12px;
+  border-radius: 6px 6px 0 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  font-family: var(--font-body);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  transition: background 0.15s, color 0.15s;
+}
+.tabbar-tab:hover { background: var(--control-hover-bg); color: var(--fg); }
+
+.tabbar-tab--active {
+  color: var(--fg);
+  background: var(--surface);
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
+.tabbar-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tabbar-dirty {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+
+.tabbar-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.tabbar-close:hover { background: var(--control-hover-bg); color: var(--danger); }
+
+.tabbar-new {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 17px;
+  cursor: pointer;
+}
+.tabbar-new:hover { background: var(--control-hover-bg); color: var(--fg); }
+
 .file-name {
   display: inline-flex;
   align-items: center;

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -1,0 +1,43 @@
+import type { OpenedFile } from './document';
+
+/**
+ * 编辑模式：所见即所得 / 源码。
+ * 与 components/Toolbar.tsx 的 EditorMode 结构一致；Task 4 改造时统一让 Toolbar 从此处 import。
+ */
+export type EditorMode = 'wysiwyg' | 'source';
+
+/** 右侧面板模式。从 app/AppLayout.tsx:82 迁移。 */
+export type RightPanelMode = 'none' | 'word' | 'wechat';
+
+export interface Tab {
+  id: string;
+  file: OpenedFile;
+  editorMode: EditorMode;
+  rightPanelMode: RightPanelMode;
+  /** 草稿是否已落盘。大文件（> DRAFT_PERSIST_MAX_BYTES）降级时为 false，仅内存。 */
+  draftPersisted: boolean;
+}
+
+export interface RecentFileEntry {
+  path: string;
+  name: string;
+  openedAt: number;
+}
+
+export interface SessionState {
+  tabs: Tab[];
+  activeTabId: string;
+  recentFiles: RecentFileEntry[];
+}
+
+/** localStorage 持久化结构（带版本号，用于 schema 校验与未来迁移）。 */
+export interface PersistedSession extends SessionState {
+  version: 1;
+}
+
+/** 单标签草稿内容超过此阈值（256KB）不持久化内容，只存 path。呼应 ISS-159。 */
+export const DRAFT_PERSIST_MAX_BYTES = 256 * 1024;
+/** 标签总数上限，超出 LRU 关最旧非激活标签。 */
+export const MAX_TABS = 12;
+/** 最近文件历史上限。 */
+export const MAX_RECENT_FILES = 20;


### PR DESCRIPTION
对应 ROADMAP v0.4「文档管理」。实现标签页多文件并存 + 草稿（含未保存内容）跨重启持久化。

- 设计：`docs/plans/2026-06-14-tabs-recent-files-design.md`
- 决策：[DEC-092]
- 实现计划：`docs/plans/2026-06-14-tabs-session-foundation-plan.md`

## 本 PR（阶段一地基）
- [x] `SessionState`/`Tab` 类型（`src/types/session.ts`）
- [x] `sessionStore`：localStorage 持久化 + 大文件降级（>256KB 只存 path，呼应 ISS-159）+ 损坏/超限兜底
- [x] `sessionReducer`：tabs CRUD + LRU（超 12 关最旧非 dirty）+ 脏检查 + 最近文件（纯函数，13 单测）
- [x] `useSession` hook：useReducer 包装 + debounce 800ms 持久化 + 派生 activeFile
- [x] AppLayout 单文档→多标签会话（`file` 收口为 `activeFile` 别名，44 处读引用零改动）
- [x] `TabBar` 组件：切换/新建/关闭/dirty 标记

## 验证
- `typecheck` ✓
- 单测 **240 全过**（新增 sessionStore 8 + sessionReducer 13 + TabBar 6）
- `lint` 0 warning
- 实操（vite dev + playwright）：TabBar 渲染、新建 1→2→3、点击切换、localStorage 草稿持久化、**刷新（模拟重启）后恢复**、0 控制台错误

## 不在本 PR（阶段二，4 个并行 PR）
- (a) 最近文件首页 `RecentFilesPage` + history
- (b) 右键菜单 + `Cmd+W` 快捷键（含 Tauri 系统快捷键配置）
- (c) 启动恢复 UI + 失效文件处理 + 大文件降级提示
- (d) 标签编辑态记忆（数据模型已就绪，阶段二接 UI）

## 兼容性
无破坏。无持久化 tabs 时 `bootstrap` 给空占位标签（等同旧「未命名」）；`reopenLastFile` 在 session 已恢复时跳过。