### PR TITLE
feat(v0.4): 大文件降级提示 + 失效文件处理 + 启动恢复 loading (ISS-42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ All notable changes to this project will be documented in this file.
 - 精简 Release 构建产物（DEC-093）：`src-tauri/tauri.conf.json` 的 `bundle.targets` 由 `"all"` 收窄为 `["dmg", "nsis"]`，Windows 不再生成冗余的 MSI 安装包，只保留 NSIS `.exe`；macOS 仍生成 `.dmg`。自动更新专用的 `.app.tar.gz` / `.nsis.zip` + `.sig` 产物不受影响（Tauri updater 依赖，无法精简）。
 - 标签栏并入顶部工具栏同一行（ISS-40）：替代原先独立一行 + 中间「当前文件名」区，文件名改由标签承载，减少一行垂直占用；`.toolbar-title` 由绝对定位居中改为 flex 占据中间并移除 `.toolbar-spacer`；标签与「新建」按钮加 `data-no-window-drag` 隔离窗口拖拽。
 - 标签页 / 最近文件首页 / 标签右键菜单接入 i18n（ISS-40）：`TabBar` / `RecentFilesPage` / `ContextMenu` 按项目统一模式（`useSettings` + `translate`）补 `zh-CN` / `en-US` / `ja-JP` 三语，替换原硬编码中文。
+- `StatusBar` 全面接入 i18n（zh-CN / en-US / ja-JP，顺带 ISS-150），并新增「重新加载中 / 文件已丢失 / 草稿过大未自动保存」三态提示（ISS-42）。
 
 ### Added
 
 - 标签右键菜单增强（ISS-40）：屏幕边界自动翻转（`computeMenuPosition` 纯函数，溢出视口时左移 / 上移）、`↑/↓` / `Home/End` 键盘导航、占位标签（`isPlaceholder`）只显示「关闭」并隐藏「关闭其他 / 关闭右侧 / 全部关闭」。
+- 大文件降级标签（>256KB 草稿未落盘）的失效与重读体验（ISS-42）：磁盘文件被删 / 移动导致重读失败时 `Tab` 标记 `pathInvalid`，状态栏显示「文件已丢失」并提供「另存为」；重读期间状态栏显示「重新加载中」；草稿过大未落盘显示「草稿过大未自动保存」。`reloading` 由 `activeTab` 派生，避免 effect 内 set state。
 
 ### Performance
 

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -519,19 +519,26 @@ export function AppLayout() {
   }, [file, settings.autoSave, updateActiveFile]);
 
   // 大文件降级 tab（draftPersisted=false 且 content 被清空）：激活时从磁盘重读内容，
