### PR TITLE
feat(local-image): 本地相对路径解析增越界防护+扩展资源范围 (ISS-160, DEC-098)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- 本地相对路径资源解析增加路径遍历防护并扩展覆盖范围（ISS-160 / DEC-098）。**越界防护**：`resolveLocalResourcePath` 新增 `isSensitivePath` 黑名单，拒绝解析后落在敏感系统 / 凭据目录（`/etc` `/System` `/var` `/usr` `.ssh` `.gnupg` `.aws` `C:\Windows` 等）的相对路径；保留合法 `../` 上级引用（律师文档常把图片放共享上级 `证据/` 目录，不破坏现有文档）。**扩展范围**：`resolveLocalImages` 从仅 `<img src>` 扩展到 `<source src>`、`<video poster>`、`<img>` / `<source>` 的 `srcset`、CSS `background-image: url(...)`（inline `style` + `<style>` 块）。外部 / 越界 / 无法解析的资源保留原属性、不抛错。
+- 内测授权码由 `FOLIA-BETA-2026` 改为 `ywxlaw`（用户微信号，便于识别归属；大小写不敏感，输入经 `toUpperCase` 归一化）（ISS-165, PR #44）。
 - 精简 Release 构建产物（DEC-093）：`src-tauri/tauri.conf.json` 的 `bundle.targets` 由 `"all"` 收窄为 `["dmg", "nsis"]`，Windows 不再生成冗余的 MSI 安装包，只保留 NSIS `.exe`；macOS 仍生成 `.dmg`。自动更新专用的 `.app.tar.gz` / `.nsis.zip` + `.sig` 产物不受影响（Tauri updater 依赖，无法精简）。
 - 标签栏并入顶部工具栏同一行（ISS-40）：替代原先独立一行 + 中间「当前文件名」区，文件名改由标签承载，减少一行垂直占用；`.toolbar-title` 由绝对定位居中改为 flex 占据中间并移除 `.toolbar-spacer`；标签与「新建」按钮加 `data-no-window-drag` 隔离窗口拖拽。
 - 标签页 / 最近文件首页 / 标签右键菜单接入 i18n（ISS-40）：`TabBar` / `RecentFilesPage` / `ContextMenu` 按项目统一模式（`useSettings` + `translate`）补 `zh-CN` / `en-US` / `ja-JP` 三语，替换原硬编码中文。

--- a/src/services/htmlPresentationService.test.ts
+++ b/src/services/htmlPresentationService.test.ts
@@ -87,6 +87,32 @@ describe('htmlPresentationService', () => {
     expect(resolveLocalResourcePath('/Users/demo/decks/case.html', '//example.test/a.js')).toBeUndefined();
   });
 
