### PR TITLE
feat(license): 内测授权码改为 ywxlaw (ISS-165)

### DIFF
--- a/src/services/licenseService.ts
+++ b/src/services/licenseService.ts
@@ -28,7 +28,7 @@ export const DEFAULT_LICENSE_STATE: LicenseState = {
 };
 
 const LOCAL_BETA_CODES: Record<string, Pick<LicenseState, 'customExportPresetLimit' | 'customHtmlExportPresetLimit' | 'expiresAt'>> = {
-  'FOLIA-BETA-2026': {
+  YWXLAW: {
     customExportPresetLimit: 8,
     customHtmlExportPresetLimit: 8,
     expiresAt: null,

--- a/src/services/settingsService.test.ts
+++ b/src/services/settingsService.test.ts
@@ -351,13 +351,13 @@ describe('settingsService', () => {
     expect(canAddCustomExportPreset(thirdWord.id)).toBe(false);
     expect(canAddCustomHtmlExportPreset(thirdHtml.id)).toBe(false);
 
-    const result = activateLicenseCode('FOLIA-BETA-2026');
+    const result = activateLicenseCode('ywxlaw');
 
     expect(result.ok).toBe(true);
     expect(getSettings().license).toMatchObject({
       status: 'active',
       plan: 'beta',
-      codeLabel: 'FOLIA-BETA-2026',
+      codeLabel: 'YWXLAW',
       customExportPresetLimit: 8,
       customHtmlExportPresetLimit: 8,
     });
@@ -384,7 +384,7 @@ describe('settingsService', () => {
   });
 
   it('clears beta license state and returns to standard slot limits', () => {
-    activateLicenseCode('FOLIA-BETA-2026');
+    activateLicenseCode('ywxlaw');
 
     clearLicense();
 
@@ -398,7 +398,7 @@ describe('settingsService', () => {
       license: {
         status: 'active',
         plan: 'beta',
-        codeLabel: 'FOLIA-BETA-2026',
+        codeLabel: 'YWXLAW',
         customExportPresetLimit: 999,
         customHtmlExportPresetLimit: 999,
       },


### PR DESCRIPTION
## 摘要
内测授权码由 FOLIA-BETA-2026 改为 ywxlaw（用户微信号，便于识别归属）。大小写不敏感（输入经 toUpperCase 归一化）。

## 改动
- src/services/licenseService.ts: LOCAL_BETA_CODES key FOLIA-BETA-2026 → YWXLAW
- src/services/settingsService.test.ts: 测试同步

## 测试
typecheck ✅ / lint ✅ / vitest(settingsService) 30/30 ✅

Refs: ISS-165