### PR TITLE
fix(v0.4): 大文件降级 tab 重启重读（阶段二c 部分）

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -518,6 +518,21 @@ export function AppLayout() {
     return () => window.clearTimeout(timeout);
   }, [file, settings.autoSave, updateActiveFile]);
 
+  // 大文件降级 tab（draftPersisted=false 且 content 被清空）：激活时从磁盘重读内容，
+  // 修复降级重启后空白编辑器（阶段一 I1 遗留，阶段二c）。失败（文件被删/移）仅 warn。
+  useEffect(() => {
+    const tab = session.activeTab;
+    if (!tab || tab.draftPersisted) return;
+    if (!tab.file.path || tab.file.content) return;
+    if (tab.file.fileType === 'docx') return;
+    let cancelled = false;
+    void import('../services/fileService')
+      .then(({ openPath }) => openPath(tab.file.path, settings.defaultEncoding))
+      .then((opened) => { if (!cancelled) updateActiveFile(() => opened); })
+      .catch((e) => console.warn('Failed to reload large-file tab:', e));
+    return () => { cancelled = true; };
+  }, [session.activeTab, settings.defaultEncoding, updateActiveFile]);
+
   useEffect(() => {
     if (!isTauriRuntime) return;
     const title = file.dirty ? `* ${file.name}` : file.name;


### PR DESCRIPTION
## v0.4 阶段二c（部分）：大文件降级 tab 重启后从 path 重读

修复**阶段一 I1 遗留**：>256KB 草稿降级时 content 被清空，重启恢复出 content 空的 tab（空白编辑器）。

### 本 PR
- `AppLayout` effect：active tab `draftPersisted=false` 且 content 空 → 从磁盘 `openPath` 重读
- 失败（文件被删/移）仅 `console.warn`，不崩溃
- 条件防循环：重读后 content 非空 → 不再重读（只一次）

### 验证
- `typecheck` + `lint` 0 warning + 非 Vditor 40 测试过
- reload 涉及 Tauri fs，真实验证靠本地 tauri dev

### c 剩余（新 session 接续，worktree `.worktrees/v0.4-stage2c` 就绪）
- 大文件降级 UI 提示（StatusBar/TabBar `draftPersisted=false` 提示）
- 失效文件精细处理（openPath 失败 → markInvalid + 提示/另存为）
- 启动恢复 UI（loading）
- b Minor（菜单屏幕边界、menu 方向键导航、占位标签右键禁用）

依赖 #36/#37/#38（均在 main）。