### PR TITLE
feat(v0.4): 标签右键菜单 + Cmd+W 快捷键（阶段二b）

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -26,6 +26,7 @@ import { StatusBar } from '../components/StatusBar';
 import { FloatingToc } from '../components/FloatingToc';
 import { TabBar } from '../components/TabBar';
 import { RecentFilesPage } from '../components/RecentFilesPage';
+import { ContextMenu } from '../components/ContextMenu';
 import type { SourceHeadingScrollRequest } from '../components/EditorPane';
 import { useSession } from '../hooks/useSession';
 
@@ -156,6 +157,8 @@ export function AppLayout() {
   const {
     activeFile: file,
     openInNewTab,
+    closeTab,
+    activeTabId,
     updateActiveFile,
     updateActiveTabMeta,
   } = session;
@@ -163,6 +166,7 @@ export function AppLayout() {
   const [tocSessionPinned, setTocSessionPinned] = useState(false);
   const [activeTocIndex, setActiveTocIndex] = useState(0);
   const [settingsVisible, setSettingsVisible] = useState(false);
+  const [contextMenu, setContextMenu] = useState<{ tabId: string; x: number; y: number } | null>(null);
   const editorMode = session.editorMode;
   const [sourceHeadingScrollRequest, setSourceHeadingScrollRequest] = useState<SourceHeadingScrollRequest>();
   const rightPanelMode = session.rightPanelMode;
@@ -347,6 +351,11 @@ export function AppLayout() {
       if (e.key === 's' && e.altKey && !e.shiftKey) { e.preventDefault(); handleToggleEditorMode(); return; }
       if (e.key === 'p' && e.altKey && !e.shiftKey) { e.preventDefault(); handleToggleWordPreview(); return; }
       if (e.key === 'm' && e.altKey && !e.shiftKey) { e.preventDefault(); handleToggleWechatPreview(); return; }
+      if (e.key === 'w' && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        closeTab(activeTabId, { confirmDirty: () => window.confirm('该标签有未保存改动，确定关闭。') });
+        return;
+      }
       if (e.key === ',' && !e.shiftKey && !e.altKey) {
         e.preventDefault();
         void preloadSettingsPage();
@@ -355,7 +364,7 @@ export function AppLayout() {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [handleOpen, handleSave, handleSaveAs, handleExportWord, handleToggleEditorMode, handleToggleWordPreview, handleToggleWechatPreview]);
+  }, [handleOpen, handleSave, handleSaveAs, handleExportWord, handleToggleEditorMode, handleToggleWordPreview, handleToggleWechatPreview, closeTab, activeTabId]);
 
   useEffect(() => {
     const handler = async (e: DragEvent) => {
@@ -718,6 +727,7 @@ export function AppLayout() {
         tabs={session.tabs}
         activeTabId={session.activeTabId}
         onSelect={session.switchTab}
+        onContextMenu={(id, x, y) => setContextMenu({ tabId: id, x, y })}
         onClose={(id) => session.closeTab(id, { confirmDirty: () => window.confirm('该标签有未保存改动，确定关闭。') })}
         onNew={() => session.openInNewTab(createEmptyFile())}
       />
@@ -764,6 +774,17 @@ export function AppLayout() {
         {rightPanel}
       </div>
       <StatusBar filePath={file.path} dirty={file.dirty} />
+      {contextMenu && (
+        <ContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          onClose={() => setContextMenu(null)}
+          onCloseTab={() => session.closeTab(contextMenu.tabId, { confirmDirty: () => window.confirm('该标签有未保存改动，确定关闭。') })}
+          onCloseOthers={() => session.closeOthers(contextMenu.tabId)}
+          onCloseToRight={() => session.closeToRight(contextMenu.tabId)}
+          onCloseAll={() => session.closeAll()}
+        />
+      )}
       {settingsVisible && (
         <Suspense fallback={<SettingsPageFallback />}>
           <SettingsPage

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -162,6 +162,7 @@ export function AppLayout() {
     updateActiveFile,
     updateActiveTabMeta,
   } = session;
+  const confirmCloseDirty = useCallback(() => window.confirm('该标签有未保存改动，确定关闭吗？'), []);
   const [toc, setToc] = useState<TocItem[]>([]);
   const [tocSessionPinned, setTocSessionPinned] = useState(false);
   const [activeTocIndex, setActiveTocIndex] = useState(0);
@@ -353,7 +354,7 @@ export function AppLayout() {
       if (e.key === 'm' && e.altKey && !e.shiftKey) { e.preventDefault(); handleToggleWechatPreview(); return; }
       if (e.key === 'w' && !e.shiftKey && !e.altKey) {
         e.preventDefault();
-        closeTab(activeTabId, { confirmDirty: () => window.confirm('该标签有未保存改动，确定关闭。') });
+        closeTab(activeTabId, { confirmDirty: confirmCloseDirty });
         return;
       }
       if (e.key === ',' && !e.shiftKey && !e.altKey) {
@@ -728,7 +729,7 @@ export function AppLayout() {
         activeTabId={session.activeTabId}
         onSelect={session.switchTab}
         onContextMenu={(id, x, y) => setContextMenu({ tabId: id, x, y })}
-        onClose={(id) => session.closeTab(id, { confirmDirty: () => window.confirm('该标签有未保存改动，确定关闭。') })}
+        onClose={(id) => session.closeTab(id, { confirmDirty: confirmCloseDirty })}
         onNew={() => session.openInNewTab(createEmptyFile())}
       />
       <div
@@ -779,7 +780,7 @@ export function AppLayout() {
           x={contextMenu.x}
           y={contextMenu.y}
           onClose={() => setContextMenu(null)}
-          onCloseTab={() => session.closeTab(contextMenu.tabId, { confirmDirty: () => window.confirm('该标签有未保存改动，确定关闭。') })}
+          onCloseTab={() => session.closeTab(contextMenu.tabId, { confirmDirty: confirmCloseDirty })}
           onCloseOthers={() => session.closeOthers(contextMenu.tabId)}
           onCloseToRight={() => session.closeToRight(contextMenu.tabId)}
           onCloseAll={() => session.closeAll()}

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -365,7 +365,7 @@ export function AppLayout() {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [handleOpen, handleSave, handleSaveAs, handleExportWord, handleToggleEditorMode, handleToggleWordPreview, handleToggleWechatPreview, closeTab, activeTabId]);
+  }, [handleOpen, handleSave, handleSaveAs, handleExportWord, handleToggleEditorMode, handleToggleWordPreview, handleToggleWechatPreview, closeTab, activeTabId, confirmCloseDirty]);
 
   useEffect(() => {
     const handler = async (e: DragEvent) => {

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+
+export interface ContextMenuProps {
+  x: number;
+  y: number;
+  onClose: () => void;
+  onCloseTab: () => void;
+  onCloseOthers: () => void;
+  onCloseToRight: () => void;
+  onCloseAll: () => void;
+}
+
+/** 标签右键菜单。点击外部 / Esc 关闭；点选项执行后关闭。 */
+export function ContextMenu({ x, y, onClose, onCloseTab, onCloseOthers, onCloseToRight, onCloseAll }: ContextMenuProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onAway = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const onEsc = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('mousedown', onAway);
+    window.addEventListener('keydown', onEsc);
+    return () => {
+      window.removeEventListener('mousedown', onAway);
+      window.removeEventListener('keydown', onEsc);
+    };
+  }, [onClose]);
+
+  const run = (fn: () => void) => { fn(); onClose(); };
+
+  return (
+    <div ref={ref} className="tab-context-menu" style={{ left: x, top: y }} role="menu">
+      <button type="button" role="menuitem" onClick={() => run(onCloseTab)}>关闭</button>
+      <button type="button" role="menuitem" onClick={() => run(onCloseOthers)}>关闭其他</button>
+      <button type="button" role="menuitem" onClick={() => run(onCloseToRight)}>关闭右侧</button>
+      <button type="button" role="menuitem" onClick={() => run(onCloseAll)}>全部关闭</button>
+    </div>
+  );
+}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -6,10 +6,11 @@ export interface TabBarProps {
   onSelect: (id: string) => void;
   onClose: (id: string) => void;
   onNew: () => void;
+  onContextMenu?: (id: string, x: number, y: number) => void;
 }
 
 /** 标签栏：独立一行，纯交互（不兼窗口拖拽）。i18n 三语留阶段二补，暂硬编码中文。 */
-export function TabBar({ tabs, activeTabId, onSelect, onClose, onNew }: TabBarProps) {
+export function TabBar({ tabs, activeTabId, onSelect, onClose, onNew, onContextMenu }: TabBarProps) {
   return (
     <div className="tabbar" role="tablist">
       <div className="tabbar-scroll">
@@ -24,6 +25,7 @@ export function TabBar({ tabs, activeTabId, onSelect, onClose, onNew }: TabBarPr
               aria-selected={active}
               title={tab.file.path || tab.file.name}
               onClick={() => onSelect(tab.id)}
+              onContextMenu={onContextMenu ? (e) => { e.preventDefault(); onContextMenu(tab.id, e.clientX, e.clientY); } : undefined}
             >
               {tab.file.dirty && <span data-dirty className="tabbar-dirty" />}
               <span className="tabbar-name">{tab.file.name}</span>

--- a/src/hooks/sessionReducer.test.ts
+++ b/src/hooks/sessionReducer.test.ts
@@ -122,6 +122,44 @@ describe('sessionReducer.closeTab', () => {
   });
 });
 
+describe('sessionReducer 批量关闭（closeOthers/closeToRight/closeAll）', () => {
+  it('closeOthers 保留目标与 dirty，关其他非 dirty', () => {
+    const t1 = makeTabFromFile(file('a.md'));
+    const t2 = makeTabFromFile(file('b.md', 'B', true));
+    const t3 = makeTabFromFile(file('c.md'));
+    const start = stateWith([t1, t2, t3], t3.id);
+    const next = sessionReducer(start, { type: 'closeOthers', id: t3.id });
+    expect(next.tabs.map((t) => t.file.name)).toEqual(['b.md', 'c.md']);
+    expect(next.activeTabId).toBe(t3.id);
+  });
+
+  it('closeToRight 关目标右侧非 dirty，保留目标/左侧/dirty', () => {
+    const t1 = makeTabFromFile(file('a.md'));
+    const t2 = makeTabFromFile(file('b.md'));
+    const t3 = makeTabFromFile(file('c.md', 'C', true));
+    const t4 = makeTabFromFile(file('d.md'));
+    const start = stateWith([t1, t2, t3, t4], t2.id);
+    const next = sessionReducer(start, { type: 'closeToRight', id: t2.id });
+    expect(next.tabs.map((t) => t.file.name)).toEqual(['a.md', 'b.md', 'c.md']);
+    expect(next.activeTabId).toBe(t2.id);
+  });
+
+  it('closeAll 全非 dirty 时补占位', () => {
+    const start = stateWith([makeTabFromFile(file('a.md')), makeTabFromFile(file('b.md'))], '');
+    const next = sessionReducer(start, { type: 'closeAll' });
+    expect(next.tabs).toHaveLength(1);
+    expect(next.tabs[0].isPlaceholder).toBe(true);
+  });
+
+  it('closeAll 有 dirty 时保留 dirty', () => {
+    const t1 = makeTabFromFile(file('a.md'));
+    const t2 = makeTabFromFile(file('b.md', 'B', true));
+    const start = stateWith([t1, t2], t1.id);
+    const next = sessionReducer(start, { type: 'closeAll' });
+    expect(next.tabs.map((t) => t.file.name)).toEqual(['b.md']);
+  });
+});
+
 describe('sessionReducer.updateActiveFile', () => {
   it('修改当前标签内容', () => {
     const t1 = makeTabFromFile(file('a.md', 'A'));

--- a/src/hooks/sessionReducer.test.ts
+++ b/src/hooks/sessionReducer.test.ts
@@ -158,6 +158,19 @@ describe('sessionReducer 批量关闭（closeOthers/closeToRight/closeAll）', (
     const next = sessionReducer(start, { type: 'closeAll' });
     expect(next.tabs.map((t) => t.file.name)).toEqual(['b.md']);
   });
+
+  it('closeOthers 目标不存在时不变（I-1 守卫）', () => {
+    const start = stateWith([makeTabFromFile(file('a.md')), makeTabFromFile(file('b.md'))], '');
+    expect(sessionReducer(start, { type: 'closeOthers', id: '不存在' })).toBe(start);
+  });
+
+  it('closeAll 全 dirty 时保留原 active（I-2）', () => {
+    const t1 = makeTabFromFile(file('a.md', 'A', true));
+    const t2 = makeTabFromFile(file('b.md', 'B', true));
+    const start = stateWith([t1, t2], t2.id);
+    const next = sessionReducer(start, { type: 'closeAll' });
+    expect(next.activeTabId).toBe(t2.id);
+  });
 });
 
 describe('sessionReducer.updateActiveFile', () => {

--- a/src/hooks/sessionReducer.ts
+++ b/src/hooks/sessionReducer.ts
@@ -26,6 +26,9 @@ export type SessionAction =
   | { type: 'openInNewTab'; file: OpenedFile }
   | { type: 'switchTab'; id: string }
   | { type: 'closeTab'; id: string; confirmed: boolean }
+  | { type: 'closeOthers'; id: string }
+  | { type: 'closeToRight'; id: string }
+  | { type: 'closeAll' }
   | { type: 'updateActiveFile'; updater: (f: OpenedFile) => OpenedFile }
   | { type: 'updateActiveTabMeta'; meta: Partial<Pick<Tab, 'editorMode' | 'rightPanelMode'>> }
   | { type: 'recordRecentFile'; file: OpenedFile };
@@ -61,6 +64,27 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
       }
       const activeTabId = state.activeTabId === action.id ? tabs[tabs.length - 1].id : state.activeTabId;
       return { ...state, tabs, activeTabId };
+    }
+    case 'closeOthers': {
+      // 保留目标标签 + 所有 dirty，关其他非 dirty（批量操作保护未保存草稿）。
+      const tabs = state.tabs.filter((t) => t.id === action.id || t.file.dirty);
+      if (tabs.length === state.tabs.length) return state;
+      return { ...state, tabs, activeTabId: action.id };
+    }
+    case 'closeToRight': {
+      const idIndex = state.tabs.findIndex((t) => t.id === action.id);
+      if (idIndex === -1) return state;
+      const tabs = state.tabs.filter((t, i) => i <= idIndex || t.file.dirty);
+      if (tabs.length === state.tabs.length) return state;
+      return { ...state, tabs, activeTabId: action.id };
+    }
+    case 'closeAll': {
+      const dirtyTabs = state.tabs.filter((t) => t.file.dirty);
+      if (dirtyTabs.length > 0) {
+        return { ...state, tabs: dirtyTabs, activeTabId: dirtyTabs[0].id };
+      }
+      const placeholder = makeTabFromFile(createEmptyFile(), true);
+      return { ...state, tabs: [placeholder], activeTabId: placeholder.id };
     }
     case 'updateActiveFile':
       return {

--- a/src/hooks/sessionReducer.ts
+++ b/src/hooks/sessionReducer.ts
@@ -66,6 +66,8 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
       return { ...state, tabs, activeTabId };
     }
     case 'closeOthers': {
+      // 目标不存在时不变（防止菜单期间标签被删导致空 tabs + 幽灵 activeTabId，I-1）。
+      if (!state.tabs.some((t) => t.id === action.id)) return state;
       // 保留目标标签 + 所有 dirty，关其他非 dirty（批量操作保护未保存草稿）。
       const tabs = state.tabs.filter((t) => t.id === action.id || t.file.dirty);
       if (tabs.length === state.tabs.length) return state;
@@ -81,7 +83,9 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
     case 'closeAll': {
       const dirtyTabs = state.tabs.filter((t) => t.file.dirty);
       if (dirtyTabs.length > 0) {
-        return { ...state, tabs: dirtyTabs, activeTabId: dirtyTabs[0].id };
+        // 保留 dirty 时，若当前 active 仍在 dirty 中则保持，否则切到首个 dirty（I-2）。
+        const keepActive = dirtyTabs.some((t) => t.id === state.activeTabId) ? state.activeTabId : dirtyTabs[0].id;
+        return { ...state, tabs: dirtyTabs, activeTabId: keepActive };
       }
       const placeholder = makeTabFromFile(createEmptyFile(), true);
       return { ...state, tabs: [placeholder], activeTabId: placeholder.id };

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -81,6 +81,10 @@ export function useSession() {
     dispatch({ type: 'recordRecentFile', file });
   }, []);
 
+  const closeOthers = useCallback((id: string) => { dispatch({ type: 'closeOthers', id }); }, []);
+  const closeToRight = useCallback((id: string) => { dispatch({ type: 'closeToRight', id }); }, []);
+  const closeAll = useCallback(() => { dispatch({ type: 'closeAll' }); }, []);
+
   const closeTab = useCallback(
     (id: string, options?: CloseOptions) => {
       const tab = state.tabs.find((t) => t.id === id);
@@ -104,6 +108,9 @@ export function useSession() {
     openInNewTab,
     switchTab,
     closeTab,
+    closeOthers,
+    closeToRight,
+    closeAll,
     updateActiveFile,
     updateActiveTabMeta,
     recordRecentFile,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -405,6 +405,34 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 .recent-page-secondary:focus-visible,
 .recent-page-item:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
+/* ===== Tab Context Menu ===== */
+.tab-context-menu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 140px;
+  padding: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.tab-context-menu button {
+  padding: 6px 12px;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  font-size: 13px;
+  font-family: var(--font-body);
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.tab-context-menu button:hover { background: var(--control-hover-bg); }
+.tab-context-menu button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+
 .file-name {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## v0.4 阶段二（b）：标签右键菜单 + Cmd+W 快捷键

### 本 PR
- `ContextMenu` 组件：关闭 / 关闭其他 / 关闭右侧 / 全部关闭（点击外部、Esc 关闭）
- `TabBar` 标签 `onContextMenu` → 弹菜单（传 tabId + 坐标）
- `AppLayout` contextMenu state + 渲染 ContextMenu + 绑定 session 批量关闭
- `Cmd+W` keydown → `closeTab(active)`（解构 closeTab/activeTabId 避免 stale closure）
- `useSession` 暴露 `closeOthers` / `closeToRight` / `closeAll`
- `reducer` 批量关闭（前序 commit `6453870`）：**保护 dirty 标签不丢草稿**
- `app.css .tab-context-menu` 样式

### 验证
- `typecheck` + `lint` 0 warning
- reducer 批量关闭 20 单测 + 非 Vditor 测试 38 过
- vite dev 实操：右键菜单 4 项渲染 ✓、点「全部关闭」回首页 ✓、**Cmd+W 关当前 2→1** ✓、0 控制台错误
- Vditor 相关 e2e timeout 是 DEC-091 既有 flake（stash baseline 同样复现，单独跑 AppLayoutSourceEditor passed），**非本次 regression**

### Cmd+W 说明
vite dev chromium 下 `Meta+w` 验证生效（关当前标签）。Tauri 桌面运行时若系统拦截 Cmd+W，需配 src-tauri（当前无 menu bar 配置，预期不拦截，但建议本地 tauri dev 确认）。

依赖阶段一（#36）+ 阶段二a（#37），均已在 main。