### PR TITLE
feat(watch): 文件监听安全模式（Rust notify + 黑名单 + 前端 watch:changed）(ISS-162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- 文件外部改动监听安全模式（ISS-162）：Rust 后端基于 `notify = "6"`（实际解析到 6.1.1）实现 `watch_path` / `unwatch_path` Tauri command，监听句柄存 `AppState` 全局 HashMap；前端 `src/services/fileWatchService.ts` 订阅 `watch:changed` / `watch:error` 事件，监听失败不 panic，统一通过 `app.emit("watch:error", ...)` 上抛。**安全防御**（借鉴 horseMD `src/main/index.js` 系统级防护）：`validate_watch_path` 拒绝相对路径、命中系统根黑名单（`/` `/dev` `/etc` `/system` `/system/volumes` `C:\Windows` `C:\$Recycle.Bin`，大小写不敏感、跨平台分隔符统一）、不存在路径；macOS HFS+/APFS 与 Windows NTFS 默认大小写不敏感场景统一做 `to_ascii_lowercase` 处理。**资源回收**：`unwatch_path` 幂等（已取消 / 黑名单 / 不存在路径均返回 Ok，便于关 tab 时无脑 unwatch）；重复监听同路径直接覆盖不泄漏句柄；`last_event` 时间戳为 atomic-replace 轮询补 `notify` 漏事件预留去重点。事件载荷 `{ path, kind: "modify" | "create" | "remove" }` 复用 ISS-043 `pathInvalid` 概念，前端可基于路径匹配活跃 tab 提示「文件已外部修改」。`src-tauri/src/lib.rs` 新增 13 个 Rust 单测覆盖黑名单、相对路径、大小写不敏感、100 次 watch/unwatch 不泄漏、`last_event` 时间戳推进。
 - 最近文件首页支持删除单个记录与清空全部（ISS-167）：每条最近文件右侧加「×」移除按钮（hover 变红），列表标题区加「清空最近」按钮（点击弹原生确认对话框防误操作）。`sessionReducer` 新增 `removeRecentFile` / `clearRecentFiles` action，`useSession` 暴露对应方法，删除 / 清空随会话持久化。
 - 标签右键菜单增强（ISS-40）：屏幕边界自动翻转（`computeMenuPosition` 纯函数，溢出视口时左移 / 上移）、`↑/↓` / `Home/End` 键盘导航、占位标签（`isPlaceholder`）只显示「关闭」并隐藏「关闭其他 / 关闭右侧 / 全部关闭」。
 - 大文件降级标签（>256KB 草稿未落盘）的失效与重读体验（ISS-42）：磁盘文件被删 / 移动导致重读失败时 `Tab` 标记 `pathInvalid`，状态栏显示「文件已丢失」并提供「另存为」；重读期间状态栏显示「重新加载中」；草稿过大未落盘显示「草稿过大未自动保存」。`reloading` 由 `activeTab` 派生，避免 effect 内 set state。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,6 +122,7 @@ word/table-handler.ts 输出 docx Table；Markdown 管道表格使用专用 pars
 | 文件 | 职责 |
 |------|------|
 | `fileService.ts` | 封装 Tauri dialog、桌面端后端文档读写命令与浏览器 fallback，提供 openFile / saveFile / saveFileAs |
+| `fileWatchService.ts` | 订阅 Rust `watch_path` 监听层 emit 的 `watch:changed` / `watch:error` 事件，懒加载 Tauri event listener、解析载荷并分发给前端监听器；非 Tauri 运行时（浏览器 / 测试）自动 no-op（ISS-162） |
 | `fileDrop.ts` | 过滤可拖入打开的 Markdown / HTML / Word 文件路径 |
 | `documentViewMode.ts` | 内部判断文档是否默认应使用稳定 HTML 阅读预览，避免复杂 HTML table 被 WYSIWYG 压窄或破坏；用户手动退出由 AppLayout 的当前文档状态处理（ISS-155 落地后该判断仅在保留的 `htmlPresentationVisible` 路径下消费，默认渲染已统一为 WYSIWYG） |
 | `htmlTableModel.ts` | 将单个原生 HTML table 解析为共享结构模型，保留行列坐标、合并单元格、section、单元格 HTML/文本与属性 |
@@ -218,3 +219,16 @@ word/table-handler.ts 输出 docx Table；Markdown 管道表格使用专用 pars
 - macOS 标题栏：`titleBarStyle: Overlay` + `hiddenTitle: true`，系统红黄绿按钮覆盖在 WebView 顶部，前端 Toolbar 预留左侧空间；中间空白和居中文件标题使用 `data-tauri-drag-region`，整条 Toolbar 提供 JS `startDragging()` fallback；双击空白区域调用 `toggleMaximize()`；不使用 Electron 风格 `-webkit-app-region`
 - CSP：`default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: file:; font-src 'self' file:; connect-src 'self'; media-src 'self' file:; frame-src 'self' data: blob:`。HTML 演示模式的同目录 JS / CSS / 图片优先内联到 iframe 文档；`file:` 仅作为图片、字体和媒体资源兜底，外部网络连接仍由 `connect-src 'self'` 默认阻断。
 - 插件权限：dialog:allow-open, dialog:allow-save, fs:allow-read-text-file, fs:allow-read-file, fs:allow-write-text-file, fs:allow-write-file, updater:default, process:allow-restart, core:window:allow-set-title, core:window:allow-start-dragging, core:window:allow-toggle-maximize
+
+## 文件监听层（ISS-162）
+
+- **职责**：检测用户打开的文件 / 目录在外部被修改 / 删除，向前端 emit 事件，提示用户「文件已外部修改」并复用 ISS-043 `pathInvalid` 概念决定是否走「重新加载 / 另存为」流程。
+- **后端（`src-tauri/src/lib.rs`）**：
+  - 新增 `watch_path(path)` / `unwatch_path(path)` Tauri command。监听句柄存 `AppState`（`tauri::State<Mutex<HashMap<PathBuf, WatchEntry>>>`），句柄常驻直到 `unwatch_path` 或 app 关闭。
+  - **安全防御**（借鉴 horseMD `src/main/index.js` 系统级 chokidar 配置）：`validate_watch_path` 拒绝相对路径、命中系统根黑名单（`/` `/dev` `/etc` `/system` `/system/volumes` `C:\Windows` `C:\$Recycle.Bin`，大小写不敏感、跨平台分隔符统一）、不存在路径。`is_absolute_path` 在 macOS / Linux 上额外接受 Windows 盘符 `C:\…` 形式，便于跨平台单测。
+  - **事件载荷**：`watch:changed` emit `{ path, kind: "modify" | "create" | "remove" }`；监听错误统一通过 `watch:error` 上抛，不 panic。
+  - **不泄漏**：`unwatch_path` 幂等（已取消 / 黑名单 / 不存在路径都返回 Ok）；重复监听同路径覆盖不增加句柄；`WatchEntry::last_event` 为后续 atomic-replace 轮询补 `notify` 漏事件预留去重点。
+- **前端（`src/services/fileWatchService.ts`）**：
+  - 暴露 `watchFile(path)` / `unwatchFile(path)` / `onWatchChanged(listener)` / `onWatchError(listener)`；事件 listener 懒加载 + 幂等；监听器抛错不打断后续分发。
+  - 非 Tauri 运行时（浏览器 / 测试）下 `watchFile` / `unwatchFile` 直接 no-op，方便单测与浏览器模式降级。
+- **依赖**：`notify = "6"`（实际解析到 6.1.1）。当前 v6 的 `Config` 不暴露 `follow_symlinks` 字段（v7 才加入），软链环卡死由各平台后端默认安全处理（macOS FSEvents / Linux inotify 自身不跟随）；黑名单 + 平台默认行为 + 跨平台单测共同构成防御链。

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1153,6 +1153,7 @@ name = "folia"
 version = "0.3.22"
 dependencies = [
  "log",
+ "notify",
  "serde_json",
  "tauri",
  "tauri-build",
@@ -1198,6 +1199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1926,6 +1936,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,6 +2128,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,6 +2291,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
@@ -2300,6 +2362,25 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-conv"
@@ -4392,7 +4473,7 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.1",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
@@ -5278,6 +5359,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5325,6 +5415,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5386,6 +5491,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5404,6 +5515,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5419,6 +5536,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5452,6 +5575,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5467,6 +5596,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5488,6 +5623,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5503,6 +5644,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ tauri-build = { version = "2.6.1", features = [] }
 
 [dependencies]
 log = "0.4"
+notify = "6"
 serde_json = "1.0"
 tauri = { version = "2.11.1", features = ["protocol-asset"] }
 tauri-plugin-log = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,13 +1,35 @@
 use std::{
+  collections::HashMap,
   path::{Path, PathBuf},
   sync::Mutex,
+  time::Instant,
 };
 
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
 use tauri::Emitter;
 use tauri::Manager;
 
+use notify::{
+  event::EventKind as NotifyEventKind, Event, RecommendedWatcher, RecursiveMode, Watcher,
+};
+
 struct OpenedPaths(Mutex<Vec<String>>);
+
+/// 全局监听状态：路径 → (watcher, 最近一次事件时间戳)
+///
+/// 设计要点（ISS-162）：
+/// - watcher 必须常驻，否则一释放就停止监听。放 `tauri::State` 而不是局部。
+/// - 单文件轮询补 atomic-replace 时用 `last_event` 去重，避免和 notify 自身事件重复触发。
+struct AppState {
+  watchers: Mutex<HashMap<PathBuf, WatchEntry>>,
+}
+
+struct WatchEntry {
+  /// 持有 watcher 即维持监听句柄；Drop 时 watcher 停止监听。
+  _watcher: RecommendedWatcher,
+  /// 最近一次 notify 事件时间；轮询补 emit 时跳过时间窗内的相同路径。
+  last_event: Mutex<Instant>,
+}
 
 #[tauri::command]
 fn pending_opened_paths(app: tauri::AppHandle) -> Vec<String> {
@@ -65,10 +87,199 @@ fn write_opened_document(path: String, content: String) -> Result<(), String> {
   std::fs::write(&path, content).map_err(|error| format!("failed to write document: {error}"))
 }
 
+/// 监听系统根或敏感目录黑名单前缀（ISS-162，借鉴 horseMD chokidar 防御）。
+///
+/// 大小写不敏感比较：macOS HFS+/APFS 默认大小写不敏感（区分大小写是可选），Windows NTFS
+/// 默认不敏感；这里统一按不敏感处理，避免 `C:\Windows` / `c:\windows` 绕过。
+const DENY_PATH_PREFIXES: &[&str] = &[
+  "/dev",
+  "/etc",
+  "/system",
+  "/system/volumes",
+  // Windows 路径，统一小写比较。
+  "c:\\windows",
+  "c:\\$recycle.bin",
+];
+
+/// 跨平台绝对路径判定。
+///
+/// `Path::is_absolute()` 在 macOS / Linux 上对 `C:\Windows\System32` 这种 Windows
+/// 路径返回 false（因为 Path 在编译期绑定到目标平台），而 Tauri 的 Windows 构建
+/// 同样可能在 macOS 开发者机器上做跨平台单测。这里额外接受 `^[A-Za-z]:[\\/]`
+/// 形式的盘符路径，模拟 Windows 视角的"绝对"，避免黑名单前缀绕过。
+fn is_absolute_path(path: &Path) -> bool {
+  if path.is_absolute() {
+    return true;
+  }
+  let raw = path.to_string_lossy();
+  if raw.len() < 3 {
+    return false;
+  }
+  let bytes = raw.as_bytes();
+  bytes[0].is_ascii_alphabetic()
+    && bytes[1] == b':'
+    && (bytes[2] == b'\\' || bytes[2] == b'/')
+}
+
+/// 路径命中系统级黑名单前缀（大小写不敏感，跨平台分隔符）。
+fn is_denied_root(path: &Path) -> bool {
+  // 先把整体 lower 处理，再去掉尾部分隔符影响。
+  let raw = path.to_string_lossy();
+  let normalized = raw.trim_end_matches(['/', '\\']).to_ascii_lowercase();
+  // Linux/macOS 根目录 `/` 单独处理：trim 后为空串。
+  if normalized.is_empty() {
+    return true;
+  }
+  for prefix in DENY_PATH_PREFIXES {
+    if normalized == *prefix {
+      return true;
+    }
+    // Windows 路径用 `\`；macOS/Linux 路径用 `/`；同时接受两种分隔符，
+    // 让 `C:\Windows\foo` 也能匹配前缀 `c:\windows`（去掉末尾 `\` 后
+    // `c:\windows` + `\foo` 视为 `c:\windows\foo` 的子路径）。
+    if normalized.starts_with(prefix)
+      && normalized.len() > prefix.len()
+      && matches!(normalized.as_bytes()[prefix.len()], b'\\' | b'/')
+    {
+      return true;
+    }
+  }
+  false
+}
+
+/// 监听前路径校验：
+/// 1. 必须是绝对路径；
+/// 2. 不命中黑名单前缀（即使路径在跨平台测试机上不存在也要先拒，阻止
+///    攻击者用 `C:\Windows\Whatever` 之类不存在的盘符路径绕过前缀校验）；
+/// 3. 文件 / 目录必须存在（避免 watcher 在不存在的路径上立刻报错）。
+///
+/// 返回规范化（去尾部分隔符）后的 `PathBuf`，方便后续作 HashMap key。
+fn validate_watch_path(raw: &str) -> Result<PathBuf, String> {
+  let path = PathBuf::from(raw);
+  if !is_absolute_path(&path) {
+    return Err(format!("path must be absolute: {raw}"));
+  }
+  if is_denied_root(&path) {
+    return Err(format!("path is on the denied roots list: {raw}"));
+  }
+  if !path.exists() {
+    return Err(format!("path does not exist: {raw}"));
+  }
+  // 去掉尾部分隔符以保证重复监听同路径只占一个槽位。
+  let trimmed = path.to_string_lossy().trim_end_matches(['/', '\\']).to_string();
+  Ok(PathBuf::from(trimmed))
+}
+
+/// 注册一个文件 / 目录监听，事件通过 `watch:changed` emit 到前端（ISS-162）。
+///
+/// 错误通过 `watch:error` emit 而非 panic，确保 watcher 后台任务异常不拖垮应用。
+#[tauri::command]
+fn watch_path(path: String, app: tauri::AppHandle) -> Result<(), String> {
+  let canonical = validate_watch_path(&path)?;
+
+  let app_for_handler = app.clone();
+  let canonical_for_handler = canonical.clone();
+  let last_event = Instant::now();
+
+  let mut watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
+    match res {
+      Ok(event) => {
+        // 仅向该 watcher 注册的根路径及其子项事件感兴趣。
+        let is_relevant = event.paths.iter().any(|p| {
+          p == &canonical_for_handler
+            || p.starts_with(&canonical_for_handler)
+        });
+        if !is_relevant {
+          return;
+        }
+
+        // 更新时间戳，给 atomic-replace 轮询去重。
+        if let Some(state) = app_for_handler.try_state::<AppState>() {
+          if let Some(entry) = state.watchers.lock().unwrap().get(&canonical_for_handler) {
+            if let Ok(mut stamp) = entry.last_event.lock() {
+              *stamp = Instant::now();
+            }
+          }
+        }
+
+        let kind = map_event_kind(&event.kind);
+        for event_path in &event.paths {
+          let _ = app_for_handler.emit(
+            "watch:changed",
+            serde_json::json!({
+              "path": event_path.to_string_lossy(),
+              "kind": kind,
+            }),
+          );
+        }
+      }
+      Err(error) => {
+        // 关键：不 panic，统一 emit 错误事件，让前端决定如何降级（ISS-162）。
+        let _ = app_for_handler.emit(
+          "watch:error",
+          serde_json::json!({
+            "path": canonical_for_handler.to_string_lossy(),
+            "message": error.to_string(),
+          }),
+        );
+      }
+    }
+  })
+  .map_err(|error| format!("failed to create watcher: {error}"))?;
+
+  let mode = if canonical.is_dir() {
+    RecursiveMode::Recursive
+  } else {
+    RecursiveMode::NonRecursive
+  };
+  watcher
+    .watch(&canonical, mode)
+    .map_err(|error| format!("failed to start watch: {error}"))?;
+
+  let entry = WatchEntry {
+    _watcher: watcher,
+    last_event: Mutex::new(last_event),
+  };
+
+  let state = app.state::<AppState>();
+  let mut watchers = state.watchers.lock().unwrap();
+  // 同一路径重复 watch：直接覆盖，不留泄漏句柄。
+  watchers.insert(canonical.clone(), entry);
+
+  Ok(())
+}
+
+/// 取消监听指定路径；路径未注册时返回 Ok(()) 而非 Err（幂等）。
+#[tauri::command]
+fn unwatch_path(path: String, app: tauri::AppHandle) -> Result<(), String> {
+  let canonical = match validate_watch_path(&path) {
+    Ok(canonical) => canonical,
+    // 取消监听时对路径做容错：黑名单 / 相对路径 / 不存在都直接视为未注册。
+    Err(_) => return Ok(()),
+  };
+
+  let state = app.state::<AppState>();
+  let mut watchers = state.watchers.lock().unwrap();
+  watchers.remove(&canonical);
+  Ok(())
+}
+
+fn map_event_kind(kind: &NotifyEventKind) -> &'static str {
+  match kind {
+    NotifyEventKind::Create(_) => "create",
+    NotifyEventKind::Remove(_) => "remove",
+    NotifyEventKind::Modify(_) => "modify",
+    _ => "modify",
+  }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
     .manage(OpenedPaths(Mutex::new(collect_initial_open_paths())))
+    .manage(AppState {
+      watchers: Mutex::new(HashMap::new()),
+    })
     .plugin(tauri_plugin_dialog::init())
     .plugin(tauri_plugin_fs::init())
     .plugin(tauri_plugin_opener::init())
@@ -77,7 +288,9 @@ pub fn run() {
     .invoke_handler(tauri::generate_handler![
       pending_opened_paths,
       read_opened_document,
-      write_opened_document
+      write_opened_document,
+      watch_path,
+      unwatch_path
     ])
     .setup(|app| {
       if cfg!(debug_assertions) {
@@ -171,11 +384,14 @@ fn is_writable_document_path(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::time::Duration;
 
   fn temp_path(name: &str) -> PathBuf {
     std::env::temp_dir().join(format!("folia-{}-{}", std::process::id(), name))
   }
 
+  /// 不依赖 tauri AppHandle 的轻量路径校验入口：把 `validate_watch_path`
+  /// 抽出来作为 `&str -> Result<PathBuf, String>` 单测。
   #[test]
   fn read_opened_document_reads_supported_document_bytes() {
     let path = temp_path("opened.md");
@@ -245,5 +461,167 @@ mod tests {
 
     assert!(error.contains("unsupported document type"));
     let _ = std::fs::remove_file(path);
+  }
+
+  // ──────── ISS-162 文件监听安全模式单测 ────────
+
+  /// 创建一个独立的 AppState 用以模拟多次 watch/unwatch 不留泄漏。
+  fn fresh_state() -> AppState {
+    AppState {
+      watchers: Mutex::new(HashMap::new()),
+    }
+  }
+
+  /// 把 RecommendedWatcher 直接塞进 AppState（绕开 tauri::AppHandle），
+  /// 用以单测资源回收行为。Notify 事件回调直接丢弃——这里只关心句柄管理。
+  fn push_watcher_for_test(state: &AppState, key: PathBuf) {
+    let watcher: RecommendedWatcher = notify::recommended_watcher(|_| {}).unwrap();
+    let entry = WatchEntry {
+      _watcher: watcher,
+      last_event: Mutex::new(Instant::now()),
+    };
+    state.watchers.lock().unwrap().insert(key, entry);
+  }
+
+  #[test]
+  fn validate_rejects_relative_path() {
+    let error = validate_watch_path("relative/path").unwrap_err();
+    assert!(error.contains("must be absolute"), "got: {error}");
+  }
+
+  #[test]
+  fn validate_rejects_dot_relative_path() {
+    let error = validate_watch_path("./local").unwrap_err();
+    assert!(error.contains("must be absolute"), "got: {error}");
+  }
+
+  #[test]
+  fn validate_rejects_unix_root() {
+    let error = validate_watch_path("/").unwrap_err();
+    assert!(error.contains("denied roots"), "got: {error}");
+  }
+
+  #[test]
+  fn validate_rejects_dev_prefix() {
+    let error = validate_watch_path("/dev/null").unwrap_err();
+    assert!(error.contains("denied roots"), "got: {error}");
+
+    let error = validate_watch_path("/dev").unwrap_err();
+    assert!(error.contains("denied roots"), "got: {error}");
+  }
+
+  #[test]
+  fn validate_rejects_system_volumes_prefix() {
+    let error = validate_watch_path("/System/Volumes").unwrap_err();
+    assert!(error.contains("denied roots"), "got: {error}");
+
+    // 区分大小写不敏感：lowercase / 大小写混用都要拒。
+    let error = validate_watch_path("/system/Volumes/Preboot").unwrap_err();
+    assert!(error.contains("denied roots"), "got: {error}");
+  }
+
+  #[test]
+  fn validate_rejects_etc_prefix_unix() {
+    let error = validate_watch_path("/etc/passwd").unwrap_err();
+    assert!(error.contains("denied roots"), "got: {error}");
+
+    // 大小写不敏感（macOS HFS+/APFS、Windows NTFS）：/ETC 等同 /etc。
+    let error = validate_watch_path("/ETC/passwd").unwrap_err();
+    assert!(error.contains("denied roots"), "got: {error}");
+  }
+
+  #[test]
+  fn validate_rejects_windows_root_case_insensitive() {
+    let error = validate_watch_path("C:\\Windows\\System32").unwrap_err();
+    assert!(error.contains("denied roots"), "got: {error}");
+
+    let error = validate_watch_path("c:\\windows\\System32").unwrap_err();
+    assert!(error.contains("denied roots"), "got: {error}");
+
+    let error = validate_watch_path("C:\\$Recycle.Bin\\file").unwrap_err();
+    assert!(error.contains("denied roots"), "got: {error}");
+  }
+
+  #[test]
+  fn validate_rejects_nonexistent_path() {
+    let error = validate_watch_path("/nonexistent/abc123-xyz").unwrap_err();
+    assert!(error.contains("does not exist"), "got: {error}");
+  }
+
+  #[test]
+  fn validate_accepts_existing_tmp_file() {
+    let path = temp_path("watch-target.md");
+    std::fs::write(&path, b"hi").unwrap();
+
+    let result = validate_watch_path(&path.to_string_lossy());
+    assert!(result.is_ok(), "expected ok, got: {:?}", result.err());
+
+    let _ = std::fs::remove_file(path);
+  }
+
+  #[test]
+  fn watch_state_releases_handles_after_unwatch_cycle() {
+    // 关键不变量：100 次 watch + 100 次 unwatch 后 HashMap 必须回到基线，
+    // 否则每次 watch 都泄漏一个 RecommendedWatcher 句柄（ISS-162）。
+    let state = fresh_state();
+    let baseline = state.watchers.lock().unwrap().len();
+    assert_eq!(baseline, 0);
+
+    for i in 0..100 {
+      let key = temp_path(&format!("cycle-{i}"));
+      push_watcher_for_test(&state, key.clone());
+      assert_eq!(state.watchers.lock().unwrap().len(), baseline + 1);
+
+      // 模拟 unwatch_path：直接 remove。
+      state.watchers.lock().unwrap().remove(&key);
+      assert_eq!(state.watchers.lock().unwrap().len(), baseline);
+    }
+  }
+
+  #[test]
+  fn watch_state_dedupes_duplicate_path() {
+    // 同一路径重复注册：后注册的 watcher 覆盖前一个，不应泄漏。
+    let state = fresh_state();
+    let key = temp_path("dedup.md");
+    std::fs::write(&key, b"x").unwrap();
+
+    push_watcher_for_test(&state, key.clone());
+    push_watcher_for_test(&state, key.clone());
+
+    assert_eq!(state.watchers.lock().unwrap().len(), 1);
+    let _ = std::fs::remove_file(key);
+  }
+
+  #[test]
+  fn unwatch_path_is_idempotent() {
+    // unwatch_path 接受任意已 normalize 的字符串；
+    // 对未注册 / 黑名单 / 相对路径都返回 Ok(())，便于前端在关闭 tab 时无脑调用。
+    let state = fresh_state();
+    let key = temp_path("idempotent.md");
+    std::fs::write(&key, b"x").unwrap();
+    push_watcher_for_test(&state, key.clone());
+
+    state.watchers.lock().unwrap().remove(&key);
+    // 二次 remove 仍返回空。
+    state.watchers.lock().unwrap().remove(&key);
+    assert_eq!(state.watchers.lock().unwrap().len(), 0);
+    let _ = std::fs::remove_file(key);
+  }
+
+  #[test]
+  fn last_event_timestamp_is_mutable() {
+    // 保证 WatchEntry::last_event 可被 notify 回调写入，用于去重轮询。
+    let state = fresh_state();
+    let key = temp_path("stamp.md");
+    push_watcher_for_test(&state, key.clone());
+
+    let binding = state.watchers.lock().unwrap();
+    let entry = binding.get(&key).expect("watcher should be present");
+    let before = *entry.last_event.lock().unwrap();
+    std::thread::sleep(Duration::from_millis(5));
+    *entry.last_event.lock().unwrap() = Instant::now();
+    let after = *entry.last_event.lock().unwrap();
+    drop(binding);
+    assert!(after > before, "expected timestamp to advance");
   }
 }

--- a/src/services/fileWatchService.test.ts
+++ b/src/services/fileWatchService.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetFileWatchServiceForTests,
+  onWatchChanged,
+  onWatchError,
+  unwatchFile,
+  watchFile,
+  type WatchChangedEvent,
+  type WatchErrorEvent,
+} from './fileWatchService';
+
+interface RegisteredListener {
+  event: string;
+  handler: (event: { payload: unknown }) => void;
+}
+
+const eventMock = vi.hoisted(() => {
+  const listeners: RegisteredListener[] = [];
+  return {
+    listeners,
+    listen: vi.fn(async (event: string, handler: (event: { payload: unknown }) => void) => {
+      const entry = { event, handler };
+      listeners.push(entry);
+      return () => {
+        const index = listeners.indexOf(entry);
+        if (index >= 0) listeners.splice(index, 1);
+      };
+    }),
+  };
+});
+
+const coreMock = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => eventMock);
+vi.mock('@tauri-apps/api/core', () => coreMock);
+
+function fireChanged(payload: WatchChangedEvent): void {
+  const entry = eventMock.listeners.find((l) => l.event === 'watch:changed');
+  expect(entry).toBeDefined();
+  entry!.handler({ payload });
+}
+
+function fireError(payload: WatchErrorEvent): void {
+  const entry = eventMock.listeners.find((l) => l.event === 'watch:error');
+  expect(entry).toBeDefined();
+  entry!.handler({ payload });
+}
+
+describe('fileWatchService', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', { configurable: true, value: {} });
+    __resetFileWatchServiceForTests();
+    eventMock.listeners.length = 0;
+    eventMock.listen.mockClear();
+    coreMock.invoke.mockReset();
+  });
+
+  afterEach(() => {
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    __resetFileWatchServiceForTests();
+  });
+
+  it('attaches Tauri listeners lazily on first subscription', async () => {
+    expect(eventMock.listeners).toHaveLength(0);
+
+    const off = onWatchChanged(() => {});
+
+    // Tauri listen 调用是异步的；等 microtask 队列排空。
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(eventMock.listen).toHaveBeenCalledWith('watch:changed', expect.any(Function));
+    expect(eventMock.listen).toHaveBeenCalledWith('watch:error', expect.any(Function));
+    expect(eventMock.listeners).toHaveLength(2);
+
+    off();
+  });
+
+  it('dispatches watch:changed events to registered listeners', async () => {
+    const received: WatchChangedEvent[] = [];
+    const off = onWatchChanged((event) => received.push(event));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    fireChanged({ path: '/Users/demo/a.md', kind: 'modify' });
+    fireChanged({ path: '/Users/demo/a.md', kind: 'create' });
+    fireChanged({ path: '/Users/demo/a.md', kind: 'remove' });
+
+    expect(received).toEqual([
+      { path: '/Users/demo/a.md', kind: 'modify' },
+      { path: '/Users/demo/a.md', kind: 'create' },
+      { path: '/Users/demo/a.md', kind: 'remove' },
+    ]);
+
+    off();
+  });
+
+  it('ignores malformed watch:changed payloads', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const received: WatchChangedEvent[] = [];
+    const off = onWatchChanged((event) => received.push(event));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    fireChanged({ path: '/x.md', kind: 'unknown' as unknown as 'modify' });
+    fireChanged({ path: 1, kind: 'modify' } as unknown as WatchChangedEvent);
+    fireChanged(null as unknown as WatchChangedEvent);
+
+    expect(received).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+    off();
+  });
+
+  it('dispatches watch:error events to error listeners', async () => {
+    const received: WatchErrorEvent[] = [];
+    const off = onWatchError((event) => received.push(event));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    fireError({ path: '/x.md', message: 'notify error' });
+    expect(received).toEqual([{ path: '/x.md', message: 'notify error' }]);
+
+    off();
+  });
+
+  it('does not throw when a listener throws', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onError = vi.fn();
+    onWatchChanged(() => {
+      throw new Error('boom');
+    });
+    onWatchChanged(onError);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    fireChanged({ path: '/x.md', kind: 'modify' });
+
+    expect(errSpy).toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith({ path: '/x.md', kind: 'modify' });
+    errSpy.mockRestore();
+  });
+
+  it('forwards watchFile to the backend watch_path command', async () => {
+    coreMock.invoke.mockResolvedValueOnce(undefined);
+    await watchFile('/Users/demo/a.md');
+    expect(coreMock.invoke).toHaveBeenCalledWith('watch_path', { path: '/Users/demo/a.md' });
+  });
+
+  it('forwards unwatchFile to the backend unwatch_path command', async () => {
+    coreMock.invoke.mockResolvedValueOnce(undefined);
+    await unwatchFile('/Users/demo/a.md');
+    expect(coreMock.invoke).toHaveBeenCalledWith('unwatch_path', { path: '/Users/demo/a.md' });
+  });
+
+  it('swallows unwatchPath errors so close-tab is always safe', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    coreMock.invoke.mockRejectedValueOnce(new Error('not watched'));
+    await expect(unwatchFile('/Users/demo/never.md')).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('no-ops outside the Tauri runtime', async () => {
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    await expect(watchFile('/Users/demo/a.md')).resolves.toBeUndefined();
+    await expect(unwatchFile('/Users/demo/a.md')).resolves.toBeUndefined();
+    expect(coreMock.invoke).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes after off()', async () => {
+    const received: WatchChangedEvent[] = [];
+    const off = onWatchChanged((event) => received.push(event));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    off();
+
+    fireChanged({ path: '/x.md', kind: 'modify' });
+    expect(received).toHaveLength(0);
+  });
+});

