### PR TITLE
feat(window): DEC-111 drag 到空白处创建新独立窗口

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -164,6 +164,7 @@ export function AppLayout() {
     activeTabId,
     updateActiveFile,
     updateActiveTabMeta,
+    tearOffViaDrag,
   } = session;
   const confirmCloseDirty = useCallback(() => window.confirm('该标签有未保存改动，确定关闭吗？'), []);
   const windowLabel = useMemo(() => detectCurrentWindowLabel(), []);
@@ -791,6 +792,7 @@ export function AppLayout() {
             onContextMenu={(id, x, y) => setContextMenu({ tabId: id, x, y })}
             onClose={(id) => session.closeTab(id, { confirmDirty: confirmCloseDirty })}
             onNew={() => session.openInNewTab(createEmptyFile())}
+            onTearOffViaDrag={isTearOffSupported ? tearOffViaDrag : undefined}
             onMergeBackDrop={isTearOffSupported ? handleMergeBackDrop : undefined}
           />
         }

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -194,4 +194,34 @@ describe('TabBar', () => {
     expect(html).toContain('draggable="true"');
     expect(spy).not.toHaveBeenCalled();
   });
+
+  // ──────── DEC-111 drag-out 到空白处创建新窗口 ────────
+
+  it('render 接受 onTearOffViaDrag 属性而不报错（多 tab 窗口）', () => {
+    // 验证 TabBar 暴露 onTearOffViaDrag prop。dragend 真正触发逻辑在 jsdom
+    // 模拟 dragstart → dragend 事件流（renderToStaticMarkup 不挂载 DOM，
+    // 这里仅验证 prop 被接受且不会破坏基本渲染）。
+    const spy = vi.fn();
+    const html = render({
+      ...baseProps,
+      tabs: [tab('a', 'a.md'), tab('b', 'b.md')],
+      activeTabId: 'a',
+      onTearOffViaDrag: spy,
+    });
+    expect(html).toContain('draggable="true"');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('单 tab 窗口不暴露 drag-out 入口（draggable=false，onTearOffViaDrag 不会被 dragend 触发）', () => {
+    const spy = vi.fn();
+    const html = render({
+      ...baseProps,
+      tabs: [tab('a', 'a.md')],
+      activeTabId: 'a',
+      onTearOffViaDrag: spy,
+    });
+    // draggable=false → handleDragEnd 第一行 `if (tab.isPlaceholder || !canDragOut) return;`
+    // 直接 return，drag-out 永远不会被触发。
+    expect(html).toContain('draggable="false"');
+  });
 });

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -18,6 +18,12 @@ export interface TabBarProps {
   onNew: () => void;
   onContextMenu?: (id: string, x: number, y: number) => void;
   /**
+   * DEC-111：drag 到空白处时调用，撕出当前 tab 到新独立窗口。
+   * - dragend 事件 + dropEffect === 'none' 时触发。
+   * - 调用方负责创建新窗口 + 从当前 session 删除 tab（通常是 `session.tearOffViaDrag`）。
+   */
+  onTearOffViaDrag?: (id: string) => void;
+  /**
    * drop 到本窗口 tab bar 上的合并请求（其他窗口拖过来的 tab）。
    * - payload 已通过 decodeTabDragPayload 校验。
    * - 调用方负责把 tab 加回 session（通常是 `session.mergeBackTab`）。
@@ -34,6 +40,7 @@ export function TabBar({
   onClose,
   onNew,
   onContextMenu,
+  onTearOffViaDrag,
   onMergeBackDrop,
 }: TabBarProps) {
   const settings = useSettings();
@@ -76,10 +83,24 @@ export function TabBar({
     if (!payload) return;
     if (payload.sourceLabel === windowLabel) {
       // 同窗口内拖动：MVP 简化 = 不处理（后续精确 drop index 再做）。
+      // 但仍 preventDefault 标记为「接受 drop」，让 dragend 不触发 tear-off。
+      event.preventDefault();
       return;
     }
     event.preventDefault();
     onMergeBackDrop(payload);
+  };
+
+  // DEC-111：drag 结束时检查 dropEffect。dropEffect === 'none' 表示没有任何
+  // drop target 接受这个 drag（即拖到了空白处或浏览器取消）——这是「撕出当前
+  // tab 到新独立窗口」的触发点。同窗口 drop 由 handleDrop 标记 preventDefault，
+  // dropEffect 会保持 move/copy，本 handler 不会触发 tear-off。
+  const handleDragEnd = (event: React.DragEvent<HTMLDivElement>, tab: Tab) => {
+    if (!onTearOffViaDrag) return;
+    if (tab.isPlaceholder || !canDragOut) return;
+    if (event.dataTransfer.dropEffect !== 'none') return;
+    event.preventDefault();
+    void onTearOffViaDrag(tab.id);
   };
 
   return (
@@ -100,6 +121,7 @@ export function TabBar({
               onDragStart={(e) => handleDragStart(e, tab)}
               onDragOver={handleDragOver}
               onDrop={handleDrop}
+              onDragEnd={(e) => handleDragEnd(e, tab)}
               onClick={() => onSelect(tab.id)}
               onContextMenu={onContextMenu ? (e) => { e.preventDefault(); onContextMenu(tab.id, e.clientX, e.clientY); } : undefined}
             >

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -10,10 +10,9 @@ import {
   detectCurrentWindowTabIds,
   mergeBackTab,
   syncWindowTabIds,
-  // DEC-111「drag 到空白处创建新窗口」独立后续项需直接调用
-  // tabWindowService.tearOffTabToWindow + TabTearOffPayload；当前 useSession
-  // 无消费者，因此这里不 import。
+  tearOffTabToWindow,
   type TabMergeBackPayload,
+  type TabTearOffPayload,
 } from '../services/tabWindowService';
 
 export interface CloseOptions {
@@ -208,10 +207,33 @@ export function useSession() {
     [state.tabs]
   );
 
-  // DEC-110：useSession.tearOffTab 包装层已删除——原 tear-off 按钮入口被移除
-  // 后，无 UI 调用此 callback。DEC-111「drag 到空白处创建新窗口」独立后续项
-  // 直接调 tabWindowService.tearOffTabToWindow，跳过包装层（保留更细粒度的
-  // dirty 检查与错误处理）。
+  // DEC-111：drag 到空白处时调用，撕出当前 tab 到新独立窗口。
+  // 与原 ISS-164 tearOffTab 流程一致，但去掉了 dirty 确认——浏览器范式下
+  // tear-off 不强制弹 confirm（Chrome / Safari 都不弹），由用户自行保存。
+  const tearOffViaDrag = useCallback(
+    async (id: string) => {
+      const tab = state.tabs.find((t) => t.id === id);
+      if (!tab) return false;
+      const windowLabel = detectCurrentWindowLabel();
+      const payload: TabTearOffPayload = {
+        tabId: id,
+        sourceLabel: windowLabel,
+        dirty: tab.file.dirty,
+      };
+      try {
+        // 确保新窗口启动时能从共享 localStorage 找到刚撕出的 tab；
+        // debounce save 可能尚未落盘。
+        saveSession(stateRef.current);
+        await tearOffTabToWindow(payload);
+        dispatch({ type: 'removeTabById', id });
+        return true;
+      } catch (error) {
+        console.warn('useSession: tearOffViaDrag failed', error);
+        return false;
+      }
+    },
+    [state.tabs]
+  );
 
   // ISS-164：把当前 tab 拖回主窗口（独立窗口调用）。
   const mergeBackTabById = useCallback(
@@ -266,7 +288,9 @@ export function useSession() {
     removeRecentFile,
     clearRecentFiles,
     // ISS-164 tear-off / merge-back
-    // tearOffTab 包装层已删除（DEC-110）；保留 mergeBackTab 走 drag merge-back 主路径
+    // tearOffViaDrag 是 DEC-111「drag 到空白处创建新窗口」的入口；
+    // mergeBackTab 走 drag merge-back 主路径。
+    tearOffViaDrag,
     mergeBackTab: mergeBackTabById,
   };
 }


### PR DESCRIPTION
## Summary

DEC-110 移除 tear-off 按钮 + toolbar X 后，唯一能创建新窗口的入口（drag 到其他窗口 tab bar = merge-back 反向）也存在缺口——用户无法把 tab 撕出到全新窗口。

按浏览器范式补：drag 一个 tab 到空白处时（dropEffect === 'none'），自动创建新独立窗口并把该 tab 从源窗口移除。

## Why

用户原话：「拖出来一个这个页面窗口，它就是一个独立的窗。窗口」——浏览器范式下 tab 撕出是 drag-only，不需要按钮。DEC-110 移除了按钮，但**没补 drag-out 到空白处的实现**，导致用户实际**无法创建第二窗口**（除非已经有 ≥2 窗口才能 merge-back）。

## Test Plan

- `npm run typecheck` ✅
- `npm test` ✅ **367/367**（+2 新测试）
- `npm run lint` ✅
- `npm run build` ✅

## 实施

| 文件 | 改动 |
|------|------|
| `TabBar.tsx` | 新增 `handleDragEnd`：dropEffect === 'none' 时调 `onTearOffViaDrag(tab.id)`；`handleDrop` 同窗口分支也 preventDefault（信号 drop 被接受，dragend 不触发 tear-off） |
| `TabBar.tsx` | 新增 `onTearOffViaDrag` prop |
| `useSession.ts` | 新增 `tearOffViaDrag` callback（流程：saveSession → tearOffTabToWindow → dispatch removeTabById）——与原 ISS-164 tearOffTab 一致，但去 dirty 确认（Chrome / Safari 不弹） |
| `AppLayout.tsx` | destructure `tearOffViaDrag`，通过 `onTearOffViaDrag` 传给 TabBar |
| `TabBar.test.tsx` | +2 测试：prop 接受 + 单 tab 窗口禁 drag |

## 行为

| 场景 | 行为 |
|------|------|
| 多 tab 窗口 + drag 到其他窗口 tab bar | merge-back（既有路径） |
| 多 tab 窗口 + drag 到空白处 | **新独立窗口创建，源窗口 tab 移除** |
| 多 tab 窗口 + drag 到同窗口 tab bar | drop accepted（preventDefault），dragend 不触发 tear-off（同窗口 drop 暂不实现 reorder） |
| 单 tab 窗口 | draggable=false（DEC-110 既有约束） |

## Risk & Rollback

- **风险**：HTML5 dragend 的 dropEffect 跨浏览器一致性 — Chromium / WebKit / Firefox 在「drop 在窗口外」的行为略有差异
- **缓解**：handleDrop 的 preventDefault 兜底（drop 在 tab bar 一定被接受，dragend 不会误触发 tear-off）
- **回滚**：revert commit `742e358`

## 遗留

- **DEC-108 dirty 拦截**：OS 原生关闭独立窗口时，若有 dirty tab 应弹原生 confirm。需 Rust `OnCloseRequested` + `prevent_close()` 重做（独立后续项）