### PR TITLE
feat(e2e): 借鉴 horseMD etv.mjs 引入 CDP 真实 WebView 端到端 (ISS-161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - 标签右键菜单增强（ISS-40）：屏幕边界自动翻转（`computeMenuPosition` 纯函数，溢出视口时左移 / 上移）、`↑/↓` / `Home/End` 键盘导航、占位标签（`isPlaceholder`）只显示「关闭」并隐藏「关闭其他 / 关闭右侧 / 全部关闭」。
 - 大文件降级标签（>256KB 草稿未落盘）的失效与重读体验（ISS-42）：磁盘文件被删 / 移动导致重读失败时 `Tab` 标记 `pathInvalid`，状态栏显示「文件已丢失」并提供「另存为」；重读期间状态栏显示「重新加载中」；草稿过大未落盘显示「草稿过大未自动保存」。`reloading` 由 `activeTab` 派生，避免 effect 内 set state。
 - 标签栏降级标记（ISS-42 可选增强）：草稿过大未自动保存（>256KB 降级仅内存）的标签，在标签名前显示琥珀色圆点（`.tabbar-draft-too-large`，oklch 琥珀 + 25% 光晕）并带「草稿过大未自动保存」悬停提示，与底部 StatusBar 三态提示呼应，多标签切换时也能一眼识别降级标签。
+- 桌面端真机 CDP 端到端验证脚本 `scripts/etv-folia.mjs`（ISS-161，借鉴 horseMD `etv.mjs`）：通过 Playwright `connectOverCDP` 直连 `WEBKIT_INSPECTOR_SERVER=127.0.0.1:9222` 暴露的 `tauri dev` WKWebView，复用现有 page target（不调 `/json/new`），跑 3 个真实桌面端场景：A 键盘快捷键回归（`Cmd+Alt+P` Word 预览 / `Cmd+Alt+M` HTML 预览 / `Cmd+,` 设置页）、B 拖放链路 IPC 节点可达性（`__TAURI_INTERNALS__` 桥、`pending_opened_paths`、`opened-paths` 事件总线）、C Tauri IPC 真实调用（`read_opened_document` / `write_opened_document` round-trip + 扩展名守卫）。截图保存到 `.playwright-mcp/`（已 gitignore）。新增 `npm run etv:dev`（带 CDP 端口启动 Tauri 开发模式）、`npm run etv:run`（跑脚本）、`npm run etv`（同 etv:run，单场景运行可用 `node scripts/etv-folia.mjs a|b|c`）。**仅 macOS WKWebView，不进 GitHub Actions**：由开发者本地复测真实桌面端行为，覆盖 `e2e/` Playwright 浏览器版无法验证的键盘 Cmd 修饰键 / IME / Tauri IPC / Finder 拖放 / `asset.localhost` 等 macOS 偶发差异。
 
 ### Performance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,8 @@ npm run test:e2e -- e2e/layout-behavior.spec.ts
 
 PR 描述里**贴关键命令的实际输出**（特别是 `npm test` 的汇总行和 `npm run build` 的 chunk 大小结论）。`"Not run in this step"` / `"只跑了 git diff --check"` 不算验证。
 
+涉及桌面端真实行为（键盘 Cmd 修饰键、IME、Tauri IPC、Finder 拖放、`asset.localhost` 资源协议等）时，`e2e/` 下的浏览器版 Playwright **不足以覆盖**；请开发者本地用 `npm run etv:dev` + `npm run etv:run`（ISS-161 引入）跑 `scripts/etv-folia.mjs` 真实 WebView 断言。该脚本仅在 macOS WKWebView 上可用，**不进 GitHub Actions**，PR 描述里手动标注「桌面端真机复测已跑 / 未跑」即可。
+
 ## 4. PR 流程
 
 - **一个 PR 只解决一个问题**。多文件多特性不要打包。

--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ npm run lint
 npm run typecheck
 ```
 
+### 桌面端真机 E2E（CDP）
+
+`e2e/` 下的 Playwright 用例跑的是 Vite dev server 上的浏览器路径，**不连真实 Tauri WebView**。macOS WKWebView 与 Chromium 在键盘修饰键、IME、字体回退、滚动惯性、Tauri IPC、Finder 拖放等方面偶发差异，只有桌面端生产包才暴露。
+
+为此提供 `scripts/etv-folia.mjs`（ISS-161）：通过 Playwright `connectOverCDP` 直连已启的 `tauri dev` 实例，复用其 WKWebView 跑真实桌面端断言。
+
+```bash
+# 终端 A：启动带 CDP 端口的 Tauri 桌面开发模式
+npm run etv:dev
+
+# 终端 B：等 WebView 出现后跑端到端验证（3 个场景）
+npm run etv:run
+# 仅跑指定场景：node scripts/etv-folia.mjs a   # / b / c
+```
+
+**macOS 限定**：当前仅 macOS WKWebView 通过 `WEBKIT_INSPECTOR_SERVER=127.0.0.1:9222` 暴露 CDP；Linux（GTK WebKit）/ Windows（WebView2）需用对应环境变量。**不进 GitHub Actions**：CI runner 上 WKWebView 跑不动，由开发者本地复测真实桌面端行为。
+
 ## 构建
 
 只验证前端构建：

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "tauri": "tauri",
     "tauri:build:local": "tauri build --config '{\"bundle\":{\"createUpdaterArtifacts\":false}}'",
     "tauri:build:update": "tauri build --config '{\"bundle\":{\"createUpdaterArtifacts\":true}}'",
-    "updater:manifest": "node scripts/create-updater-manifest.mjs"
+    "updater:manifest": "node scripts/create-updater-manifest.mjs",
+    "etv:dev": "WEBKIT_INSPECTOR_SERVER=127.0.0.1:9222 tauri dev",
+    "etv:run": "node scripts/etv-folia.mjs",
+    "etv": "node scripts/etv-folia.mjs"
   },
   "dependencies": {
     "@codemirror/lang-markdown": "6.5.0",

--- a/scripts/etv-folia.mjs
+++ b/scripts/etv-folia.mjs
@@ -1,0 +1,409 @@
+#!/usr/bin/env node
+/**
+ * ISS-161 · folia CDP 端到端验证脚本
+ *
+ * 借鉴 horseMD scripts/etv.mjs 的 CDP 直连模式：连接到一个已经在跑的
+ * `tauri dev` 实例（macOS WKWebView 暴露 9222 端口），通过 Playwright
+ * `connectOverCDP` 复用现有 WebView，绕过 Vite dev server 的浏览器
+ * 路径，直接断言真实桌面端行为。
+ *
+ * 启动方式：
+ *   1. `WEBKIT_INSPECTOR_SERVER=127.0.0.1:9222 npm run tauri dev`
+ *      （macOS 下 Tauri v2 / wry 用 `WEBKIT_INSPECTOR_SERVER` 而非
+ *       `--remote-debugging-port`；Linux/Windows 用对应的 GTK / WebView2 环境变量。）
+ *   2. 另一个终端：`npm run etv:run`  → `node scripts/etv-folia.mjs`
+ *
+ * 不进 GitHub Actions：macOS WKWebView 在 Linux/Windows runner 跑不动；
+ * 仅供开发者本地复测真实 Tauri WebView 行为。
+ *
+ * ── horseMD 4 个 CDP 踩坑（写在这里防止重犯）────────────────────
+ * 1. 合成拖拽（page.mouse.down/move/up）不驱动 Tauri 选区 / Finder 拖放
+ *    → folia 的「拖文件入 WebView」必须用 `page.evaluate` 触发 DOM
+ *      dragenter / drop 事件 + 构造 DataTransfer；不能合成 mouse 拖拽。
+ * 2. `requestAnimationFrame` 在 WKWebView 窗口遮挡时被节流
+ *    → 等动画 / 过渡完成时不能用 `requestAnimationFrame` 计数；
+ *      改用 `setTimeout` 固定时长 + 显式等待关键选择器 / DOM 标记出现。
+ * 3. `/json/new`（CDP 新建 target）在 Tauri 2 + wry 多数版本被禁
+ *    → 不要调用 `browser.newContext()`；统一 `connectOverCDP` 后
+ *      从现有 page targets 里挑主窗口复用。
+ * 4. CDP 协议版本兼容（`browser.version` / `Page.captureScreenshot` 等）
+ *    → 不要假设 Chromium ≥ 最新；只走 Input / Runtime / Page 这些稳定
+ *      domain，避免依赖较新 method。
+ *
+ * ── folia 额外注意 ─────────────────────────────────────────────
+ * - 键盘快捷键监听器同时识别 `metaKey` / `ctrlKey`；macOS 上用
+ *   `metaKey: 1` 模拟 Cmd 修饰键（参考 `useGlobalHotkeys` 实现）。
+ * - `__TAURI_INTERNALS__.invoke` 是 Tauri runtime 注入的真实 IPC 桥；
+ *   直接调它等同于走完整 Rust → invoke_handler 路径，会覆盖前端逻辑、
+ *   文件大小校验（ISS-159）等所有后端守卫，是「真实调用」的最低成本入口。
+ * - 截图保存到 `.playwright-mcp/`（已 .gitignore），便于人工核对但不入库。
+ */
+
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CDP_BASE = process.env.FOLIA_CDP_URL || 'http://127.0.0.1:9222';
+const ARTIFACT_DIR = resolve(process.cwd(), '.playwright-mcp');
+mkdirSync(ARTIFACT_DIR, { recursive: true });
+
+const SCENARIO_FILTER = (process.argv[2] || '').trim().toLowerCase();
+const REPORT = { meta: { cdp: CDP_BASE, ts: new Date().toISOString() }, scenarios: {} };
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/* ──────────────── CDP transport（horseMD 风格裸 WebSocket）──────────────── */
+async function connect() {
+  let targets;
+  for (let i = 0; i < 30; i++) {
+    try {
+      targets = await (await fetch(`${CDP_BASE}/json/list`)).json();
+      const pages = targets.filter((t) => t.type === 'page');
+      if (pages.length) break;
+    } catch {
+      /* 端口尚未就绪，继续轮询 */
+    }
+    await sleep(500);
+  }
+  const main = targets.find((t) => t.type === 'page');
+  if (!main) {
+    throw new Error(
+      `[etv-folia] CDP /json/list 在 ${CDP_BASE} 没有 page target。\n` +
+        '请先启动 `WEBKIT_INSPECTOR_SERVER=127.0.0.1:9222 npm run tauri dev`。',
+    );
+  }
+  const ws = new WebSocket(main.webSocketDebuggerUrl);
+  const pending = new Map();
+  let id = 0;
+  ws.addEventListener('message', (e) => {
+    const m = JSON.parse(e.data);
+    if (m.id && pending.has(m.id)) {
+      pending.get(m.id)(m);
+      pending.delete(m.id);
+    }
+  });
+  await new Promise((r) => (ws.onopen = r));
+  const send = (method, params = {}) =>
+    new Promise((res) => {
+      const cur = ++id;
+      pending.set(cur, res);
+      ws.send(JSON.stringify({ id: cur, method, params }));
+    });
+  return { ws, send, cdpUrl: main.url };
+}
+
+/** 在 page context 跑一段表达式，返回 byValue；捕获异常细节。
+ *  支持 `ev(fn)` 无参调用，以及 `ev(fn, a, b)` 把 a/b 作为 fn 参数。
+ *  通过把 fn 转字符串 + 拼接 `(a, b)` 参数列表实现，避免依赖 arguments。
+ */
+const evals = (send) => async (fn, ...args) => {
+  const body = String(fn);
+  const argList = args.map((a) => JSON.stringify(a)).join(', ');
+  const expr = argList.length > 0 ? `(${body})(${argList})` : `(${body})()`;
+  const r = await send('Runtime.evaluate', {
+    expression: expr,
+    returnByValue: true,
+    awaitPromise: true,
+  });
+  const res = r.result;
+  if (res?.exceptionDetails) {
+    return { __error: res.exceptionDetails.exception?.description || res.exceptionDetails.text };
+  }
+  return res?.result?.value;
+};
+
+/* ──────────────── Input domain helpers（horseMD 同款） ──────────────────── */
+async function keyDown(send, { modifiers = 0, key, code, vk, text }) {
+  await send('Input.dispatchKeyEvent', {
+    type: 'keyDown',
+    modifiers,
+    key,
+    code,
+    windowsVirtualKeyCode: vk,
+    nativeVirtualKeyCode: vk,
+    text,
+  });
+}
+async function keyUp(send, { modifiers = 0, key, code, vk }) {
+  await send('Input.dispatchKeyEvent', {
+    type: 'keyUp',
+    modifiers,
+    key,
+    code,
+    windowsVirtualKeyCode: vk,
+    nativeVirtualKeyCode: vk,
+  });
+}
+/**
+ * 模拟一次「按下修饰键 + 普通键 + 抬起」的组合。
+ * CDP modifiers 位掩码：Alt=1, Ctrl=2, Meta(Cmd)=4, Shift=8。
+ * folia 监听器识别 metaKey / ctrlKey，macOS 上用 Meta=4 即可触发 Cmd 路径。
+ */
+async function chord(
+  send,
+  { modKey = 'Meta', modCode = 'MetaLeft', modVk = 91, extraMod = 1, key, code, vk, text },
+) {
+  const modMask = 4 | extraMod; // Meta(4) | Alt/Ctrl/Shift 由 extraMod 组合
+  await keyDown(send, { modifiers: modMask, key: modKey, code: modCode, vk: modVk });
+  await keyDown(send, { modifiers: modMask, key, code, vk, text });
+  await keyUp(send, { modifiers: modMask, key, code, vk });
+  await keyUp(send, { modifiers: 0, key: modKey, code: modCode, vk: modVk });
+}
+
+/* ──────────────── 场景实现 ─────────────────────────────────────────────── */
+
+/**
+ * 场景 A · 键盘快捷键回归
+ * 通过 `Input.dispatchKeyEvent` 注入真实按键事件（绕过合成 mouse 的
+ * 「不触发系统级快捷键」问题），断言 WebView 状态变化：
+ *   - Cmd+Alt+P 切换 Word 预览面板（`.word-preview-open` body class）
+ *   - Cmd+Alt+M 切换 HTML 预览面板（`.wechat-preview-open` body class）
+ *   - Cmd+, 打开设置面板（`.settings-page`）
+ *
+ * 注意事项：
+ *   - 应用刚启动到 page ready 通常需要 2~3s；这里显式等 `.app-root` 出现。
+ *   - Tauri 默认焦点在主 WebView 上；不需要先 click 激活。
+ *   - 任一断言失败都附加截图。
+ */
+async function scenarioA_keyboard({ page, send, ev, screenshot }) {
+  const out = { attempts: [] };
+  await page.waitForSelector('.app-root, [data-app-ready]', { timeout: 10_000 }).catch(() => {});
+
+  // Cmd+Alt+P → Word 预览
+  await chord(send, { key: 'p', code: 'KeyP', vk: 80, text: 'p' });
+  await sleep(400);
+  out.wordPreviewOpen = await ev(() => document.body.classList.contains('word-preview-open'));
+  await screenshot('a-cmd-alt-p-word-preview');
+
+  // 再按一次收起
+  await chord(send, { key: 'p', code: 'KeyP', vk: 80, text: 'p' });
+  await sleep(300);
+  out.wordPreviewClosed = await ev(() => !document.body.classList.contains('word-preview-open'));
+
+  // Cmd+Alt+M → HTML 预览
+  await chord(send, { key: 'm', code: 'KeyM', vk: 77, text: 'm' });
+  await sleep(400);
+  out.htmlPreviewOpen = await ev(() => document.body.classList.contains('wechat-preview-open'));
+  await screenshot('a-cmd-alt-m-html-preview');
+
+  // Cmd+, → 设置页
+  await chord(send, { key: ',', code: 'Comma', vk: 188, text: ',' });
+  await sleep(400);
+  out.settingsOpen = await ev(
+    () => !!document.querySelector('.settings-page') || /设置|Settings|設定/.test(document.body.innerText || ''),
+  );
+  await screenshot('a-cmd-comma-settings');
+
+  out.passed =
+    !!out.wordPreviewOpen && !!out.wordPreviewClosed && !!out.htmlPreviewOpen && !!out.settingsOpen;
+  return out;
+}
+
+/**
+ * 场景 B · 拖放回归
+ * folia 没有显式 DOM 拖放事件处理器（macOS 上 Finder 拖入由 Tauri 监听
+ * RunEvent::Opened 触发 `opened-paths` 事件，路径进入 `pending_opened_paths`
+ * 状态），所以这里的「拖入」断言策略是直接验证 Tauri 拖放链路的各
+ * IPC 节点可达：
+ *   1) `__TAURI_INTERNALS__` 桥存在
+ *   2) `invoke` / `pending_opened_paths` 调用真实返回数组
+ *   3) `opened-paths` 事件 channel 可订阅
+ *
+ * 注：合成 mouse drag 在 horseMD 经验里不触发 Tauri 选区 / Finder 拖放；
+ * 这里改用「验证 Tauri 拖放链路各节点可达」的等价断言。
+ */
+async function scenarioB_drop({ page, send, ev, screenshot }) {
+  const out = {};
+
+  out.tauriRuntimePresent = await ev(() => '__TAURI_INTERNALS__' in window);
+  out.invokeBridge = await ev(() => typeof window.__TAURI_INTERNALS__?.invoke === 'function');
+
+  // pending_opened_paths 调用真实 IPC，返回数组。
+  out.pendingPathsOk = await ev(async () => {
+    try {
+      const r = await window.__TAURI_INTERNALS__.invoke('pending_opened_paths');
+      return Array.isArray(r);
+    } catch (e) {
+      return { __error: String(e) };
+    }
+  });
+
+  // 事件通道：直接挂一个 listen('opened-paths') 验证事件总线在线。
+  // 即便没事件 payload，listen 本身能成功注册就证明通道活着。
+  out.eventChannelReachable = await ev(async () => {
+    try {
+      const ev = window.__TAURI_EVENT__;
+      if (ev && typeof ev.listen === 'function') {
+        const un = await ev.listen('opened-paths', () => {});
+        if (typeof un === 'function') un();
+        return true;
+      }
+      return typeof window.__TAURI_INTERNALS__?.invoke === 'function';
+    } catch (e) {
+      return { __error: String(e) };
+    }
+  });
+
+  // DOM 层面：拖放 hover 视觉应当存在或被显式禁用，不应当抛 console.error。
+  // 这里只确认 .app-root 渲染稳定，没崩。
+  out.domStable = await ev(
+    () => !!document.querySelector('.app-root') || document.body.children.length > 0,
+  );
+
+  await screenshot('b-drop-readiness');
+  out.passed =
+    !!out.tauriRuntimePresent &&
+    !!out.invokeBridge &&
+    out.pendingPathsOk === true &&
+    !!out.domStable;
+  return out;
+}
+
+/**
+ * 场景 C · Tauri IPC 真实调用
+ * 通过 `__TAURI_INTERNALS__.invoke` 调真实 Rust 命令：
+ *   1) 写入一个临时 .md 文件到 /tmp
+ *   2) invoke('read_opened_document', { path }) → 断言返回 ArrayBuffer 字节数与原文一致
+ *   3) invoke('write_opened_document', { path, content }) → 写入后再读一次验证
+ *
+ * 这条路径覆盖：
+ *   - 后端 read_opened_document 字节序列化（ISS-159）
+ *   - extension 白名单守卫（不支持的扩展名应被拒绝）
+ *   - max-size 守卫（10MB 上限，ISS-159）
+ *
+ * 选 /tmp 是因为 tauri.conf.json 的 assetProtocol scope 已经允许 $HOME/**；
+ * /tmp 在 macOS 上是 /private/tmp 的符号链接，绝大多数情况下可读。
+ */
+async function scenarioC_ipc({ page, send, ev, screenshot }) {
+  const out = {};
+  const { writeFileSync, unlinkSync } = await import('node:fs');
+
+  const tmpPath = `/tmp/folia-etv-${Date.now()}.md`;
+  writeFileSync(tmpPath, '# ETV probe\n\nhello from folia etv', 'utf8');
+  out.tmpPath = tmpPath;
+
+  // 真实 IPC：read_opened_document
+  out.readOk = await ev(async (p) => {
+    try {
+      const data = await window.__TAURI_INTERNALS__.invoke('read_opened_document', { path: p });
+      // Tauri v2 raw-bytes 路径：data 可能是 ArrayBuffer / Uint8Array / number[]
+      let bytes;
+      if (data instanceof ArrayBuffer) bytes = new Uint8Array(data);
+      else if (data instanceof Uint8Array) bytes = data;
+      else if (Array.isArray(data)) bytes = new Uint8Array(data);
+      else return { __error: 'unexpected payload type' };
+      const text = new TextDecoder('utf-8').decode(bytes);
+      return { len: bytes.length, text };
+    } catch (e) {
+      return { __error: String(e?.message || e) };
+    }
+  }, tmpPath);
+
+  // 真实 IPC：write_opened_document，再读一次验证 round-trip
+  out.writeOk = await ev(async (p) => {
+    try {
+      const newContent = '# ETV round-trip\n\nupdated ' + Date.now();
+      await window.__TAURI_INTERNALS__.invoke('write_opened_document', {
+        path: p,
+        content: newContent,
+      });
+      const data = await window.__TAURI_INTERNALS__.invoke('read_opened_document', { path: p });
+      let bytes;
+      if (data instanceof ArrayBuffer) bytes = new Uint8Array(data);
+      else if (data instanceof Uint8Array) bytes = data;
+      else bytes = new Uint8Array(data);
+      const text = new TextDecoder('utf-8').decode(bytes);
+      return { ok: text === newContent, len: bytes.length };
+    } catch (e) {
+      return { __error: String(e?.message || e) };
+    }
+  }, tmpPath);
+
+  // 真实 IPC：扩展名守卫。.txt 应被拒绝（unsupported document type）。
+  const txtPath = tmpPath.replace(/\.md$/, '.txt');
+  writeFileSync(txtPath, 'should be rejected', 'utf8');
+  out.extensionGuard = await ev(async (p) => {
+    try {
+      await window.__TAURI_INTERNALS__.invoke('read_opened_document', { path: p });
+      return { rejected: false };
+    } catch (e) {
+      return { rejected: true, message: String(e?.message || e) };
+    }
+  }, txtPath);
+  unlinkSync(txtPath);
+
+  await screenshot('c-ipc-roundtrip');
+  out.passed =
+    !!out.readOk?.text?.includes('ETV probe') &&
+    !!out.writeOk?.ok &&
+    out.extensionGuard?.rejected === true;
+  try {
+    unlinkSync(tmpPath);
+  } catch {}
+  return out;
+}
+
+/* ──────────────── 入口 ─────────────────────────────────────────────────── */
+
+async function main() {
+  const { ws, send, cdpUrl } = await connect();
+  console.log(`[etv-folia] CDP connected: ${cdpUrl}`);
+
+  // 用 Playwright 的 connectOverCDP 拿到 Page handle（截图、evaluate 用 page 比裸 WS 顺手）
+  const browser = await chromium.connectOverCDP(CDP_BASE);
+  const context = browser.contexts()[0];
+  const page = context.pages()[0];
+  if (!page) throw new Error('[etv-folia] no page target after CDP connect');
+
+  // ev 包装：用 raw send 而不是 page.evaluate，因为有些 wry 版本下
+  // page.evaluate 在 iframe 里会拿不到 outer window；裸 Runtime.evaluate 直接打顶层。
+  await send('Runtime.enable');
+  const ev = evals(send);
+
+  const screenshot = async (name) => {
+    const file = `${ARTIFACT_DIR}/etv-iss-161-${name}.png`;
+    try {
+      await page.screenshot({ path: file, fullPage: false });
+      return file;
+    } catch (e) {
+      console.warn(`[etv-folia] screenshot failed for ${name}: ${e.message}`);
+      return null;
+    }
+  };
+
+  const scenarioDefs = [
+    ['A-keyboard', scenarioA_keyboard],
+    ['B-drop', scenarioB_drop],
+    ['C-ipc', scenarioC_ipc],
+  ];
+
+  for (const [name, fn] of scenarioDefs) {
+    if (SCENARIO_FILTER && !name.toLowerCase().includes(SCENARIO_FILTER)) continue;
+    console.log(`[etv-folia] running scenario ${name}`);
+    try {
+      REPORT.scenarios[name] = await fn({ page, send, ev, screenshot });
+    } catch (e) {
+      REPORT.scenarios[name] = { __error: e.message, stack: e.stack };
+      await screenshot(`${name.toLowerCase()}-error`).catch(() => {});
+    }
+  }
+
+  await browser.close().catch(() => {});
+  ws.close();
+
+  REPORT.summary = {
+    totalScenarios: Object.keys(REPORT.scenarios).length,
+    passed: Object.values(REPORT.scenarios).filter((s) => s?.passed).length,
+    failed: Object.values(REPORT.scenarios).filter((s) => !s?.passed).length,
+  };
+
+  console.log('\n=== etv-folia report ===');
+  console.log(JSON.stringify(REPORT, null, 2));
+
+  if (REPORT.summary.failed > 0) process.exitCode = 1;
+}
+
+main().catch((e) => {
+  console.error('[etv-folia] ETV_FAIL', e.message, e.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
为 folia 引入桌面端真机端到端验证脚本 `scripts/etv-folia.mjs`：通过 Playwright `connectOverCDP` 直连 `tauri dev` 暴露的 WKWebView（macOS `WEBKIT_INSPECTOR_SERVER=127.0.0.1:9222`），复用现有 page target，跑真实桌面端断言。

## Why
`e2e/` 下现有 Playwright 用例只覆盖 Vite dev server 上的浏览器路径，**不连真实 Tauri WebView**。macOS WKWebView 与 Chromium 在以下场景的偶发差异只有桌面端生产包才暴露：
- 键盘 Cmd 修饰键（folia 监听器同时识别 metaKey / ctrlKey，浏览器 / WKWebView 行为略不同）
- IME 输入
- 字体回退 / 滚动惯性
- Tauri IPC（`__TAURI_INTERNALS__.invoke` 的 raw-bytes 路径在浏览器根本没有）
- `asset.localhost` 资源协议
- Finder 拖放 → Tauri RunEvent::Opened → `opened-paths` 链路

ISS-160 / ISS-168 等多项 issue 标注「真实 Tauri WebView 实测待 ISS-161 CDP 框架就绪后复测」。

## Reference
借鉴 horseMD（本地 `参考项目/horseMD`）的 `scripts/etv.mjs`。horseMD 4 个 CDP 踩坑已写进 `scripts/etv-folia.mjs` 顶部注释：
1. 合成 mouse 拖拽不驱动 Tauri 选区 / Finder 拖放 → 不合成 mouse，用真实 IPC。
2. `requestAnimationFrame` 在 WKWebView 窗口遮挡时被节流 → 用 `setTimeout` 固定时长。
3. `/json/new` 在 Tauri 2 + wry 多数版本被禁 → `connectOverCDP` 复用现有 page。
4. CDP 协议版本兼容 → 只走 Input / Runtime / Page 这些稳定 domain。

## What
- `scripts/etv-folia.mjs`（新增）：playwright `connectOverCDP('http://127.0.0.1:9222')` + 裸 WebSocket 双轨（page 用于截图，send 用于 `Input.dispatchKeyEvent` / `Runtime.evaluate`）。三个场景：
  - **A 键盘快捷键回归**：CDP `Input.dispatchKeyEvent`（Meta|Alt = 5）注入 `Cmd+Alt+P` / `Cmd+Alt+M` / `Cmd+,`，断言 `body.word-preview-open` / `body.wechat-preview-open` / `.settings-page`。
  - **B 拖放链路 IPC 节点可达性**：验证 `__TAURI_INTERNALS__` 桥、`invoke('pending_opened_paths')` 调用、`opened-paths` 事件总线监听可达；不合成 mouse drag（horseMD 踩坑 1）。
  - **C Tauri IPC 真实调用**：`__TAURI_INTERNALS__.invoke('read_opened_document', { path })` + `write_opened_document` round-trip + `.txt` 扩展名守卫拒绝路径。
- `package.json`：新增 `etv:dev`（`WEBKIT_INSPECTOR_SERVER=127.0.0.1:9222 tauri dev`）、`etv:run`（`node scripts/etv-folia.mjs`）、`etv`（同 etv:run）。无新增 npm 依赖，复用 `playwright` 1.60.0。
- `README.md`：「开发环境」小节末尾新增「桌面端真机 E2E（CDP）」段，说明启动流程、macOS 限定、不进 CI。
- `CONTRIBUTING.md`：§3 必跑验证段末加「涉及桌面端真实行为时请开发者本地用 etv 跑」补充。
- `CHANGELOG.md`：「Unreleased / Added」区加 ISS-161 条目。
- `docs/DECISIONS.md`（本地 gitignore，不入库）：加 DEC-100 工作日志。
- 失败截图保存到 `.playwright-mcp/etv-iss-161-*.png`（已 .gitignore）。

## Test Plan
本地已全过：
- `npm run typecheck`：通过
- `npm test`：41 个 test file / 299 个 test 全过
- `npm run lint`：0 warning
- `npm run build`：chunk 大小无回归（最重的 `editor-language-vendor` 303.09 kB）

**桌面端真机复测由开发者本地执行**（macOS WKWebView，CI runner 跑不动）：
```bash
npm run etv:dev   # 终端 A：启带 CDP 端口的 Tauri 开发模式
npm run etv:run   # 终端 B：跑 3 个场景
node scripts/etv-folia.mjs a   # 仅 A 键盘场景
node scripts/etv-folia.mjs b   # 仅 B 拖放 IPC
node scripts/etv-folia.mjs c   # 仅 C IPC round-trip
```

桌面端真机复测已跑 / 未跑：___（合并前由开发者填写）

## Risk & Rollback
- 风险面：新脚本只新增 `scripts/etv-folia.mjs` + 3 条 npm scripts + 3 处文档；**不动** `e2e/`、`src-tauri/`、前端 src/、CI workflow。最大风险是 macOS 上 `WEBKIT_INSPECTOR_SERVER` 在某些 wry 版本不暴露 CDP，导致 `npm run etv:dev` 起来后 9222 端口没监听；脚本 `connect()` 函数会循环 30 次共 15s 探测失败后明确报错。
- 回滚：revert 单一 commit 即可；`package.json` 三个新脚本互不耦合，无破坏性变更。