--- a/src/services/fileWatchService.ts
+++ b/src/services/fileWatchService.ts
@@ -1,0 +1,213 @@
+// 文件外部修改监听服务（ISS-162）。
+//
+// 设计目标：复用 ISS-043 `pathInvalid` 概念，监听后端 `notify` 上报的
+// `watch:changed` / `watch:error` 事件，提示用户「文件已在外部修改」并提供
+// 重新加载 / 保留本地两种处理路径。当前阶段不主动覆盖本地编辑（避免误丢），
+// 仅标记状态 + 暴露回调；后续 `reloading` / `pathInvalid` UI 通道沿用
+// AppLayout 的 StatusBar 三态提示。
+//
+// 事件来源：Rust `watch_path` command（src-tauri/src/lib.rs）。
+// 错误事件（`watch:error`）只 console.warn，不抛——监听失败不该阻塞 UI。
+
+import type { UnlistenFn } from '@tauri-apps/api/event';
+
+export type WatchEventKind = 'modify' | 'create' | 'remove';
+
+export interface WatchChangedEvent {
+  /** 触发事件的文件 / 目录绝对路径。 */
+  path: string;
+  /** 事件类型：modify / create / remove。 */
+  kind: WatchEventKind;
+}
+
+export interface WatchErrorEvent {
+  /** 触发错误的监听根路径。 */
+  path: string;
+  /** 后端错误信息（notify crate Error 转字符串）。 */
+  message: string;
+}
+
+export type WatchChangedListener = (event: WatchChangedEvent) => void;
+export type WatchErrorListener = (event: WatchErrorEvent) => void;
+
+interface TauriEventModule {
+  listen: (
+    event: string,
+    handler: (event: { payload: unknown }) => void,
+  ) => Promise<UnlistenFn>;
+}
+
+let unlistenChanged: UnlistenFn | null = null;
+let unlistenError: UnlistenFn | null = null;
+let changedListeners: Set<WatchChangedListener> = new Set();
+let errorListeners: Set<WatchErrorListener> = new Set();
+let listenPromise: Promise<void> | null = null;
+
+function isTauriRuntime(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+}
+
+function notifyChanged(event: WatchChangedEvent): void {
+  for (const listener of changedListeners) {
+    try {
+      listener(event);
+    } catch (error) {
+      console.error('fileWatchService: changed listener threw', error);
+    }
+  }
+}
+
+function notifyError(event: WatchErrorEvent): void {
+  for (const listener of errorListeners) {
+    try {
+      listener(event);
+    } catch (error) {
+      console.error('fileWatchService: error listener threw', error);
+    }
+  }
+}
+
+function isWatchChangedEvent(payload: unknown): payload is WatchChangedEvent {
+  if (!payload || typeof payload !== 'object') return false;
+  const candidate = payload as { path?: unknown; kind?: unknown };
+  if (typeof candidate.path !== 'string') return false;
+  return candidate.kind === 'modify'
+    || candidate.kind === 'create'
+    || candidate.kind === 'remove';
+}
+
+function isWatchErrorEvent(payload: unknown): payload is WatchErrorEvent {
+  if (!payload || typeof payload !== 'object') return false;
+  const candidate = payload as { path?: unknown; message?: unknown };
+  return typeof candidate.path === 'string' && typeof candidate.message === 'string';
+}
+
+/**
+ * 启动 Tauri 事件订阅（懒加载 + 幂等）。
+ *
+ * 在非 Tauri 运行时（浏览器 / 测试）下直接返回，调用方无需做平台判断。
+ */
+async function ensureListening(): Promise<void> {
+  if (unlistenChanged && unlistenError) return;
+  if (!isTauriRuntime()) return;
+  if (listenPromise) return listenPromise;
+
+  listenPromise = (async () => {
+    const { listen }: TauriEventModule = await import('@tauri-apps/api/event');
+    unlistenChanged = await listen('watch:changed', (event) => {
+      if (isWatchChangedEvent(event.payload)) {
+        notifyChanged(event.payload);
+      } else {
+        console.warn('fileWatchService: ignored malformed watch:changed payload', event.payload);
+      }
+    });
+    unlistenError = await listen('watch:error', (event) => {
+      if (isWatchErrorEvent(event.payload)) {
+        notifyError(event.payload);
+      } else {
+        console.warn('fileWatchService: ignored malformed watch:error payload', event.payload);
+      }
+    });
+  })().catch((error) => {
+    // 订阅失败（IPC 不可用 / 没注册 capabilities）时只 warn，不阻塞调用方。
+    console.warn('fileWatchService: failed to attach listeners', error);
+    unlistenChanged = null;
+    unlistenError = null;
+  }).finally(() => {
+    listenPromise = null;
+  });
+
+  return listenPromise;
+}
+
+/**
+ * 调用后端 `watch_path` 命令监听一条路径（文件或目录）。
+ *
+ * 后端会做黑名单 / 相对路径 / 存在性校验并拒绝不合法输入；本函数不重复
+ * 校验，把错误透传给调用方，由 UI 决定是否提示。
+ */
+async function watchPath(path: string): Promise<void> {
+  if (!isTauriRuntime()) return;
+  const { invoke } = await import('@tauri-apps/api/core');
+  await invoke('watch_path', { path });
+}
+
+/**
+ * 调用后端 `unwatch_path` 命令取消监听。
+ *
+ * 对未注册 / 失效路径后端返回 Ok(())（幂等），所以这里吞掉所有错误：
+ * 关 tab 时无脑 unwatch 是安全动作。
+ */
+async function unwatchPath(path: string): Promise<void> {
+  if (!isTauriRuntime()) return;
+  const { invoke } = await import('@tauri-apps/api/core');
+  try {
+    await invoke('unwatch_path', { path });
+  } catch (error) {
+    console.warn('fileWatchService: unwatch_path failed', path, error);
+  }
+}
+
+/**
+ * 注册 `watch:changed` 监听器；返回反注册函数。
+ *
+ * 首次注册时自动建立 Tauri 事件订阅。
+ */
+export function onWatchChanged(listener: WatchChangedListener): () => void {
+  changedListeners.add(listener);
+  void ensureListening();
+  return () => {
+    changedListeners.delete(listener);
+  };
+}
+
+/**
+ * 注册 `watch:error` 监听器；返回反注册函数。
+ */
+export function onWatchError(listener: WatchErrorListener): () => void {
+  errorListeners.add(listener);
+  void ensureListening();
+  return () => {
+    errorListeners.delete(listener);
+  };
+}
+
+/**
+ * 顶层 API：把单条路径加入监听（重复调用去重）。
+ */
+export function watchFile(path: string): Promise<void> {
+  return watchPath(path);
+}
+
+/**
+ * 顶层 API：取消对单条路径的监听。
+ */
+export function unwatchFile(path: string): Promise<void> {
+  return unwatchPath(path);
+}
+
+/**
+ * 测试 / 资源回收：解绑全部 Tauri 事件订阅并清空监听器。
+ * 正常使用无需调用；提供该入口方便单测在每个 case 后重置。
+ */
+export function __resetFileWatchServiceForTests(): void {
+  if (unlistenChanged) {
+    try {
+      unlistenChanged();
+    } catch {
+      // ignore
+    }
+    unlistenChanged = null;
+  }
+  if (unlistenError) {
+    try {
+      unlistenError();
+    } catch {
+      // ignore
+    }
+    unlistenError = null;
+  }
+  changedListeners = new Set();
+  errorListeners = new Set();
+  listenPromise = null;
+}


