### PR TITLE
feat(v0.4): 标签栏并入工具栏 + i18n 三语 + 右键菜单增强 (ISS-40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - 精简 Release 构建产物（DEC-093）：`src-tauri/tauri.conf.json` 的 `bundle.targets` 由 `"all"` 收窄为 `["dmg", "nsis"]`，Windows 不再生成冗余的 MSI 安装包，只保留 NSIS `.exe`；macOS 仍生成 `.dmg`。自动更新专用的 `.app.tar.gz` / `.nsis.zip` + `.sig` 产物不受影响（Tauri updater 依赖，无法精简）。
+- 标签栏并入顶部工具栏同一行（ISS-40）：替代原先独立一行 + 中间「当前文件名」区，文件名改由标签承载，减少一行垂直占用；`.toolbar-title` 由绝对定位居中改为 flex 占据中间并移除 `.toolbar-spacer`；标签与「新建」按钮加 `data-no-window-drag` 隔离窗口拖拽。
+- 标签页 / 最近文件首页 / 标签右键菜单接入 i18n（ISS-40）：`TabBar` / `RecentFilesPage` / `ContextMenu` 按项目统一模式（`useSettings` + `translate`）补 `zh-CN` / `en-US` / `ja-JP` 三语，替换原硬编码中文。
+
+### Added
+
+- 标签右键菜单增强（ISS-40）：屏幕边界自动翻转（`computeMenuPosition` 纯函数，溢出视口时左移 / 上移）、`↑/↓` / `Home/End` 键盘导航、占位标签（`isPlaceholder`）只显示「关闭」并隐藏「关闭其他 / 关闭右侧 / 全部关闭」。
 
 ### Performance
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,7 +21,7 @@
 | v0.1 MVP | 基础分屏阅读编辑 | 🟢 已完成 | CodeMirror + markdown-it |
 | v0.2 渲染引擎 | Vditor 替换 markdown-it | 🟢 已完成 | Vditor.preview() + 本地 CDN |
 | v0.3 编辑体验 | Typora-like 所见即所得 + HTML 阅读优先 + Word / HTML 导出预览 | 🟡 进行中 | 普通 Markdown 默认 WYSIWYG；原生 HTML 表格自动稳定预览；源码 fallback、按需 Word 多页预览与 HTML 预览面板已完成 |
-| v0.4 文档管理 | 最近文件、多文件 | ⚪ 未开始 | |
+| v0.4 文档管理 | 最近文件、多文件 | 🟡 进行中 | 多标签页 + 最近文件首页核心已合并；标签栏并入工具栏 + i18n 三语 + 右键菜单增强（ISS-40） |
 | v0.5 桌面发布体验 | 自动更新、发布产物、版本提示 | 🟢 已完成 | Tauri updater + GitHub Releases；Gitee 作为产物镜像 |
 | v0.6 Word 导出与预览 | md2word 集成、docx 导出 + 预览 | 🟢 已完成 | 纯 TS 方案，docx npm + mammoth |
 | v0.7 法律增强 | 表格编辑、模板 | 🟡 进行中 | 已完成 HTML table 共享模型、源码区块定位服务、法律表格 fixture 基线 |
@@ -87,12 +87,18 @@
 - [x] 新增发布脚本：签名 updater artifact 与生成统一 `latest.json` manifest
 - [x] 新增 GitHub Actions 全平台发布：macOS ARM / Intel、Windows、Release manifest 与 Gitee 产物同步
 
-### v0.4 文档管理
+### v0.4 多标签页 + 最近文件首页
 
-- [ ] 最近打开文件列表（持久化到本地存储）
-- [ ] 文件变更检测（外部编辑后提示刷新）
-- [ ] 关闭前未保存提醒
-- [ ] 左侧文件侧边栏（可选）
+- [x] 多标签页会话（sessionStore + useSession + AppLayout 单文档 → 多文档改造）
+- [x] 最近文件首页（无可恢复会话时显示最近文件列表）
+- [x] 标签右键菜单 + Cmd+W 快捷键
+- [x] 大文件（>256KB）降级 tab 重启从 path 重读
+- [x] 标签栏并入顶部工具栏同一行（ISS-40）
+- [x] 标签页 / 首页 / 右键菜单 i18n 三语（ISS-40）
+- [x] 右键菜单边界裁切 + 键盘导航 + 占位标签处理（ISS-40）
+- [ ] 大文件降级 UI 提示（StatusBar / TabBar 显示「草稿过大未自动保存」）
+- [ ] 失效文件精细处理（openPath 失败 → pathInvalid + 引导另存为）
+- [ ] 启动恢复 loading UI
 
 ### v0.6 Word 导出与预览（已完成）
 

--- a/e2e/layout-behavior.spec.ts
+++ b/e2e/layout-behavior.spec.ts
@@ -46,30 +46,27 @@ test('toolbar hides the app name and keeps draggable space around controls', asy
   await expect(page.locator('.wordmark')).toHaveCount(0);
   await expect(page.locator('.app-toolbar')).not.toContainText('Folia');
   const toolbarState = await page.evaluate(() => {
-    const toolbar = document.querySelector('.app-toolbar')?.getBoundingClientRect();
-    const title = document.querySelector('.toolbar-title')?.getBoundingClientRect();
-
     return {
-      spacer: document.querySelector('.toolbar-spacer')?.hasAttribute('data-tauri-drag-region') ?? false,
       titleDrag: document.querySelector('.toolbar-title')?.hasAttribute('data-tauri-drag-region') ?? false,
+      tabbarInsideTitle: !!document.querySelector('.toolbar-title [role="tablist"]'),
+      tabNoDrag: document.querySelector('.tabbar-tab')?.hasAttribute('data-no-window-drag') ?? false,
+      newBtnNoDrag: document.querySelector('.tabbar-new')?.hasAttribute('data-no-window-drag') ?? false,
       overlayCount: document.querySelectorAll('.toolbar-drag-region').length,
       fallback: document.querySelector('.app-toolbar')?.getAttribute('data-window-drag-fallback') ?? '',
       groups: Array.from(document.querySelectorAll('.toolbar-group')).map((group) => (
         group.getAttribute('aria-label')
       )),
-      centerOffset: toolbar && title
-        ? Math.abs((title.left + title.width / 2) - (toolbar.left + toolbar.width / 2))
-        : Number.POSITIVE_INFINITY,
     };
   });
   expect(toolbarState).toEqual(expect.objectContaining({
-    spacer: true,
     titleDrag: true,
+    tabbarInsideTitle: true,
+    tabNoDrag: true,
+    newBtnNoDrag: true,
     overlayCount: 0,
     fallback: 'manual',
     groups: ['文件操作', '视图与导出', '导航设置'],
   }));
-  expect(toolbarState.centerOffset).toBeLessThanOrEqual(1);
   await expect(page.getByRole('button', { name: '大纲', exact: true })).toHaveCount(0);
 });
 

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -721,6 +721,16 @@ export function AppLayout() {
       <Toolbar
         dirty={file.dirty}
         fileName={file.name}
+        tabBar={
+          <TabBar
+            tabs={session.tabs}
+            activeTabId={session.activeTabId}
+            onSelect={session.switchTab}
+            onContextMenu={(id, x, y) => setContextMenu({ tabId: id, x, y })}
+            onClose={(id) => session.closeTab(id, { confirmDirty: confirmCloseDirty })}
+            onNew={() => session.openInNewTab(createEmptyFile())}
+          />
+        }
         editorMode={editorMode}
         wordPreviewVisible={rightPanelMode === 'word'}
         wechatPreviewVisible={rightPanelMode === 'wechat'}
@@ -738,14 +748,6 @@ export function AppLayout() {
         onPreloadSettings={preloadSettingsPageInBackground}
         updateStatus={updateToolbarStatus}
         onRestartUpdate={handleRestartUpdate}
-      />
-      <TabBar
-        tabs={session.tabs}
-        activeTabId={session.activeTabId}
-        onSelect={session.switchTab}
-        onContextMenu={(id, x, y) => setContextMenu({ tabId: id, x, y })}
-        onClose={(id) => session.closeTab(id, { confirmDirty: confirmCloseDirty })}
-        onNew={() => session.openInNewTab(createEmptyFile())}
       />
       <div
         ref={mainContentRef}
@@ -799,6 +801,7 @@ export function AppLayout() {
           onCloseOthers={() => session.closeOthers(contextMenu.tabId)}
           onCloseToRight={() => session.closeToRight(contextMenu.tabId)}
           onCloseAll={() => session.closeAll()}
+          isPlaceholder={session.tabs.find((t) => t.id === contextMenu.tabId)?.isPlaceholder ?? false}
         />
       )}
       {settingsVisible && (

--- a/src/components/ContextMenu.test.tsx
+++ b/src/components/ContextMenu.test.tsx
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import React, { createElement, act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ContextMenu, type ContextMenuProps } from './ContextMenu';
+import { computeMenuPosition } from './contextMenuPosition';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const noop = () => {};
+const handlers = {
+  onClose: noop,
+  onCloseTab: noop,
+  onCloseOthers: noop,
+  onCloseToRight: noop,
+  onCloseAll: noop,
+};
+
+function render(props: ContextMenuProps): string {
+  return renderToStaticMarkup(createElement(ContextMenu, props));
+}
+
+describe('ContextMenu i18n', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('zh-CN 默认渲染中文菜单项', () => {
+    const html = render({ ...handlers, x: 10, y: 10 });
+    expect(html).toContain('关闭其他');
+    expect(html).toContain('关闭右侧');
+    expect(html).toContain('全部关闭');
+  });
+
+  it('en-US locale 渲染英文菜单项', () => {
+    localStorage.setItem('folia-settings', JSON.stringify({ locale: 'en-US' }));
+    const html = render({ ...handlers, x: 10, y: 10 });
+    expect(html).toContain('Close others');
+    expect(html).toContain('Close to the right');
+    expect(html).toContain('Close all');
+  });
+
+  it('ja-JP locale 渲染日文菜单项', () => {
+    localStorage.setItem('folia-settings', JSON.stringify({ locale: 'ja-JP' }));
+    const html = render({ ...handlers, x: 10, y: 10 });
+    expect(html).toContain('他を閉じる');
+    expect(html).toContain('右側を閉じる');
+    expect(html).toContain('すべて閉じる');
+  });
+});
+
+describe('computeMenuPosition', () => {
+  it('菜单溢出右侧时左移到视口内', () => {
+    const pos = computeMenuPosition(1000, 10, 200, 100, 1024, 768);
+    expect(pos.left).toBeLessThanOrEqual(1024 - 200 - 8);
+    expect(pos.left).toBeGreaterThanOrEqual(8);
+    expect(pos.top).toBe(10);
+  });
+
+  it('菜单溢出底部时上移到视口内', () => {
+    const pos = computeMenuPosition(10, 700, 200, 100, 1024, 768);
+    expect(pos.top).toBeLessThanOrEqual(768 - 100 - 8);
+    expect(pos.top).toBeGreaterThanOrEqual(8);
+    expect(pos.left).toBe(10);
+  });
+
+  it('菜单在视口内时保持原位', () => {
+    const pos = computeMenuPosition(100, 100, 200, 100, 1024, 768);
+    expect(pos).toEqual({ left: 100, top: 100 });
+  });
+});
+
+describe('ContextMenu 占位标签', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('isPlaceholder 时只显示关闭，隐藏关闭其他/右侧/全部', () => {
+    const html = render({ ...handlers, x: 10, y: 10, isPlaceholder: true });
+    expect(html).toContain('关闭');
+    expect(html).not.toContain('关闭其他');
+    expect(html).not.toContain('关闭右侧');
+    expect(html).not.toContain('全部关闭');
+  });
+
+  it('非占位时显示全部四项', () => {
+    const html = render({ ...handlers, x: 10, y: 10 });
+    expect(html).toContain('关闭其他');
+    expect(html).toContain('全部关闭');
+  });
+});
+
+describe('ContextMenu 键盘导航', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    localStorage.clear();
+    host = document.createElement('div');
+    document.body.append(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  it('ArrowDown 在菜单项间向后移动焦点', () => {
+    act(() => {
+      root.render(<ContextMenu {...handlers} x={10} y={10} />);
+    });
+    const items = host.querySelectorAll<HTMLButtonElement>('[role="menuitem"]');
+    expect(items.length).toBe(4);
+    act(() => { items[0].focus(); });
+    expect(document.activeElement).toBe(items[0]);
+    act(() => {
+      items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    });
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  it('End 将焦点移到最后一项', () => {
+    act(() => {
+      root.render(<ContextMenu {...handlers} x={10} y={10} />);
+    });
+    const items = host.querySelectorAll<HTMLButtonElement>('[role="menuitem"]');
+    act(() => { items[0].focus(); });
+    act(() => {
+      items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    });
+    expect(document.activeElement).toBe(items[items.length - 1]);
+  });
+
+  it('ArrowUp 在菜单项间向前移动焦点（循环到末尾）', () => {
+    act(() => {
+      root.render(<ContextMenu {...handlers} x={10} y={10} />);
+    });
+    const items = host.querySelectorAll<HTMLButtonElement>('[role="menuitem"]');
+    act(() => { items[0].focus(); });
+    act(() => {
+      items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    });
+    expect(document.activeElement).toBe(items[items.length - 1]);
+  });
+});

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useSettings } from '../hooks/useSettings';
+import { translate } from '../services/i18n';
+import { computeMenuPosition } from './contextMenuPosition';
 
 export interface ContextMenuProps {
   x: number;
   y: number;
+  /** 占位标签（首页空标签）时为 true：只显示「关闭」，隐藏「关闭其他/右侧/全部」。 */
+  isPlaceholder?: boolean;
   onClose: () => void;
   onCloseTab: () => void;
   onCloseOthers: () => void;
@@ -10,31 +15,70 @@ export interface ContextMenuProps {
   onCloseAll: () => void;
 }
 
-/** 标签右键菜单。点击外部 / Esc 关闭；点选项执行后关闭。 */
-export function ContextMenu({ x, y, onClose, onCloseTab, onCloseOthers, onCloseToRight, onCloseAll }: ContextMenuProps) {
+/** 标签右键菜单。点击外部 / Esc 关闭；点选项执行后关闭；溢出视口自动翻转；支持 ↑↓/Home/End 键盘导航。文案接入 i18n。 */
+export function ContextMenu({ x, y, isPlaceholder = false, onClose, onCloseTab, onCloseOthers, onCloseToRight, onCloseAll }: ContextMenuProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const settings = useSettings();
+  const t = (key: Parameters<typeof translate>[1]) => translate(settings.locale, key);
+  const [pos, setPos] = useState<{ left: number; top: number }>({ left: x, top: y });
+
+  // 挂载后测量真实尺寸并裁切到视口内
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    setPos(computeMenuPosition(x, y, el.offsetWidth, el.offsetHeight, window.innerWidth, window.innerHeight));
+  }, [x, y]);
 
   useEffect(() => {
     const onAway = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) onClose();
     };
-    const onEsc = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      const el = ref.current;
+      if (!el) return;
+      const items = Array.from(el.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
+      if (items.length === 0) return;
+      const currentIndex = items.findIndex((it) => it === document.activeElement);
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length;
+        items[next].focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const prev = currentIndex < 0 ? items.length - 1 : (currentIndex - 1 + items.length) % items.length;
+        items[prev].focus();
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        items[0].focus();
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        items[items.length - 1].focus();
+      }
+    };
     window.addEventListener('mousedown', onAway);
-    window.addEventListener('keydown', onEsc);
+    window.addEventListener('keydown', onKey);
     return () => {
       window.removeEventListener('mousedown', onAway);
-      window.removeEventListener('keydown', onEsc);
+      window.removeEventListener('keydown', onKey);
     };
   }, [onClose]);
 
   const run = (fn: () => void) => { fn(); onClose(); };
 
   return (
-    <div ref={ref} className="tab-context-menu" style={{ left: x, top: y }} role="menu">
-      <button type="button" role="menuitem" onClick={() => run(onCloseTab)}>关闭</button>
-      <button type="button" role="menuitem" onClick={() => run(onCloseOthers)}>关闭其他</button>
-      <button type="button" role="menuitem" onClick={() => run(onCloseToRight)}>关闭右侧</button>
-      <button type="button" role="menuitem" onClick={() => run(onCloseAll)}>全部关闭</button>
+    <div ref={ref} className="tab-context-menu" style={{ left: pos.left, top: pos.top }} role="menu">
+      <button type="button" role="menuitem" onClick={() => run(onCloseTab)}>{t('tabMenuClose')}</button>
+      {!isPlaceholder && (
+        <>
+          <button type="button" role="menuitem" onClick={() => run(onCloseOthers)}>{t('tabMenuCloseOthers')}</button>
+          <button type="button" role="menuitem" onClick={() => run(onCloseToRight)}>{t('tabMenuCloseRight')}</button>
+          <button type="button" role="menuitem" onClick={() => run(onCloseAll)}>{t('tabMenuCloseAll')}</button>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/RecentFilesPage.test.tsx
+++ b/src/components/RecentFilesPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { createElement } from 'react';
 import { RecentFilesPage, type RecentFilesPageProps } from './RecentFilesPage';
@@ -12,6 +12,29 @@ const noop = () => {};
 const baseProps = { onOpenFile: noop, onOpenRecent: noop, onNew: noop };
 
 describe('RecentFilesPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('en-US locale 下显示 Open file 与 New 按钮', () => {
+    localStorage.setItem('folia-settings', JSON.stringify({ locale: 'en-US' }));
+    const html = render({ ...baseProps, recentFiles: [] });
+    expect(html).toContain('Open file');
+    expect(html).toContain('New');
+  });
+
+  it('en-US locale 下空状态为 No recently opened files', () => {
+    localStorage.setItem('folia-settings', JSON.stringify({ locale: 'en-US' }));
+    const html = render({ ...baseProps, recentFiles: [] });
+    expect(html).toContain('No recently opened files');
+  });
+
+  it('ja-JP locale 下打开文件按钮为 ファイルを開く', () => {
+    localStorage.setItem('folia-settings', JSON.stringify({ locale: 'ja-JP' }));
+    const html = render({ ...baseProps, recentFiles: [] });
+    expect(html).toContain('ファイルを開く');
+  });
+
   it('渲染标题与打开/新建按钮', () => {
     const html = render({ ...baseProps, recentFiles: [] });
     expect(html).toContain('打开文件');

--- a/src/components/RecentFilesPage.tsx
+++ b/src/components/RecentFilesPage.tsx
@@ -1,3 +1,5 @@
+import { useSettings } from '../hooks/useSettings';
+import { translate } from '../services/i18n';
 import type { RecentFileEntry } from '../types/session';
 
 export interface RecentFilesPageProps {
@@ -7,16 +9,18 @@ export interface RecentFilesPageProps {
   onNew: () => void;
 }
 
-/** 最近文件首页：占位标签时显示，替代编辑器区。i18n 三语留后续，暂硬编码中文。 */
+/** 最近文件首页：占位标签时显示，替代编辑器区。文案接入 i18n（zh-CN / en-US / ja-JP）。 */
 export function RecentFilesPage({ recentFiles, onOpenFile, onOpenRecent, onNew }: RecentFilesPageProps) {
+  const settings = useSettings();
+  const t = (key: Parameters<typeof translate>[1]) => translate(settings.locale, key);
   return (
     <div className="recent-page">
       <div className="recent-page-inner">
         <h1 className="recent-page-title">Folia</h1>
-        <p className="recent-page-subtitle">Markdown 阅读与写作 · 开始</p>
+        <p className="recent-page-subtitle">{t('recentSubtitle')}</p>
         <div className="recent-page-actions">
-          <button type="button" className="recent-page-primary" onClick={onOpenFile}>打开文件</button>
-          <button type="button" className="recent-page-secondary" onClick={onNew}>新建</button>
+          <button type="button" className="recent-page-primary" onClick={onOpenFile}>{t('recentOpenFileLabel')}</button>
+          <button type="button" className="recent-page-secondary" onClick={onNew}>{t('recentNewLabel')}</button>
         </div>
         {recentFiles.length > 0 ? (
           <ul className="recent-page-list">
@@ -35,7 +39,7 @@ export function RecentFilesPage({ recentFiles, onOpenFile, onOpenRecent, onNew }
             ))}
           </ul>
         ) : (
-          <p className="recent-page-empty">还没有最近打开的文件</p>
+          <p className="recent-page-empty">{t('recentEmpty')}</p>
         )}
       </div>
     </div>

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { createElement } from 'react';
 import { TabBar, type TabBarProps } from './TabBar';
@@ -24,6 +24,28 @@ const noop = () => {};
 const baseProps = { onSelect: noop, onClose: noop, onNew: noop };
 
 describe('TabBar', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('en-US locale 下新建按钮 aria-label 为 New file', () => {
+    localStorage.setItem('folia-settings', JSON.stringify({ locale: 'en-US' }));
+    const html = render({ ...baseProps, tabs: [tab('a', 'a.md')], activeTabId: 'a' });
+    expect(html).toContain('New file');
+  });
+
+  it('ja-JP locale 下新建按钮 aria-label 为 新規ファイル', () => {
+    localStorage.setItem('folia-settings', JSON.stringify({ locale: 'ja-JP' }));
+    const html = render({ ...baseProps, tabs: [tab('a', 'a.md')], activeTabId: 'a' });
+    expect(html).toContain('新規ファイル');
+  });
+
+  it('en-US locale 下关闭按钮 aria-label 含 Close', () => {
+    localStorage.setItem('folia-settings', JSON.stringify({ locale: 'en-US' }));
+    const html = render({ ...baseProps, tabs: [tab('a', 'a.md')], activeTabId: 'a' });
+    expect(html).toContain('Close');
+  });
+
   it('渲染所有标签名', () => {
     const html = render({ ...baseProps, tabs: [tab('a', 'a.md'), tab('b', 'b.md')], activeTabId: 'a' });
     expect(html).toContain('a.md');

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,3 +1,5 @@
+import { useSettings } from '../hooks/useSettings';
+import { translate } from '../services/i18n';
 import type { Tab } from '../types/session';
 
 export interface TabBarProps {
@@ -9,8 +11,10 @@ export interface TabBarProps {
   onContextMenu?: (id: string, x: number, y: number) => void;
 }
 
-/** 标签栏：独立一行，纯交互（不兼窗口拖拽）。i18n 三语留阶段二补，暂硬编码中文。 */
+/** 标签栏：嵌入 Toolbar 中间行，纯交互。tab/按钮加 data-no-window-drag 避免触发窗口拖拽。文案接入 i18n。 */
 export function TabBar({ tabs, activeTabId, onSelect, onClose, onNew, onContextMenu }: TabBarProps) {
+  const settings = useSettings();
+  const t = (key: Parameters<typeof translate>[1]) => translate(settings.locale, key);
   return (
     <div className="tabbar" role="tablist">
       <div className="tabbar-scroll">
@@ -20,6 +24,7 @@ export function TabBar({ tabs, activeTabId, onSelect, onClose, onNew, onContextM
             <div
               key={tab.id}
               data-tab={tab.id}
+              data-no-window-drag="true"
               className={`tabbar-tab${active ? ' tabbar-tab--active' : ''}`}
               role="tab"
               aria-selected={active}
@@ -31,9 +36,10 @@ export function TabBar({ tabs, activeTabId, onSelect, onClose, onNew, onContextM
               <span className="tabbar-name">{tab.file.name}</span>
               <button
                 type="button"
+                data-no-window-drag="true"
                 className="tabbar-close"
-                aria-label={`关闭 ${tab.file.name}`}
-                title="关闭"
+                aria-label={`${t('tabCloseLabel')} ${tab.file.name}`}
+                title={t('tabCloseLabel')}
                 onClick={(e) => { e.stopPropagation(); onClose(tab.id); }}
               >
                 ×
@@ -42,7 +48,7 @@ export function TabBar({ tabs, activeTabId, onSelect, onClose, onNew, onContextM
           );
         })}
       </div>
-      <button type="button" className="tabbar-new" aria-label="新建文件" title="新建文件" onClick={onNew}>+</button>
+      <button type="button" data-no-window-drag="true" className="tabbar-new" aria-label={t('tabNewFileLabel')} title={t('tabNewFileLabel')} onClick={onNew}>+</button>
     </div>
   );
 }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import {
   BookOpenText,
   Braces,
@@ -22,6 +23,8 @@ type UpdateToolbarStatus = {
 type ToolbarProps = {
   dirty: boolean;
   fileName: string;
+  /** 传入 <TabBar /> 占据中间区域，替代独立文件名显示。占位首页时不传。 */
+  tabBar?: ReactNode;
   editorMode: EditorMode;
   wordPreviewVisible: boolean;
   wechatPreviewVisible: boolean;
@@ -39,7 +42,7 @@ type ToolbarProps = {
 };
 
 export function Toolbar({
-  dirty, fileName,
+  dirty, fileName, tabBar,
   editorMode, wordPreviewVisible, wechatPreviewVisible, editingDisabled, onToggleEditorMode, onToggleWordPreview, onToggleWechatPreview,
   onOpen, onSave, onSaveAs, onOpenSettings, onPreloadSettings, updateStatus, onRestartUpdate,
 }: ToolbarProps) {
@@ -75,13 +78,18 @@ export function Toolbar({
           </button>
         </div>
       </div>
-      <div className="toolbar-title" data-tauri-drag-region aria-label={t('currentFileLabel')}>
-        <span className={`file-name ${hasOpenedFile || dirty ? 'visible' : ''}`}>
-          {dirty && <span className="dirty-dot" />}
-          <span className="file-name-text">{fileName}</span>
-        </span>
+      <div
+        className={`toolbar-title${tabBar ? ' toolbar-title--tabs' : ''}`}
+        data-tauri-drag-region
+        aria-label={t('currentFileLabel')}
+      >
+        {tabBar ?? (
+          <span className={`file-name ${hasOpenedFile || dirty ? 'visible' : ''}`}>
+            {dirty && <span className="dirty-dot" />}
+            <span className="file-name-text">{fileName}</span>
+          </span>
+        )}
       </div>
-      <div className="toolbar-spacer" data-tauri-drag-region aria-hidden="true" />
       <div className="toolbar-right">
         <div className="toolbar-group toolbar-view-actions" aria-label={t('toolbarViewGroup')}>
           {updateStatus && (

--- a/src/components/contextMenuPosition.ts
+++ b/src/components/contextMenuPosition.ts
@@ -1,0 +1,22 @@
+const MENU_MARGIN = 8;
+
+/** 根据菜单尺寸与视口计算不溢出的位置。纯函数，便于单测。 */
+export function computeMenuPosition(
+  x: number,
+  y: number,
+  menuWidth: number,
+  menuHeight: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  margin = MENU_MARGIN,
+): { left: number; top: number } {
+  let left = x;
+  let top = y;
+  if (x + menuWidth + margin > viewportWidth) {
+    left = Math.max(margin, viewportWidth - menuWidth - margin);
+  }
+  if (y + menuHeight + margin > viewportHeight) {
+    top = Math.max(margin, viewportHeight - menuHeight - margin);
+  }
+  return { left, top };
+}

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -122,6 +122,16 @@ const zhCN = {
   closePreviewTitle: '关闭',
   closePreviewLabel: '关闭预览',
   openFileTooLargeMessage: '该文件过大（超过 10MB），暂不支持打开。',
+  tabCloseLabel: '关闭',
+  tabNewFileLabel: '新建文件',
+  recentSubtitle: 'Markdown 阅读与写作 · 开始',
+  recentOpenFileLabel: '打开文件',
+  recentNewLabel: '新建',
+  recentEmpty: '还没有最近打开的文件',
+  tabMenuClose: '关闭',
+  tabMenuCloseOthers: '关闭其他',
+  tabMenuCloseRight: '关闭右侧',
+  tabMenuCloseAll: '全部关闭',
 };
 
 type I18nKey = keyof typeof zhCN;
@@ -242,6 +252,16 @@ const enUS: Record<I18nKey, string> = {
   closePreviewTitle: 'Close',
   closePreviewLabel: 'Close preview',
   openFileTooLargeMessage: 'This file is too large (over 10 MB) and cannot be opened.',
+  tabCloseLabel: 'Close',
+  tabNewFileLabel: 'New file',
+  recentSubtitle: 'Markdown reading & writing · Start',
+  recentOpenFileLabel: 'Open file',
+  recentNewLabel: 'New',
+  recentEmpty: 'No recently opened files',
+  tabMenuClose: 'Close',
+  tabMenuCloseOthers: 'Close others',
+  tabMenuCloseRight: 'Close to the right',
+  tabMenuCloseAll: 'Close all',
 };
 
 const jaJP: Record<I18nKey, string> = {
@@ -360,6 +380,16 @@ const jaJP: Record<I18nKey, string> = {
   closePreviewTitle: '閉じる',
   closePreviewLabel: 'プレビューを閉じる',
   openFileTooLargeMessage: 'このファイルは大きすぎます（10MB 超）ため、開けません。',
+  tabCloseLabel: '閉じる',
+  tabNewFileLabel: '新規ファイル',
+  recentSubtitle: 'Markdown 読み書き · はじめる',
+  recentOpenFileLabel: 'ファイルを開く',
+  recentNewLabel: '新規',
+  recentEmpty: '最近開いたファイルはまだありません',
+  tabMenuClose: '閉じる',
+  tabMenuCloseOthers: '他を閉じる',
+  tabMenuCloseRight: '右側を閉じる',
+  tabMenuCloseAll: 'すべて閉じる',
 };
 
 const dictionaries: Record<AppLocale, Record<I18nKey, string>> = {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -131,17 +131,19 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 }
 
 .toolbar-title {
-  position: absolute;
-  left: 50%;
-  top: 0;
-  bottom: 0;
+  position: relative;
   z-index: 1;
+  flex: 1 1 auto;
+  min-width: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: min(42vw, 360px);
-  transform: translateX(-50%);
   pointer-events: none;
+}
+
+.toolbar-title--tabs {
+  justify-content: flex-start;
+  pointer-events: auto;
 }
 
 .toolbar-group,
@@ -233,10 +235,10 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 .tabbar {
   display: flex;
   align-items: stretch;
-  height: 34px;
-  flex-shrink: 0;
-  border-bottom: 1px solid var(--border-soft);
-  background: var(--bg);
+  width: 100%;
+  height: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
   -webkit-user-select: none;
   user-select: none;
 }


### PR DESCRIPTION
Closes #40

## 背景
v0.4 多标签页 + 最近文件首页核心（PR #36–#39）已合并 main。本 PR 收口 TASKS.md「v0.4」待处理的 UI 项，并落地用户反馈的标签栏布局调整。

## 改动

### 1. 标签栏并入顶部工具栏同一行（用户反馈）
- 替代原先独立一行 + 中间「当前文件名」区，文件名由标签承载，减少一行垂直占用
- `Toolbar` 增加 `tabBar` slot；`toolbar-title` 由绝对定位居中改为 flex 占据中间，移除 `toolbar-spacer`
- tab / 新建按钮加 `data-no-window-drag`，避免在拖拽区触发窗口拖拽

### 2. i18n 三语（TabBar / RecentFilesPage / ContextMenu）
- 按项目统一模式（`useSettings` + `translate`）接入，补 `zh-CN` / `en-US` / `ja-JP`，替换硬编码中文

### 3. 右键菜单 b Minor
- 边界裁切：`computeMenuPosition` 纯函数，溢出视口自动左移 / 上移
- 键盘导航：`↑/↓` / `Home/End`
- 占位标签（`isPlaceholder`）只显示「关闭」，隐藏「关闭其他 / 关闭右侧 / 全部关闭」

## 不在本 PR
- c 剩余（大文件降级 UI 提示 / 失效文件 `pathInvalid` / 启动 loading）→ 独立 PR

## 验证
- `typecheck` / `lint`（0 warning）/ `build`（无 chunk warning）通过
- `vitest` 41 文件 / 270 用例（新增 17：TabBar 3 + RecentFilesPage 3 + ContextMenu 11，覆盖 i18n 三语 + 边界 + 键盘 + 占位）
- `test:e2e` 20 用例通过（更新 `layout-behavior` toolbar 断言适配新布局）
- `tauri dev` 实操（Playwright MCP）：标签栏与文件操作 / 视图按钮同行 ✅、占位标签右键只显示「关闭」✅、i18n en-US 文案生效 ✅