+  it('refuses paths that traverse into sensitive system or credential directories', () => {
+    const base = '/Users/demo/decks/case.html';
+    // Three `..` reach the filesystem root from /Users/demo/decks/, landing in /etc, /var, /private.
+    expect(resolveLocalResourcePath(base, '../../../etc/passwd')).toBeUndefined();
+    expect(resolveLocalResourcePath(base, '../../../private/etc/hosts')).toBeUndefined();
+    expect(resolveLocalResourcePath(base, '../../../var/log/system.log')).toBeUndefined();
+    // Credential folders are refused by segment anywhere in the resolved path.
+    expect(resolveLocalResourcePath(base, '../../../.ssh/id_rsa')).toBeUndefined();
+    expect(resolveLocalResourcePath(base, '../.gnupg/secring.gpg')).toBeUndefined();
+    // Windows base resolving into a sensitive drive folder (3 x `..` keeps the C: drive).
+    expect(
+      resolveLocalResourcePath('C:\\Users\\demo\\docs\\note.md', '..\\..\\..\\Windows\\System32\\config.sys'),
+    ).toBeUndefined();
+  });
+
+  it('still resolves legitimate parent-directory references to ordinary folders', () => {
+    // ../shared/theme.css → /Users/demo/shared/theme.css — not sensitive, allowed.
+    expect(resolveLocalResourcePath('/Users/demo/decks/case.html', '../shared/theme.css')).toBe(
+      '/Users/demo/shared/theme.css',
+    );
+    // Chinese-named parent directory (common for shared 证据/ folders).
+    expect(resolveLocalResourcePath('/Users/demo/decks/case.html', '../证据/photo.webp')).toBe(
+      '/Users/demo/证据/photo.webp',
+    );
+  });
+
   it('inlines same-directory scripts, stylesheets, and images before building the iframe document', async () => {
     const reads = new Map<string, Uint8Array>([
       ['/Users/demo/decks/assets/deck.js', new TextEncoder().encode('window.slide = 2;')],

--- a/src/services/htmlPresentationService.ts
+++ b/src/services/htmlPresentationService.ts
@@ -90,6 +90,43 @@ function normalizePathParts(parts: string[]): string[] {
   return normalized;
 }
 
+/**
+ * Sensitive-path blacklist — stops a maliciously-crafted Markdown / HTML
+ * document from traversing out of the user's document tree to read system
+ * secrets through the Tauri asset protocol (whose scope is the whole `$HOME`).
+ *
+ * Design choice (DEC-098): keep legitimate `../` references working — lawyers
+ * commonly store images in a shared parent `证据/` directory — but refuse any
+ * resolved path that lands inside well-known sensitive system directories or
+ * credential folders. Compared are forward-slash-normalized, lower-cased paths.
+ */
+const SENSITIVE_PATH_PREFIXES = [
+  // Unix system directories
+  '/etc', '/private/etc',
+  '/system', '/system/volumes',
+  '/usr',
+  '/bin', '/sbin',
+  '/var', '/private/var',
+  '/dev',
+  '/proc', '/sys',
+  '/root',
+  '/library/keychains',
+  '/private/var/keychain',
+  // Windows system directories (forward-slash form)
+  'c:/windows', 'c:/$recycle.bin', 'c:/program files', 'c:/program files (x86)', 'c:/programdata',
+];
+
+const SENSITIVE_PATH_SEGMENTS = ['.ssh', '.gnupg', '.aws'];
+
+function isSensitivePath(normalizedPath: string): boolean {
+  const lower = normalizedPath.toLowerCase();
+  for (const prefix of SENSITIVE_PATH_PREFIXES) {
+    if (lower === prefix || lower.startsWith(`${prefix}/`)) return true;
+  }
+  if (lower.split('/').some((segment) => SENSITIVE_PATH_SEGMENTS.includes(segment))) return true;
+  return false;
+}
+
 export function resolveLocalResourcePath(filePath: string | undefined, resourceUrl: string): string | undefined {
   if (!filePath || !isRelativeLocalUrl(resourceUrl)) return undefined;
 
@@ -104,6 +141,13 @@ export function resolveLocalResourcePath(filePath: string | undefined, resourceU
   const hasLeadingSlash = joined.startsWith('/');
   const parts = normalizePathParts(joined.split('/'));
   const normalized = `${hasLeadingSlash ? '/' : ''}${parts.join('/')}`;
+
+  // Path-traversal guard: refuse resolved paths that land inside sensitive
+  // system / credential directories. Ordinary `../` references to normal
+  // directories still resolve (see DEC-098).
+  if (isSensitivePath(normalized)) {
+    return undefined;
+  }
 
   return usesWindowsSeparators ? normalized.replaceAll('/', '\\') : normalized;
 }

--- a/src/services/localImageResolver.test.ts
+++ b/src/services/localImageResolver.test.ts
@@ -120,4 +120,87 @@ describe('resolveLocalImages', () => {
     expect(imgs[2].getAttribute('src')).toContain('/Users/demo/docs/parent.gif');
     expect(imgs[3].getAttribute('src')).toBe('data:image/svg+xml,<svg></svg>');
   });
+
+  it('resolves <source src> relative paths', async () => {
+    const { resolveLocalImages: resolve } = await importFresh();
+    const container = document.createElement('div');
+    const video = document.createElement('video');
+    const source = document.createElement('source');
+    source.setAttribute('src', './clip.mp4');
+    video.appendChild(source);
+    container.appendChild(video);
+    await resolve(container, '/Users/demo/docs/note.md');
+    const src = container.querySelector('source')?.getAttribute('src') ?? '';
+    expect(src).toContain('asset.localhost');
+    expect(src).toContain('/Users/demo/docs/clip.mp4');
+  });
+
+  it('resolves <video poster> relative paths', async () => {
+    const { resolveLocalImages: resolve } = await importFresh();
+    const container = document.createElement('div');
+    const video = document.createElement('video');
+    video.setAttribute('poster', './cover.jpg');
+    container.appendChild(video);
+    await resolve(container, '/Users/demo/docs/note.md');
+    const poster = container.querySelector('video')?.getAttribute('poster') ?? '';
+    expect(poster).toContain('asset.localhost');
+    expect(poster).toContain('/Users/demo/docs/cover.jpg');
+  });
+
+  it('resolves <img srcset> candidates while preserving descriptors', async () => {
+    const { resolveLocalImages: resolve } = await importFresh();
+    const container = document.createElement('div');
+    const img = document.createElement('img');
+    img.setAttribute('srcset', './a.webp 1x, ./b.webp 2x, https://cdn.example/c.webp 3x');
+    container.appendChild(img);
+    await resolve(container, '/Users/demo/docs/note.md');
+    const srcset = container.querySelector('img')?.getAttribute('srcset') ?? '';
+    expect(srcset).toContain('/Users/demo/docs/a.webp');
+    expect(srcset).toContain('1x');
+    expect(srcset).toContain('/Users/demo/docs/b.webp');
+    expect(srcset).toContain('2x');
+    // External URL inside srcset is left untouched.
+    expect(srcset).toContain('https://cdn.example/c.webp');
+    expect(srcset).toContain('3x');
+  });
+
+  it('resolves CSS background-image url() in inline styles', async () => {
+    const { resolveLocalImages: resolve } = await importFresh();
+    const container = document.createElement('div');
+    const el = document.createElement('div');
+    el.setAttribute('style', "background-image: url('./bg.png'); color: red");
+    container.appendChild(el);
+    await resolve(container, '/Users/demo/docs/note.md');
+    const style = container.querySelector('div')?.getAttribute('style') ?? '';
+    expect(style).toContain('asset.localhost');
+    expect(style).toContain('/Users/demo/docs/bg.png');
+    // Unrelated CSS declarations are preserved.
+    expect(style).toContain('color: red');
+  });
+
+  it('resolves CSS url() inside <style> blocks', async () => {
+    const { resolveLocalImages: resolve } = await importFresh();
+    const container = document.createElement('div');
+    const style = document.createElement('style');
+    style.textContent =
+      '.hero { background: url("./hero.jpg") center; } .keep { background: url("https://x/y.png"); }';
+    container.appendChild(style);
+    await resolve(container, '/Users/demo/docs/note.md');
+    const text = container.querySelector('style')?.textContent ?? '';
+    expect(text).toContain('/Users/demo/docs/hero.jpg');
+    expect(text).toContain('asset.localhost');
+    // External URL left untouched.
+    expect(text).toContain('https://x/y.png');
+  });
+
+  it('keeps original src for sensitive path traversal while resolving normal refs', async () => {
+    const { resolveLocalImages: resolve } = await importFresh();
+    const container = createContainerWithImages([{ src: '../../../etc/passwd' }, { src: './ok.png' }]);
+    await resolve(container, '/Users/demo/decks/case.html');
+    const imgs = container.querySelectorAll('img');
+    // Sensitive traversal refused → original src preserved.
+    expect(imgs[0].getAttribute('src')).toBe('../../../etc/passwd');
+    // Normal sibling reference resolved.
+    expect(imgs[1].getAttribute('src')).toContain('/Users/demo/decks/ok.png');
+  });
 });

--- a/src/services/localImageResolver.ts
+++ b/src/services/localImageResolver.ts
@@ -24,15 +24,85 @@ async function ensureConvertFileSrc(): Promise<ConvertFileSrcFn | null> {
 }
 
 /**
- * Resolve local relative image `src` attributes inside a container element
- * so they can be loaded by the Tauri WebView.
+ * `true` if `rawSrc` is an absolute URL, data URI, blob URI, protocol-relative
+ * URL, or hash-only fragment that must be left untouched (not a local relative
+ * path). Also recognises already-converted Tauri asset URLs so the pass is
+ * idempotent.
+ */
+function isExternalOrDataUrl(rawSrc: string): boolean {
+  const value = rawSrc.trim();
+  if (!value) return true;
+  return (
+    value.startsWith('data:') ||
+    value.startsWith('blob:') ||
+    value.startsWith('http://') ||
+    value.startsWith('https://') ||
+    value.startsWith('file://') ||
+    value.startsWith('//') ||
+    value.startsWith('#') ||
+    value.startsWith('asset:') ||
+    value.startsWith('http://asset.localhost') ||
+    value.startsWith('https://asset.localhost')
+  );
+}
+
+/** Resolve a single relative URL to a Tauri asset URL, or `null` if it must be left as-is. */
+function resolveSingleUrl(rawSrc: string, filePath: string, convertFn: ConvertFileSrcFn): string | null {
+  if (isExternalOrDataUrl(rawSrc)) return null;
+  const absolutePath = resolveLocalResourcePath(filePath, rawSrc);
+  if (!absolutePath) return null;
+  return convertFn(absolutePath);
+}
+
+const SRCSET_DESCRIPTOR_PATTERN = /^\d+(\.\d+)?[wx]$/;
+
+/** Resolve every candidate URL inside a `srcset` attribute (`./a.webp 1x, ./b.webp 2x`). */
+function resolveSrcset(raw: string, filePath: string, convertFn: ConvertFileSrcFn): string {
+  return raw
+    .split(',')
+    .map((candidate) => {
+      const trimmed = candidate.trim();
+      if (!trimmed) return '';
+      // A srcset entry is `url [descriptor]` where descriptor is `1x` / `100w`.
+      // Only treat the last token as a descriptor when it matches that shape,
+      // so URLs containing spaces (rare, non-spec) are not mis-split.
+      const lastSpace = trimmed.lastIndexOf(' ');
+      let urlPart = trimmed;
+      let descriptor = '';
+      if (lastSpace > 0 && SRCSET_DESCRIPTOR_PATTERN.test(trimmed.slice(lastSpace + 1))) {
+        urlPart = trimmed.slice(0, lastSpace);
+        descriptor = trimmed.slice(lastSpace + 1);
+      }
+      const resolved = resolveSingleUrl(urlPart, filePath, convertFn);
+      if (resolved === null) return trimmed; // external / traversal-protected — keep original
+      return descriptor ? `${resolved} ${descriptor}` : resolved;
+    })
+    .filter(Boolean)
+    .join(', ');
+}
+
+/** Resolve relative `url(...)` references inside CSS (inline `style` or `<style>` text). */
+function resolveCssUrls(text: string, filePath: string, convertFn: ConvertFileSrcFn): string {
+  return text.replace(/url\(\s*(['"]?)([^'")]+)\1\s*\)/g, (full, _quote, url) => {
+    const resolved = resolveSingleUrl(url, filePath, convertFn);
+    return resolved === null ? full : `url(${resolved})`;
+  });
+}
+
+/**
+ * Resolve local relative media references inside a container element so they
+ * can be loaded by the Tauri WebView.
  *
- * For each `<img>` whose `src` is a relative path (e.g. `./images/photo.webp`),
- * resolve it to an absolute filesystem path based on the currently-open file's
- * directory, then convert it to a Tauri asset URL via `convertFileSrc()`.
+ * Covers `<img src>`, `<source src>`, `<video poster>`, `srcset` candidates
+ * (`<img>` / `<source>`), and CSS `background-image: url(...)` (both inline
+ * `style` attributes and `<style>` blocks). Each relative path is resolved
+ * against the currently-open file's directory, then converted to a Tauri asset
+ * URL via `convertFileSrc()`.
  *
- * This is intentionally idempotent: images whose `src` already starts with
- * `https://asset.localhost` (or any absolute URL) are left untouched.
+ * Idempotent: absolute URLs / data URIs / already-converted asset URLs are
+ * left untouched. Paths that traverse into sensitive directories (see
+ * `isSensitivePath` in `htmlPresentationService`) are refused and the original
+ * attribute is preserved.
  */
 export async function resolveLocalImages(
   container: HTMLElement,
@@ -43,27 +113,41 @@ export async function resolveLocalImages(
   const convertFn = await ensureConvertFileSrc();
   if (!convertFn) return;
 
-  const images = container.querySelectorAll<HTMLImageElement>('img[src]');
-  for (const img of images) {
-    const rawSrc = img.getAttribute('src');
-    if (!rawSrc) continue;
-
-    // Skip URLs that are already absolute / data URIs / hash-only.
-    if (
-      rawSrc.startsWith('data:') ||
-      rawSrc.startsWith('http://') ||
-      rawSrc.startsWith('https://') ||
-      rawSrc.startsWith('file://') ||
-      rawSrc.startsWith('//') ||
-      rawSrc.startsWith('#')
-    ) {
-      continue;
-    }
-
-    const absolutePath = resolveLocalResourcePath(filePath, rawSrc);
-    if (!absolutePath) continue;
-
-    const assetUrl = convertFn(absolutePath);
-    img.src = assetUrl;
+  // Single-attribute media sources: img[src], source[src], video[poster].
+  const singleAttrSelectors: Array<{ selector: string; attr: string }> = [
+    { selector: 'img[src]', attr: 'src' },
+    { selector: 'source[src]', attr: 'src' },
+    { selector: 'video[poster]', attr: 'poster' },
+  ];
+  for (const { selector, attr } of singleAttrSelectors) {
+    container.querySelectorAll(selector).forEach((el) => {
+      const raw = el.getAttribute(attr);
+      if (!raw) return;
+      const resolved = resolveSingleUrl(raw, filePath, convertFn);
+      if (resolved !== null) el.setAttribute(attr, resolved);
+    });
   }
+
+  // srcset candidates: img[srcset], source[srcset].
+  container.querySelectorAll('img[srcset], source[srcset]').forEach((el) => {
+    const raw = el.getAttribute('srcset');
+    if (!raw) return;
+    const resolved = resolveSrcset(raw, filePath, convertFn);
+    if (resolved !== raw) el.setAttribute('srcset', resolved);
+  });
+
+  // CSS background-image: inline `style` attributes containing url(...).
+  container.querySelectorAll<HTMLElement>('[style]').forEach((el) => {
+    const style = el.getAttribute('style');
+    if (!style || !style.includes('url(')) return;
+    const resolved = resolveCssUrls(style, filePath, convertFn);
+    if (resolved !== style) el.setAttribute('style', resolved);
+  });
+
+  // CSS: <style> blocks containing url(...).
+  container.querySelectorAll('style').forEach((styleEl) => {
+    const text = styleEl.textContent;
+    if (!text || !text.includes('url(')) return;
+    styleEl.textContent = resolveCssUrls(text, filePath, convertFn);
+  });
 }

--- a/src/services/tauriCapabilities.test.ts
+++ b/src/services/tauriCapabilities.test.ts
@@ -23,7 +23,9 @@ describe('Tauri capabilities', () => {
     const csp = config.app?.security?.csp ?? '';
 
     expect(csp).toContain("script-src 'self' 'unsafe-eval' 'unsafe-inline'");
-    expect(csp).toContain("img-src 'self' data: file:");
+    // DEC-096: img-src must include asset: / http://asset.localhost so that
+    // convertFileSrc() URLs for local images can load in the WebView.
+    expect(csp).toContain("img-src 'self' asset: http://asset.localhost");
     expect(csp).toContain("frame-src 'self' data: blob:");
     expect(csp).toContain("connect-src 'self'");
   });


### PR DESCRIPTION
## 摘要

ISS-160：本地相对路径资源解析的稳健性补强（参考 horseMD）。

- **越界防护**：`resolveLocalResourcePath` 新增 `isSensitivePath` 黑名单，阻止恶意文档通过相对路径遍历读取系统敏感文件（asset scope 是 `$HOME/**/*`，前端再叠一层防线）。
- **扩展范围**：`resolveLocalImages` 从仅 `<img src>` 扩展到 `<source src>` / `<video poster>` / `img`+`source` 的 `srcset` / CSS `background-image: url(...)`（inline `style` + `<style>` 块）。

## 关键决策（DEC-098）

越界策略采用**「兼容 + 黑名单」**（已与用户确认），而非原始 ISS-160 建议的「严格文件目录及子目录」：
- ✅ 保留合法 `../` 上级引用——律师文档常把图片放共享上级 `证据/` 目录，严格策略会 break 现有文档。
- ❌ 仅拒绝解析后落在 `/etc` `/System` `/var` `/usr` `/bin` `.ssh` `.gnupg` `.aws` `C:\Windows` 等敏感系统/凭据目录的路径。

## 顺手修复

DEC-096 改 CSP `img-src` 加 `asset: http://asset.localhost` 后，`tauriCapabilities.test.ts` 的断言（`img-src 'self' data: file:`）过时未同步，导致 `npm test` 一直有 1 个 pre-existing 失败。本轮更新断言验证 asset 源仍在，全量 288 测试恢复全绿。

## 测试计划

- [x] `npm run typecheck`
- [x] `npm run lint`（0 warning）
- [x] `npm run build`
- [x] `npm test`（288/288，新增 `resolveLocalResourcePath` 越界拒绝 + `resolveLocalImages` 扩展元素单测）
- [ ] 真实 Tauri WebView 眼见为实——待 ISS-161 CDP 端到端框架就绪后复测（现有 e2e 跑 Vite dev server，不连真实 Tauri WebView；`convertFileSrc` 图片加载链路 DEC-096 已实测）

## 风险

- 黑名单若误伤合法路径，图片保留原 src 不显示（用户立即可见）；漏判的安全影响有限（asset scope 已是 `$HOME`，前端黑名单是叠加防线）。
- 回退：还原 `resolveLocalResourcePath` 的 `isSensitivePath` 检查即可恢复旧行为（允许任意 `../`）。

Refs: ISS-160（项目本地任务）