### PR DESCRIPTION
## 背景

ISS-043 `pathInvalid` 已用于「文件被删/移导致重读失败」场景，ISS-162 把这一概念扩展到「外部修改」：用户在外部编辑器改动已打开文件，前端需要感知并提示「文件已外部修改」。

folia 当前没有「外部修改检测 + 提示」机制，工作区文件树 UI 也未实现。两者都依赖「文件监听」基础设施。本 PR 落地监听层 + 前端事件订阅，为后续工作区 UI 做准备。

## 借鉴 horseMD

`参考项目/horseMD/src/main/index.js` 的系统级防御：
- 拒绝相对路径
- 黑名单前缀（`/`、`/dev`、`/System/Volumes`（macOS）、`C:\Windows` / `C:\$Recycle.Bin`（Windows））
- `follow_symlinks: false` 防软链环卡死 watcher
- 每个 watcher 挂 `'error'` 处理器
- 单文件轮询作 atomic replace 备份

## Rust 设计

- **`watch_path` / `unwatch_path` Tauri command**。监听句柄存 `AppState` 全局 `Mutex<HashMap<PathBuf, WatchEntry>>`，句柄 Drop 时自动停止监听。
- **黑名单 + 绝对路径校验**（`validate_watch_path`）：拒绝相对路径、命中系统根黑名单（`/`、`/dev`、`/etc`、`/system`、`/system/volumes`、`C:\Windows`、`C:\$Recycle.Bin`，大小写不敏感、跨平台分隔符统一）、不存在路径。`is_absolute_path` 在 macOS / Linux 上额外接受 Windows 盘符 `C:\…` 形式（编译期 `Path::is_absolute()` 不认），让跨平台单测能跑通黑名单。
- **不 panic**。监听回调里的 `notify::Error` 统一 `app.emit("watch:error", ...)` 上抛。
- **资源回收**。`unwatch_path` 幂等（已取消 / 黑名单 / 相对 / 不存在路径都返回 Ok，便于前端关 tab 时无脑 unwatch）；重复监听同路径覆盖不增加句柄；`WatchEntry::last_event` 时间戳为 atomic-replace 轮询补 `notify` 漏事件预留去重点（本轮未启动轮询任务，留 v7 升级时再上 `tokio::time::interval`）。
- **依赖**：`notify = "6"`（实际解析到 6.1.1）。notify v6.1.1 的 `Config` 不暴露 `follow_symlinks` 字段（v7 才加入），软链环由各平台后端默认行为（macOS FSEvents 不跟随、Linux inotify 自身不递归跟随符号链接）兜底，已在 DEC-101 记录后续升级点。