-  // 修复降级重启后空白编辑器（阶段一 I1 遗留，阶段二c）。失败（文件被删/移）仅 warn。
+  // 修复降级重启后空白编辑器。失败（文件被删/移）标记 pathInvalid 并提示另存为（ISS-42）。
+  // reloading 由 activeTab 派生（draftPersisted=false + content 空 = 重读中），避免 effect 内 set state。
+  const { activeTab, markPathInvalid } = session;
   useEffect(() => {
-    const tab = session.activeTab;
-    if (!tab || tab.draftPersisted) return;
-    if (!tab.file.path || tab.file.content) return;
-    if (tab.file.fileType === 'docx') return;
+    if (!activeTab || activeTab.draftPersisted) return;
+    if (!activeTab.file.path || activeTab.file.content) return;
+    if (activeTab.file.fileType === 'docx') return;
     let cancelled = false;
     void import('../services/fileService')
-      .then(({ openPath }) => openPath(tab.file.path, settings.defaultEncoding))
+      .then(({ openPath }) => openPath(activeTab.file.path, settings.defaultEncoding))
       .then((opened) => { if (!cancelled) updateActiveFile(() => opened); })
-      .catch((e) => console.warn('Failed to reload large-file tab:', e));
+      .catch(() => { if (!cancelled) markPathInvalid(activeTab.id); });
     return () => { cancelled = true; };
-  }, [session.activeTab, settings.defaultEncoding, updateActiveFile]);
+  }, [activeTab, settings.defaultEncoding, updateActiveFile, markPathInvalid]);
+  const reloading = !!activeTab
+    && !activeTab.pathInvalid
+    && !activeTab.draftPersisted
+    && !!activeTab.file.path
+    && !activeTab.file.content
+    && activeTab.file.fileType !== 'docx';
 
   useEffect(() => {
     if (!isTauriRuntime) return;
@@ -791,7 +798,14 @@ export function AppLayout() {
         )}
         {rightPanel}
       </div>
-      <StatusBar filePath={file.path} dirty={file.dirty} />
+      <StatusBar
+        filePath={file.path}
+        dirty={file.dirty}
+        draftPersisted={session.activeTab?.draftPersisted}
+        pathInvalid={session.activeTab?.pathInvalid}
+        reloading={reloading}
+        onSaveAs={() => { void handleSaveAs(); }}
+      />
       {contextMenu && (
         <ContextMenu
           x={contextMenu.x}

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -32,6 +32,7 @@ describe('StatusBar', () => {
   beforeEach(() => {
     writeTextMock.mockReset();
     writeTextRejection = null;
+    localStorage.clear();
     host = document.createElement('div');
     document.body.append(host);
     root = createRoot(host);
@@ -43,9 +44,18 @@ describe('StatusBar', () => {
     vi.clearAllTimers();
   });
 
-  function render(props: { filePath: string; dirty?: boolean }) {
+  function render(props: { filePath: string; dirty?: boolean; draftPersisted?: boolean; pathInvalid?: boolean; reloading?: boolean; onSaveAs?: () => void }) {
     act(() => {
-      root.render(<StatusBar filePath={props.filePath} dirty={props.dirty ?? false} />);
+      root.render(
+        <StatusBar
+          filePath={props.filePath}
+          dirty={props.dirty ?? false}
+          draftPersisted={props.draftPersisted}
+          pathInvalid={props.pathInvalid}
+          reloading={props.reloading}
+          onSaveAs={props.onSaveAs}
+        />,
+      );
     });
   }
 
@@ -146,5 +156,34 @@ describe('StatusBar', () => {
     });
     expect(host.querySelector('.status-copy-feedback')).toBeNull();
     expect(host.querySelector('.status-path')?.getAttribute('data-copy-state')).toBe('idle');
+  });
+
+  it('reloading 时显示「重新加载中」提示', () => {
+    render({ filePath: '/tmp/a.md', reloading: true });
+    expect(host.querySelector('.status-notice')?.textContent).toContain('重新加载中');
+    expect(host.querySelector('.status-notice')?.getAttribute('data-notice')).toBe('info');
+  });
+
+  it('pathInvalid 时显示「文件已丢失」与另存为按钮，点击触发 onSaveAs', () => {
+    const onSaveAs = vi.fn();
+    render({ filePath: '/tmp/a.md', pathInvalid: true, onSaveAs });
+    const notice = host.querySelector('.status-notice');
+    expect(notice?.textContent).toContain('文件已丢失');
+    expect(notice?.getAttribute('data-notice')).toBe('error');
+    const btn = host.querySelector<HTMLButtonElement>('.status-notice-action');
+    expect(btn).not.toBeNull();
+    act(() => { btn!.click(); });
+    expect(onSaveAs).toHaveBeenCalledTimes(1);
+  });
+
+  it('draftPersisted=false 时显示「草稿过大未自动保存」提示', () => {
+    render({ filePath: '/tmp/a.md', draftPersisted: false });
+    expect(host.querySelector('.status-notice')?.textContent).toContain('草稿过大');
+    expect(host.querySelector('.status-notice')?.getAttribute('data-notice')).toBe('warn');
+  });
+
+  it('draftPersisted=true 正常状态不显示 notice', () => {
+    render({ filePath: '/tmp/a.md', draftPersisted: true });
+    expect(host.querySelector('.status-notice')).toBeNull();
   });
 });

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,17 +1,30 @@
 import { useEffect, useRef, useState } from 'react';
 import { writeText } from '../services/clipboardService';
+import { useSettings } from '../hooks/useSettings';
+import { translate } from '../services/i18n';
 
 type StatusBarProps = {
   filePath: string;
   dirty: boolean;
+  /** 草稿是否已落盘（大文件 >256KB 降级时 false）。false 时提示「草稿过大未自动保存」。 */
+  draftPersisted?: boolean;
+  /** 文件路径失效（磁盘文件被删 / 移动，重读失败）时为 true，提示「文件已丢失」并提供另存为。 */
+  pathInvalid?: boolean;
+  /** 大文件重读期间为 true，提示「重新加载中」。 */
+  reloading?: boolean;
+  /** pathInvalid 时点击「另存为」的回调。 */
+  onSaveAs?: () => void;
 };
 
 type CopyOutcome = 'copied' | 'failed';
 type CopyMarker = { path: string; outcome: CopyOutcome } | null;
+type NoticeTone = 'info' | 'warn' | 'error';
 
 const COPY_FEEDBACK_RESET_MS = 1200;
 
-export function StatusBar({ filePath, dirty }: StatusBarProps) {
+export function StatusBar({ filePath, dirty, draftPersisted, pathInvalid, reloading, onSaveAs }: StatusBarProps) {
+  const settings = useSettings();
+  const t = (key: Parameters<typeof translate>[1]) => translate(settings.locale, key);
   const hasPath = filePath.length > 0;
   const [copyMarker, setCopyMarker] = useState<CopyMarker>(null);
   const resetTimerRef = useRef<number | null>(null);
@@ -54,19 +67,41 @@ export function StatusBar({ filePath, dirty }: StatusBarProps) {
       ? copyMarker.outcome
       : 'idle';
 
+  // 提示优先级：reloading > pathInvalid > draftPersisted 降级。
+  const notice: { text: string; tone: NoticeTone; action?: boolean } | null = reloading
+    ? { text: t('reloadingLabel'), tone: 'info' }
+    : pathInvalid
+      ? { text: t('fileLostLabel'), tone: 'error', action: true }
+      : draftPersisted === false
+        ? { text: t('draftTooLargeLabel'), tone: 'warn' }
+        : null;
+
   return (
     <div className="status-bar">
       <span
         className="status-path"
         data-copy-state={copyState}
         onDoubleClick={hasPath ? handleDoubleClick : undefined}
-        title={hasPath ? '双击复制完整路径' : undefined}
+        title={hasPath ? t('statusBarCopyHint') : undefined}
         style={
           hasPath ? { cursor: 'text', userSelect: 'text' } : undefined
         }
       >
-        {hasPath ? filePath : '未打开文件'}
+        {hasPath ? filePath : t('statusBarNoFile')}
       </span>
+      {notice && (
+        <span
+          className={`status-notice status-notice--${notice.tone}`}
+          data-notice={notice.tone}
+        >
+          {notice.text}
+          {notice.action && onSaveAs && (
+            <button type="button" className="status-notice-action" onClick={onSaveAs}>
+              {t('statusBarSaveAs')}
+            </button>
+          )}
+        </span>
+      )}
       {copyState !== 'idle' && (
         <span
           className="status-copy-feedback"
@@ -76,10 +111,10 @@ export function StatusBar({ filePath, dirty }: StatusBarProps) {
             fontWeight: 500,
           }}
         >
-          {copyState === 'copied' ? '已复制' : '复制失败'}
+          {copyState === 'copied' ? t('statusBarCopied') : t('statusBarCopyFailed')}
         </span>
       )}
-      {dirty && <span className="status-dirty">未保存</span>}
+      {dirty && <span className="status-dirty">{t('statusBarUnsaved')}</span>}
     </div>
   );
 }

--- a/src/hooks/sessionReducer.test.ts
+++ b/src/hooks/sessionReducer.test.ts
@@ -205,3 +205,27 @@ describe('sessionReducer.recordRecentFile', () => {
     expect(next.recentFiles).toHaveLength(0);
   });
 });
+
+describe('sessionReducer.markPathInvalid', () => {
+  it('标记指定 tab 为 pathInvalid', () => {
+    const t1 = makeTabFromFile(file('a.md'));
+    const start = stateWith([t1], t1.id);
+    const next = sessionReducer(start, { type: 'markPathInvalid', id: t1.id });
+    expect(next.tabs[0].pathInvalid).toBe(true);
+  });
+
+  it('id 不存在时不变', () => {
+    const t1 = makeTabFromFile(file('a.md'));
+    const start = stateWith([t1]);
+    expect(sessionReducer(start, { type: 'markPathInvalid', id: '不存在' })).toBe(start);
+  });
+
+  it('不影响其他标签', () => {
+    const t1 = makeTabFromFile(file('a.md'));
+    const t2 = makeTabFromFile(file('b.md'));
+    const start = stateWith([t1, t2], t1.id);
+    const next = sessionReducer(start, { type: 'markPathInvalid', id: t1.id });
+    expect(next.tabs[0].pathInvalid).toBe(true);
+    expect(next.tabs[1].pathInvalid).toBeUndefined();
+  });
+});

--- a/src/hooks/sessionReducer.ts
+++ b/src/hooks/sessionReducer.ts
@@ -31,7 +31,8 @@ export type SessionAction =
   | { type: 'closeAll' }
   | { type: 'updateActiveFile'; updater: (f: OpenedFile) => OpenedFile }
   | { type: 'updateActiveTabMeta'; meta: Partial<Pick<Tab, 'editorMode' | 'rightPanelMode'>> }
-  | { type: 'recordRecentFile'; file: OpenedFile };
+  | { type: 'recordRecentFile'; file: OpenedFile }
+  | { type: 'markPathInvalid'; id: string };
 
 export function sessionReducer(state: SessionState, action: SessionAction): SessionState {
   switch (action.type) {
@@ -106,6 +107,9 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
       const filtered = state.recentFiles.filter((r) => r.path !== entry.path);
       return { ...state, recentFiles: [entry, ...filtered].slice(0, MAX_RECENT_FILES) };
     }
+    case 'markPathInvalid':
+      if (!state.tabs.some((t) => t.id === action.id)) return state;
+      return { ...state, tabs: state.tabs.map((t) => (t.id === action.id ? { ...t, pathInvalid: true } : t)) };
     default:
       return state;
   }

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -85,6 +85,10 @@ export function useSession() {
   const closeToRight = useCallback((id: string) => { dispatch({ type: 'closeToRight', id }); }, []);
   const closeAll = useCallback(() => { dispatch({ type: 'closeAll' }); }, []);
 
+  const markPathInvalid = useCallback((id: string) => {
+    dispatch({ type: 'markPathInvalid', id });
+  }, []);
+
   const closeTab = useCallback(
     (id: string, options?: CloseOptions) => {
       const tab = state.tabs.find((t) => t.id === id);
@@ -111,6 +115,7 @@ export function useSession() {
     closeOthers,
     closeToRight,
     closeAll,
+    markPathInvalid,
     updateActiveFile,
     updateActiveTabMeta,
     recordRecentFile,

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -132,6 +132,15 @@ const zhCN = {
   tabMenuCloseOthers: '关闭其他',
   tabMenuCloseRight: '关闭右侧',
   tabMenuCloseAll: '全部关闭',
+  statusBarNoFile: '未打开文件',
+  statusBarCopyHint: '双击复制完整路径',
+  statusBarCopied: '已复制',
+  statusBarCopyFailed: '复制失败',
+  statusBarUnsaved: '未保存',
+  reloadingLabel: '重新加载中…',
+  fileLostLabel: '文件已丢失',
+  draftTooLargeLabel: '草稿过大未自动保存',
+  statusBarSaveAs: '另存为',
 };
 
 type I18nKey = keyof typeof zhCN;
@@ -262,6 +271,15 @@ const enUS: Record<I18nKey, string> = {
   tabMenuCloseOthers: 'Close others',
   tabMenuCloseRight: 'Close to the right',
   tabMenuCloseAll: 'Close all',
+  statusBarNoFile: 'No file open',
+  statusBarCopyHint: 'Double-click to copy full path',
+  statusBarCopied: 'Copied',
+  statusBarCopyFailed: 'Copy failed',
+  statusBarUnsaved: 'Unsaved',
+  reloadingLabel: 'Reloading…',
+  fileLostLabel: 'File missing',
+  draftTooLargeLabel: 'Draft too large to auto-save',
+  statusBarSaveAs: 'Save as',
 };
 
 const jaJP: Record<I18nKey, string> = {
@@ -390,6 +408,15 @@ const jaJP: Record<I18nKey, string> = {
   tabMenuCloseOthers: '他を閉じる',
   tabMenuCloseRight: '右側を閉じる',
   tabMenuCloseAll: 'すべて閉じる',
+  statusBarNoFile: 'ファイルを開いていません',
+  statusBarCopyHint: 'ダブルクリックでフルパスをコピー',
+  statusBarCopied: 'コピーしました',
+  statusBarCopyFailed: 'コピー失敗',
+  statusBarUnsaved: '未保存',
+  reloadingLabel: '再読み込み中…',
+  fileLostLabel: 'ファイルが見つかりません',
+  draftTooLargeLabel: '下書きが大きすぎて自動保存できません',
+  statusBarSaveAs: '名前を付けて保存',
 };
 
 const dictionaries: Record<AppLocale, Record<I18nKey, string>> = {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2107,6 +2107,42 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
   font-weight: 500;
 }
 
+.status-notice {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-size: 10px;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+.status-notice--info { color: var(--muted, var(--border)); }
+.status-notice--warn {
+  color: oklch(52% 0.12 75);
+  background: color-mix(in oklch, oklch(52% 0.12 75) 12%, transparent);
+}
+.status-notice--error {
+  color: var(--danger);
+  background: color-mix(in oklch, var(--danger) 12%, transparent);
+}
+.status-notice-action {
+  display: inline-flex;
+  align-items: center;
+  height: 16px;
+  padding: 0 5px;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  background: transparent;
+  color: inherit;
+  font-family: inherit;
+  font-size: 10px;
+  cursor: pointer;
+}
+.status-notice-action:hover {
+  background: color-mix(in oklch, currentColor 14%, transparent);
+}
+
 /* ===== Settings Overlay & Modal ===== */
 
 .settings-overlay {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -18,6 +18,8 @@ export interface Tab {
   draftPersisted: boolean;
   /** 是否占位标签（bootstrap/关到最后一个时补的空标签）。占位时显示最近文件首页，而非编辑器。 */
   isPlaceholder: boolean;
+  /** 文件路径失效（磁盘文件被删 / 移动，重读失败）时为 true，UI 提示「文件已丢失」并引导另存为。 */
+  pathInvalid?: boolean;
 }
 
 export interface RecentFileEntry {


### PR DESCRIPTION
Closes #42

## 背景
v0.4 c 剩余三项（启动恢复与降级体验），TASKS.md「v0.4」最后待办。

## 改动
1. **失效文件 pathInvalid**：`Tab` 加可选 `pathInvalid` + `sessionReducer` `markPathInvalid` action + `AppLayout` reload effect 失败时标记（替代原 `console.warn`），StatusBar 显示「文件已丢失」+ 「另存为」按钮
2. **启动恢复 loading**：`reloading` 由 `activeTab` 派生（`draftPersisted=false` + content 空），避免 effect 内 set state（`react-hooks/set-state-in-effect`）；StatusBar 显示「重新加载中」
3. **大文件降级提示**：`draftPersisted=false` 时 StatusBar 显示「草稿过大未自动保存」
4. **StatusBar 全面 i18n**（顺带 ISS-150）+ i18n.ts 新增 10 key × 三语 + app.css `.status-notice` 样式

## 与 PR #41 的关系
本 PR 基于 `origin/main`（不含 #41）。两 PR 都改 `i18n.ts` / `CHANGELOG.md`（同位置 append）→ merge 时需手动合并；`AppLayout.tsx` 改的是不同区域（#41 改 Toolbar/ContextMenu，本 PR 改 reload effect/StatusBar 渲染），可自动合并。建议先 merge #41，再 rebase 本 PR 解 i18n / CHANGELOG。

## 验证
- `typecheck` / `lint`（0 warning）/ `build` 通过
- `vitest` 40 文件 / 260 用例（新增 `sessionReducer.markPathInvalid` 3 + `StatusBar` notice 4）
- `test:e2e` 20 用例通过
- `pathInvalid` 的 Tauri 真实文件删除场景留桌面 review 实操