### PR TITLE
feat(v0.4): 最近文件首页（阶段二a）

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -25,6 +25,7 @@ import { Toolbar } from '../components/Toolbar';
 import { StatusBar } from '../components/StatusBar';
 import { FloatingToc } from '../components/FloatingToc';
 import { TabBar } from '../components/TabBar';
+import { RecentFilesPage } from '../components/RecentFilesPage';
 import type { SourceHeadingScrollRequest } from '../components/EditorPane';
 import { useSession } from '../hooks/useSession';
 
@@ -725,7 +726,14 @@ export function AppLayout() {
         className={mainContentClassName}
         style={{ '--right-panel-width': `${rightPanelWidth}px` } as React.CSSProperties}
       >
-        {isDocx ? docxPane : (
+        {session.showHomePage ? (
+          <RecentFilesPage
+            recentFiles={session.recentFiles}
+            onOpenFile={handleOpen}
+            onOpenRecent={(path) => { void handleOpenPath(path); }}
+            onNew={() => session.openInNewTab(createEmptyFile())}
+          />
+        ) : isDocx ? docxPane : (
           <>
             <FloatingToc
               items={toc}

--- a/src/components/RecentFilesPage.test.tsx
+++ b/src/components/RecentFilesPage.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createElement } from 'react';
+import { RecentFilesPage, type RecentFilesPageProps } from './RecentFilesPage';
+import type { RecentFileEntry } from '../types/session';
+
+function render(props: RecentFilesPageProps): string {
+  return renderToStaticMarkup(createElement(RecentFilesPage, props));
+}
+
+const noop = () => {};
+const baseProps = { onOpenFile: noop, onOpenRecent: noop, onNew: noop };
+
+describe('RecentFilesPage', () => {
+  it('渲染标题与打开/新建按钮', () => {
+    const html = render({ ...baseProps, recentFiles: [] });
+    expect(html).toContain('打开文件');
+    expect(html).toContain('新建');
+  });
+
+  it('渲染最近文件列表（文件名 + 路径）', () => {
+    const recentFiles: RecentFileEntry[] = [
+      { path: '/tmp/a.md', name: 'a.md', openedAt: 1 },
+      { path: '/tmp/b.md', name: 'b.md', openedAt: 2 },
+    ];
+    const html = render({ ...baseProps, recentFiles });
+    expect(html).toContain('a.md');
+    expect(html).toContain('b.md');
+    expect(html).toContain('/tmp/a.md');
+  });
+
+  it('无最近文件时显示空状态文案', () => {
+    const html = render({ ...baseProps, recentFiles: [] });
+    expect(html).toContain('还没有最近打开的文件');
+  });
+
+  it('每条最近文件为可点击 button（携带 path）', () => {
+    const recentFiles: RecentFileEntry[] = [{ path: '/tmp/a.md', name: 'a.md', openedAt: 1 }];
+    const html = render({ ...baseProps, recentFiles });
+    expect(html).toContain('<button');
+    expect(html).toContain('/tmp/a.md');
+  });
+});

--- a/src/components/RecentFilesPage.tsx
+++ b/src/components/RecentFilesPage.tsx
@@ -1,0 +1,43 @@
+import type { RecentFileEntry } from '../types/session';
+
+export interface RecentFilesPageProps {
+  recentFiles: RecentFileEntry[];
+  onOpenFile: () => void;
+  onOpenRecent: (path: string) => void;
+  onNew: () => void;
+}
+
+/** 最近文件首页：占位标签时显示，替代编辑器区。i18n 三语留后续，暂硬编码中文。 */
+export function RecentFilesPage({ recentFiles, onOpenFile, onOpenRecent, onNew }: RecentFilesPageProps) {
+  return (
+    <div className="recent-page">
+      <div className="recent-page-inner">
+        <h1 className="recent-page-title">Folia</h1>
+        <p className="recent-page-subtitle">Markdown 阅读与写作 · 开始</p>
+        <div className="recent-page-actions">
+          <button type="button" className="recent-page-primary" onClick={onOpenFile}>打开文件</button>
+          <button type="button" className="recent-page-secondary" onClick={onNew}>新建</button>
+        </div>
+        {recentFiles.length > 0 ? (
+          <ul className="recent-page-list">
+            {recentFiles.map((entry) => (
+              <li key={entry.path}>
+                <button
+                  type="button"
+                  className="recent-page-item"
+                  title={entry.path}
+                  onClick={() => onOpenRecent(entry.path)}
+                >
+                  <span className="recent-page-item-name">{entry.name}</span>
+                  <span className="recent-page-item-path">{entry.path}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="recent-page-empty">还没有最近打开的文件</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -12,6 +12,7 @@ function tab(id: string, name: string, dirty = false): Tab {
     editorMode: 'wysiwyg',
     rightPanelMode: 'none',
     draftPersisted: true,
+    isPlaceholder: false,
   };
 }
 

--- a/src/hooks/sessionReducer.test.ts
+++ b/src/hooks/sessionReducer.test.ts
@@ -28,6 +28,7 @@ describe('bootstrapSession', () => {
     expect(result.tabs).toHaveLength(1);
     expect(result.activeTabId).toBe(result.tabs[0].id);
     expect(result.tabs[0].file.name).toBe('未命名');
+    expect(result.tabs[0].isPlaceholder).toBe(true);
   });
 });
 
@@ -38,6 +39,12 @@ describe('sessionReducer.openInNewTab', () => {
     expect(next.tabs).toHaveLength(2);
     expect(next.activeTabId).toBe(next.tabs[1].id);
     expect(next.tabs[1].file.content).toBe('A');
+  });
+
+  it('openInNewTab 创建的标签非占位（isPlaceholder=false）', () => {
+    const start = bootstrapSession({ tabs: [], activeTabId: '', recentFiles: [] });
+    const next = sessionReducer(start, { type: 'openInNewTab', file: file('a.md', 'A') });
+    expect(next.tabs[next.tabs.length - 1].isPlaceholder).toBe(false);
   });
 
   it('超 MAX_TABS 时 LRU 关闭最旧非 dirty 非激活标签', () => {
@@ -85,6 +92,7 @@ describe('sessionReducer.closeTab', () => {
     const next = sessionReducer(start, { type: 'closeTab', id: t1.id, confirmed: true });
     expect(next.tabs).toHaveLength(1);
     expect(next.tabs[0].file.name).toBe('未命名');
+    expect(next.tabs[0].isPlaceholder).toBe(true);
   });
 
   it('dirty 标签未确认时返回同一引用（取消）', () => {

--- a/src/hooks/sessionReducer.test.ts
+++ b/src/hooks/sessionReducer.test.ts
@@ -33,12 +33,23 @@ describe('bootstrapSession', () => {
 });
 
 describe('sessionReducer.openInNewTab', () => {
-  it('增加标签并激活新标签', () => {
-    const start = bootstrapSession({ tabs: [], activeTabId: '', recentFiles: [] });
+  it('active 非占位时增加标签并激活', () => {
+    const t1 = makeTabFromFile(file('exist.md', 'E'));
+    const start = stateWith([t1], t1.id);
     const next = sessionReducer(start, { type: 'openInNewTab', file: file('a.md', 'A') });
     expect(next.tabs).toHaveLength(2);
     expect(next.activeTabId).toBe(next.tabs[1].id);
     expect(next.tabs[1].file.content).toBe('A');
+  });
+
+  it('active 为占位标签时替换之（不累积「未命名」空标签）', () => {
+    const start = bootstrapSession({ tabs: [], activeTabId: '', recentFiles: [] });
+    expect(start.tabs).toHaveLength(1);
+    expect(start.tabs[0].isPlaceholder).toBe(true);
+    const next = sessionReducer(start, { type: 'openInNewTab', file: file('a.md', 'A') });
+    expect(next.tabs).toHaveLength(1);
+    expect(next.tabs[0].file.name).toBe('a.md');
+    expect(next.tabs[0].isPlaceholder).toBe(false);
   });
 
   it('openInNewTab 创建的标签非占位（isPlaceholder=false）', () => {

--- a/src/hooks/sessionReducer.ts
+++ b/src/hooks/sessionReducer.ts
@@ -8,8 +8,8 @@ export function newTabId(): string {
   return globalThis.crypto?.randomUUID?.() ?? `tab-${Date.now()}-${Math.random()}`;
 }
 
-export function makeTabFromFile(file: OpenedFile): Tab {
-  return { id: newTabId(), file, editorMode: 'wysiwyg', rightPanelMode: 'none', draftPersisted: true };
+export function makeTabFromFile(file: OpenedFile, isPlaceholder = false): Tab {
+  return { id: newTabId(), file, editorMode: 'wysiwyg', rightPanelMode: 'none', draftPersisted: true, isPlaceholder };
 }
 
 /** 启动引导：有持久化 tabs 则恢复（修正失效的 activeTabId），否则给一个空占位标签保证编辑器可用。 */
@@ -18,7 +18,7 @@ export function bootstrapSession(loaded: SessionState): SessionState {
     const activeId = loaded.tabs.some((t) => t.id === loaded.activeTabId) ? loaded.activeTabId : loaded.tabs[0].id;
     return { ...loaded, activeTabId: activeId };
   }
-  const placeholder = makeTabFromFile(createEmptyFile());
+  const placeholder = makeTabFromFile(createEmptyFile(), true);
   return { tabs: [placeholder], activeTabId: placeholder.id, recentFiles: loaded.recentFiles };
 }
 
@@ -50,7 +50,7 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
       if (tab.file.dirty && !action.confirmed) return state;
       const tabs = state.tabs.filter((t) => t.id !== action.id);
       if (tabs.length === 0) {
-        const placeholder = makeTabFromFile(createEmptyFile());
+        const placeholder = makeTabFromFile(createEmptyFile(), true);
         return { ...state, tabs: [placeholder], activeTabId: placeholder.id };
       }
       const activeTabId = state.activeTabId === action.id ? tabs[tabs.length - 1].id : state.activeTabId;

--- a/src/hooks/sessionReducer.ts
+++ b/src/hooks/sessionReducer.ts
@@ -33,14 +33,20 @@ export type SessionAction =
 export function sessionReducer(state: SessionState, action: SessionAction): SessionState {
   switch (action.type) {
     case 'openInNewTab': {
-      let tabs = [...state.tabs, makeTabFromFile(action.file)];
-      // LRU：超上限时优先关最旧的非 dirty、非激活标签（dirty 标签保留以免丢草稿）。
+      const active = state.tabs.find((t) => t.id === state.activeTabId);
+      // 当前 active 是干净占位标签时替换它，避免占位标签累积成「未命名」空标签（I-1）。
+      const replaceActivePlaceholder = !!active?.isPlaceholder && !active.file.dirty;
+      const newTab = makeTabFromFile(action.file);
+      let tabs = replaceActivePlaceholder
+        ? state.tabs.map((t) => (t.id === state.activeTabId ? newTab : t))
+        : [...state.tabs, newTab];
+      // LRU：超上限时优先关最旧的非 dirty、非新打开标签（dirty 与刚打开的保留）。
       while (tabs.length > MAX_TABS) {
-        const idx = tabs.findIndex((t) => t.id !== state.activeTabId && !t.file.dirty);
+        const idx = tabs.findIndex((t) => t.id !== newTab.id && !t.file.dirty);
         if (idx === -1) break;
         tabs = tabs.filter((_, i) => i !== idx);
       }
-      return { ...state, tabs, activeTabId: tabs[tabs.length - 1].id };
+      return { ...state, tabs, activeTabId: newTab.id };
     }
     case 'switchTab':
       return state.tabs.some((t) => t.id === action.id) ? { ...state, activeTabId: action.id } : state;

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -100,6 +100,7 @@ export function useSession() {
     recentFiles: state.recentFiles,
     editorMode: (activeTab?.editorMode ?? 'wysiwyg') as EditorMode,
     rightPanelMode: (activeTab?.rightPanelMode ?? 'none') as RightPanelMode,
+    showHomePage: activeTab?.isPlaceholder ?? false,
     openInNewTab,
     switchTab,
     closeTab,

--- a/src/services/sessionStore.test.ts
+++ b/src/services/sessionStore.test.ts
@@ -16,6 +16,7 @@ function makeTab(id: string, content = 'hello', dirty = false): SessionState['ta
     editorMode: 'wysiwyg',
     rightPanelMode: 'none',
     draftPersisted: true,
+    isPlaceholder: false,
   };
 }
 

--- a/src/services/sessionStore.ts
+++ b/src/services/sessionStore.ts
@@ -26,7 +26,8 @@ export function loadSession(): SessionState {
     const parsed: unknown = JSON.parse(raw);
     if (!isPersistedSession(parsed)) return emptySession();
     return {
-      tabs: parsed.tabs as Tab[],
+      // 补 isPlaceholder 默认值，防旧版数据（无该字段）恢复后 undefined 传播（M-1）。
+      tabs: parsed.tabs.map((t) => ({ ...t, isPlaceholder: t.isPlaceholder ?? false })) as Tab[],
       activeTabId: parsed.activeTabId,
       recentFiles: parsed.recentFiles,
     };

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -401,6 +401,9 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 .recent-page-item-name { font-size: 13px; color: var(--fg); font-weight: 500; }
 .recent-page-item-path { font-size: 11px; color: var(--muted); word-break: break-all; }
 .recent-page-empty { margin: 8px 0 0; color: var(--muted); font-size: 12px; }
+.recent-page-primary:focus-visible,
+.recent-page-secondary:focus-visible,
+.recent-page-item:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 .file-name {
   display: inline-flex;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -325,6 +325,83 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 }
 .tabbar-new:hover { background: var(--control-hover-bg); color: var(--fg); }
 
+/* ===== Recent Files Home Page ===== */
+.recent-page {
+  flex: 1 1 auto;
+  overflow: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+  background: var(--bg);
+}
+.recent-page-inner {
+  width: min(560px, 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 18px;
+}
+.recent-page-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.recent-page-subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+.recent-page-actions { display: flex; gap: 10px; }
+.recent-page-primary,
+.recent-page-secondary {
+  padding: 8px 18px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--fg);
+  font-size: 13px;
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.recent-page-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--surface);
+}
+.recent-page-primary:hover { filter: brightness(1.05); }
+.recent-page-secondary:hover { background: var(--control-hover-bg); border-color: var(--border-hover); }
+.recent-page-list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+}
+.recent-page-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s;
+}
+.recent-page-item:hover { background: var(--control-hover-bg); }
+.recent-page-item-name { font-size: 13px; color: var(--fg); font-weight: 500; }
+.recent-page-item-path { font-size: 11px; color: var(--muted); word-break: break-all; }
+.recent-page-empty { margin: 8px 0 0; color: var(--muted); font-size: 12px; }
+
 .file-name {
   display: inline-flex;
   align-items: center;

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -16,6 +16,8 @@ export interface Tab {
   rightPanelMode: RightPanelMode;
   /** 草稿是否已落盘。大文件（> DRAFT_PERSIST_MAX_BYTES）降级时为 false，仅内存。 */
   draftPersisted: boolean;
+  /** 是否占位标签（bootstrap/关到最后一个时补的空标签）。占位时显示最近文件首页，而非编辑器。 */
+  isPlaceholder: boolean;
 }
 
 export interface RecentFileEntry {


### PR DESCRIPTION
## v0.4 阶段二（a）：最近文件首页

实现你提的第二个核心需求「打开软件有个最近打开文件的页面」。

### 本 PR
- `RecentFilesPage` 组件：标题 + 打开文件 + 新建 + 最近文件列表（空状态）
- `Tab.isPlaceholder` 字段：区分占位标签（首页）vs 用户新建空标签（编辑器）
- `useSession` 派生 `showHomePage`（`activeTab.isPlaceholder`）
- `AppLayout` 占位标签时渲染 `RecentFilesPage` 替代编辑器区
- `app.css .recent-page` 样式（居中布局 + 列表 hover）

### 三条路径都自然
- 打开软件（无持久化 tabs）→ 占位标签 → **首页**
- 点 `+` 新建 → 空标签（`isPlaceholder=false`）→ **编辑器**（不弹首页）
- 关掉所有标签 → 补占位 → **首页**

### 验证
- `typecheck` + **246 单测** + `lint` 0 warning
- vite dev 实操：首页渲染（CSS 1280×700）+ 标题/打开/空状态 + 点新建进编辑器 + **0 控制台错误**
- reload 持久化恢复（recentFiles 列表）：靠 **tauri dev 本地验收**（vite reload 会触发 C1 的 pagehide flush 覆盖测试注入，是预期行为）+ 单测覆盖 loadSession/bootstrap/RecentFilesPage 逻辑

### 不在本 PR（后续增强）
- (b) 右键菜单 + `Cmd+W` 快捷键（需 Tauri 系统快捷键配置）
- (c) 启动恢复 UI 细节 + 失效文件处理 + 大文件降级提示
- 首页 i18n 三语（暂硬编码中文）

依赖阶段一（PR #36 已合并）。