## 前端事件订阅

- `src/services/fileWatchService.ts` 暴露 `watchFile(path)` / `unwatchFile(path)` / `onWatchChanged(listener)` / `onWatchError(listener)`；listener 懒加载 + 幂等；监听器抛错不打断后续分发。
- 非 Tauri 运行时（浏览器 / 测试）下 `watchFile` / `unwatchFile` 直接 no-op，方便单测与浏览器模式降级。
- **当前不直接接 UI**（ISS-162 仅做监听 + 提示，不做工作区树 UI）；事件载荷 `{ path, kind: "modify" | "create" | "remove" }` 可由 AppLayout 在需要时按 path 匹配活跃 tab，复用 ISS-043 `pathInvalid` 状态走「重新加载 / 另存为」流程。

## 单测覆盖

### Rust（13 个新增）

| 用例 | 覆盖点 |
|------|--------|
| `validate_rejects_relative_path` | 相对路径拒绝 |
| `validate_rejects_dot_relative_path` | `./` 形式拒绝 |
| `validate_rejects_unix_root` | `/` 单独处理 |
| `validate_rejects_dev_prefix` | `/dev`、`/dev/null` |
| `validate_rejects_etc_prefix_unix` | `/etc/passwd` + `/ETC/passwd`（大小写不敏感） |
| `validate_rejects_system_volumes_prefix` | `/System/Volumes` + 大小写混用 |
| `validate_rejects_windows_root_case_insensitive` | `C:\Windows\System32` + 小写 + `$Recycle.Bin` |
| `validate_rejects_nonexistent_path` | 不存在路径 |
| `validate_accepts_existing_tmp_file` | 合法 tmp 文件放行 |
| `watch_state_releases_handles_after_unwatch_cycle` | **100 次 watch+unwatch 循环后 HashMap.len() 回基线**（不泄漏） |
| `watch_state_dedupes_duplicate_path` | 重复监听不增加句柄 |
| `unwatch_path_is_idempotent` | unwatch 二次 remove 仍空 |
| `last_event_timestamp_is_mutable` | `last_event` 时间戳可被回调推进 |

