### PR TITLE
fix(macos): 窗口关闭问题（主窗口×销毁无法恢复 + 独立窗口×关不掉）

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -452,13 +452,31 @@ pub fn run() {
     })
     .on_window_event(|window, event| {
       // ISS-164：新窗口（包括 tear-off 出的独立窗口）创建时也挂上关闭监听。
-      if let tauri::WindowEvent::CloseRequested { .. } = event {
-        handle_window_close(window);
+      if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+        let label = window.label();
+        if label == "main" {
+          // macOS 标准：主窗口点 × = 隐藏（prevent_close + hide），不销毁窗口、不退出 app。
+          // 这样点 Dock 图标（RunEvent::Reopen）能重新 show 恢复；否则窗口销毁后
+          // Dock 图标无法再打开窗口，用户会感到"关不掉 / 恢复不了"。
+          api.prevent_close();
+          let _ = window.hide();
+        } else {
+          handle_window_close(window);
+        }
       }
     })
     .build(tauri::generate_context!())
     .expect("error while building tauri application")
     .run(|_app, _event| {
+      // macOS：点 Dock 图标（窗口已 hide 或 minimize 后）触发 Reopen，恢复主窗口。
+      #[cfg(target_os = "macos")]
+      if let tauri::RunEvent::Reopen { .. } = _event {
+        if let Some(window) = _app.get_webview_window("main") {
+          let _ = window.unminimize();
+          let _ = window.show();
+          let _ = window.set_focus();
+        }
+      }
       #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
       if let tauri::RunEvent::Opened { urls } = _event {
         let paths = opened_paths_from_urls(urls);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -461,7 +461,11 @@ pub fn run() {
           api.prevent_close();
           let _ = window.hide();
         } else {
+          // 独立窗口（tear-off）：emit window:closed 回收 tab，并主动销毁窗口。
+          // macOS 动态创建窗口的 CloseRequested 默认关闭偶发不生效（× 点了不关），
+          // destroy() 强制销毁且不再触发 CloseRequested（无递归）。
           handle_window_close(window);
+          let _ = window.destroy();
         }
       }
     })


### PR DESCRIPTION
## 问题

macOS 上窗口关闭有两个问题：

1. **主窗口**：点红色 × 会**销毁窗口**，导致点 Dock 图标无法再打开主窗口——用户感到"窗口关不掉 / 最小化后恢复不了"。
2. **独立窗口（tear-off 标签撕离）**：点 × **关不掉**——macOS 动态创建窗口的 CloseRequested 默认关闭偶发不生效。

## 原因

- 主窗口：`on_window_event` 对 `CloseRequested` 未拦截，走默认销毁；`.run()` 未处理 macOS `Reopen` 事件（点 Dock 图标触发）
- 独立窗口：动态创建窗口的 CloseRequested 默认关闭在 macOS 上偶发失效

## 修复

`on_window_event`：
- 主窗口（`label == "main"`）`CloseRequested` → `prevent_close + hide`（隐藏不销毁）
- 独立窗口 → `handle_window_close`（emit `window:closed` 回收 tab）+ `destroy()`（强制销毁，不再触发 CloseRequested，无递归）

`.run()`：
- 新增 `RunEvent::Reopen` 处理（macOS），点 Dock 图标时 `unminimize + show + set_focus` 恢复主窗口

## 行为

符合 macOS 标准窗口规范：
- 主窗口红 × → 隐藏到 Dock → 点 Dock 唤回（覆盖红 × 隐藏 + 黄 - 最小化两种恢复）
- 独立窗口 × → 正常关闭销毁 + tab 回收

## 验证

- `cargo check` 通过
- 手动：主窗口红 × → 隐藏 → 点 Dock → 恢复；黄 - 最小化 → 点 Dock → 恢复；tear-off 独立窗口 × → 正常关闭