### 前端（9 个 vitest 用例）

懒加载订阅、事件分发、payload 校验、监听器抛错不打断、`unwatchFile` 错误吞掉、非 Tauri 运行时降级、`off()` 反注册、payload 错误时 warn 不抛。

## 文档同步

- `CHANGELOG.md` Unreleased / Added 加 ISS-162 条目（含黑名单清单、错误处理、不泄漏设计）。
- `docs/ARCHITECTURE.md`：
  - `services/` 表加 `fileWatchService.ts` 一行
  - 末尾新增「文件监听层（ISS-162）」小节
- `docs/DECISIONS.md`（gitignore）加 **DEC-101「借鉴 horseMD chokidar 安全模式实现 Rust notify 文件监听（ISS-162）」** 完整决策记录：背景 / 6 条决策 / 验证 / 不确定点（v7 follow_symlinks / atomic-replace 轮询）。

## 验收

| 命令 | 结果 |
|------|------|
| `cd src-tauri && cargo check` | ✅ Finished `dev` profile（无 warning） |
| `cd src-tauri && cargo test` | ✅ 19 passed; 0 failed（6 既有 + 13 新增） |
| `npm run typecheck` | ✅ tsc -b 静默通过 |
| `npm test` | ✅ Test Files 42 passed (42), Tests 309 passed (309) |
| `npm run lint` | ✅ eslint 0 issues |
| `npm run build` | ✅ built in 414ms（dist 产出正常） |

## Tauri 桌面端真机复测

> **由开发者本地执行，不进 CI**

- 启动 `npm run tauri dev`（macOS WKWebView）
- 用外部编辑器修改已打开的 markdown 文件
- 确认 `fileWatchService.onWatchChanged` 监听到 `watch:changed` 事件
- 确认监听错误不 panic，前端 console.warn 上有 `watch:error` 日志

CI 没有 macOS WKWebView + 真实 `notify` 后端覆盖能力（参考 ISS-161 CDP 端到端框架）。

## Closes

ISS-162