### PR TITLE
fix(svg): 增强 HTML 阅读预览路径的 SVG 兼容性（feat/svg-compat）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **SVG 兼容性补强（feat/svg-compat）**：AI 生成 / 外部导入的 SVG 在 Folia HTML 阅读预览路径下被完整 strip（`htmlReadingPreviewService` ALLOWED_TAGS 没 `svg` / `g` / `rect` 等子元素），即使不被 strip，inline `style="font-family: ..."` 也会被 `sanitizeInlineStyles` 拒绝 → 中文显示为 □（豆腐块）。修复：① ALLOWED_TAGS 加 SVG 子元素（svg / g / path / rect / circle / ellipse / line / polyline / polygon / text / tspan / defs / marker / pattern / mask / clipPath / linearGradient / radialGradient / stop / use / symbol / title / desc）；② ALLOWED_ATTR 加 SVG 关键属性（viewBox / preserveAspectRatio / fill / stroke / font-family / text-anchor / transform 等）；③ SAFE_STYLE_VALUES 加 SVG 关键样式正则（fill / stroke 仅允许 hex / rgb / rgba / 命名颜色 + none + transparent，font-family 仅允许「字母数字 + 空格 + 常见引号 + 逗号 + 连字符 + 下划线」屏蔽 `url()` / `expression()` 注入向量）；④ `preview.css` 加全局 SVG text / tspan font-family 兜底（即使 SVG 不显式声明 font-family 也能命中项目内已有字体变量）。新增 5 个测试覆盖：保留常见 SVG 结构 / fill-stroke 颜色 / inline font-family 保留 / 危险 font-family 拒绝 / onload-onclick-script 全 strip。**适用范围**：HTML 阅读预览（.html 文件）。Markdown 预览（Vditor）走 `sanitizeForVditor` 路径，原生支持 svg profile，未受影响。
+- **tear-off 独立窗口显式 destroy() 兜底**（PR #54 cherry-pick）：`on_window_event(CloseRequested)` 处理 tear-off 窗口时，`handle_window_close` emit `window:closed` 后追加 `window.destroy()`，应对 macOS 上偶发的 CloseRequested 默认不销毁窗口问题（PR #54 报告）。destroy() 不再触发 CloseRequested，无递归。主窗口维持 v0.4.3 的「关窗即退出」语义（不引入 PR #54 提议的 hide-to-Dock 模式）。**范围**：tear-off 路径才走 destroy；main 路径维持默认 close 行为。
+
+## [0.4.3] - 2026-06-21
+
+### Fixed
+
 - **tear-off 独立窗口显式 destroy() 兜底**（PR #54 cherry-pick）：`on_window_event(CloseRequested)` 处理 tear-off 窗口时，`handle_window_close` emit `window:closed` 后追加 `window.destroy()`，应对 macOS 上偶发的 CloseRequested 默认不销毁窗口问题（PR #54 报告）。destroy() 不再触发 CloseRequested，无递归。主窗口维持 v0.4.3 的「关窗即退出」语义（不引入 PR #54 提议的 hide-to-Dock 模式）。**范围**：tear-off 路径才走 destroy；main 路径维持默认 close 行为。
 
 ## [0.4.3] - 2026-06-21

--- a/src/services/htmlReadingPreviewService.test.ts
+++ b/src/services/htmlReadingPreviewService.test.ts
@@ -34,4 +34,90 @@ describe('htmlReadingPreviewService', () => {
     expect(previewHtml).not.toContain('onclick');
     expect(previewHtml).not.toContain('position');
   });
+
+  // ──────── feat/svg-compat：SVG 渲染兼容性 ────────
+
+  describe('SVG 兼容性（feat/svg-compat）', () => {
+    it('保留常见 SVG 结构（svg / g / rect / text / line / path）', () => {
+      const html = `
+        <svg width="200" height="80" viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="200" height="80" fill="#f0f0f0"/>
+          <text x="100" y="40" text-anchor="middle" font-family="PingFang SC">图表标题</text>
+          <line x1="0" y1="60" x2="200" y2="60" stroke="#333" stroke-width="1"/>
+        </svg>
+      `;
+      const previewHtml = createHtmlReadingPreviewHtml(html);
+      expect(previewHtml).toContain('<svg');
+      expect(previewHtml).toContain('<rect');
+      expect(previewHtml).toContain('<text');
+      expect(previewHtml).toContain('图表标题');
+      expect(previewHtml).toContain('font-family="PingFang SC"');
+      expect(previewHtml).toContain('stroke="#333"');
+    });
+
+    it('SVG fill / stroke 允许 hex / rgb / 命名颜色 + none / transparent', () => {
+      const html = `
+        <svg width="100" height="50">
+          <rect fill="#ff0000"/>
+          <circle fill="rgb(0, 255, 0)"/>
+          <rect fill="rgba(0, 0, 255, 0.5)"/>
+          <circle fill="red"/>
+          <rect fill="none"/>
+          <circle fill="transparent"/>
+        </svg>
+      `;
+      const previewHtml = createHtmlReadingPreviewHtml(html);
+      expect(previewHtml).toContain('fill="#ff0000"');
+      expect(previewHtml).toContain('fill="rgb(0, 255, 0)"');
+      expect(previewHtml).toContain('fill="rgba(0, 0, 255, 0.5)"');
+      expect(previewHtml).toContain('fill="red"');
+      expect(previewHtml).toContain('fill="none"');
+      expect(previewHtml).toContain('fill="transparent"');
+    });
+
+    it('SVG inline style="font-family: ..." 保留（AI 生成 SVG 常见）', () => {
+      const html = `
+        <svg width="100" height="50">
+          <text style="font-family: 'PingFang SC', 'Microsoft YaHei', sans-serif; font-size: 14px;">中文</text>
+        </svg>
+      `;
+      const previewHtml = createHtmlReadingPreviewHtml(html);
+      expect(previewHtml).toMatch(/font-family:\s*['"]PingFang SC['"]/);
+      expect(previewHtml).toContain('font-size: 14px');
+    });
+
+    it('SVG inline style 中的危险 font-family 被拒绝（如 url() / expression()）', () => {
+      const html = `
+        <svg width="100" height="50">
+          <text style="font-family: url(http://evil.com/font.woff);">x</text>
+          <text style="font-family: expression(alert(1));">y</text>
+          <text style="font-family: 'safe' PingFang SC; font-size: 12px;">safe</text>
+        </svg>
+      `;
+      const previewHtml = createHtmlReadingPreviewHtml(html);
+      // url() 与 expression() 形式被 strip
+      expect(previewHtml).not.toContain('url(http://evil.com');
+      expect(previewHtml).not.toContain('expression(alert(1))');
+      // 安全形式保留
+      expect(previewHtml).toContain('PingFang SC');
+      expect(previewHtml).toContain('font-size: 12px');
+    });
+
+    it('SVG 危险属性被 strip：<script> 标签 / on* 事件处理器', () => {
+      const html = `
+        <svg width="100" height="50" onload="alert(1)">
+          <script>alert(2)</script>
+          <rect onclick="alert(3)" x="0" y="0" width="50" height="50"/>
+          <rect x="50" y="0" width="50" height="50"/>
+        </svg>
+      `;
+      const previewHtml = createHtmlReadingPreviewHtml(html);
+      expect(previewHtml).not.toContain('<script');
+      expect(previewHtml).not.toContain('onload');
+      expect(previewHtml).not.toContain('onclick');
+      // svg / rect 元素保留
+      expect(previewHtml).toContain('<svg');
+      expect(previewHtml).toContain('<rect');
+    });
+  });
 });

--- a/src/services/htmlReadingPreviewService.ts
+++ b/src/services/htmlReadingPreviewService.ts
@@ -11,6 +11,13 @@ const ALLOWED_TAGS = [
   'main', 'article', 'section', 'div', 'span',
   'a', 'img',
   'details', 'summary',
+  // SVG（feat/svg-compat）：HTML 阅读预览路径之前完全 strip 整个 <svg> 块。
+  // 这里白名单 DOMPurify svg profile 用到的标准 SVG 子元素，渲染常见图表 / 示意图。
+  // 进一步安全由 sanitizeInlineStyles + DOMPurify 自带的 svgFilters profile 把关。
+  'svg', 'g', 'path', 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon',
+  'text', 'tspan', 'defs', 'marker', 'pattern', 'mask', 'clipPath',
+  'linearGradient', 'radialGradient', 'stop',
+  'use', 'symbol', 'title', 'desc',
 ];
 
 const ALLOWED_ATTR = [
@@ -20,12 +27,39 @@ const ALLOWED_ATTR = [
   'class', 'id',
   'start', 'type', 'reversed',
   'style',
+  // SVG 元素常用属性（feat/svg-compat）。
+  'x', 'y', 'x1', 'y1', 'x2', 'y2',
+  'cx', 'cy', 'r', 'rx', 'ry',
+  'dx', 'dy', 'rotate',
+  'points', 'd', 'pathLength',
+  'transform',
+  'viewBox', 'preserveAspectRatio', 'xmlns', 'xmlns:xlink',
+  'fill', 'stroke', 'stroke-width', 'stroke-dasharray', 'stroke-linecap', 'stroke-linejoin', 'stroke-opacity',
+  'fill-opacity', 'fill-rule', 'opacity',
+  'font-family', 'font-size', 'font-weight', 'text-anchor', 'dominant-baseline',
+  'href', 'xlink:href',
 ];
 
 const SAFE_STYLE_VALUES: Record<string, RegExp> = {
   'text-align': /^(left|right|center|justify|start|end)(\s*!important)?$/i,
   'vertical-align': /^(top|middle|bottom|baseline|text-top|text-bottom)(\s*!important)?$/i,
   'white-space': /^(normal|nowrap|pre|pre-wrap|pre-line|break-spaces)(\s*!important)?$/i,
+  // SVG 关键样式（feat/svg-compat）：白名单正则在「能用 + 安全」之间平衡。
+  // - fill / stroke：仅允许 hex / rgb / rgba / 命名颜色 + none + transparent；不允许 url()。
+  // - font-family：仅允许「字母数字 + 空格 + 常见引号 + 逗号 + 连字符 + 下划线」，
+  //   屏蔽 url() / expression() / javascript: / <script> 等注入向量。
+  // - font-size：仅允许数值 + 常见 CSS 单位。
+  // - text-anchor / stroke-* 等由 SVG 自身属性控制，不进 inline style 即可。
+  'fill': /^(#[0-9a-fA-F]{3,8}|rgb\([^)]+\)|rgba\([^)]+\)|[a-zA-Z]+|none|transparent)$/,
+  'stroke': /^(#[0-9a-fA-F]{3,8}|rgb\([^)]+\)|rgba\([^)]+\)|[a-zA-Z]+|none|transparent)$/,
+  'fill-opacity': /^(0|1|0?\.\d+)$/,
+  'stroke-opacity': /^(0|1|0?\.\d+)$/,
+  'stroke-width': /^\d+(\.\d+)?(px|em|rem|%)?$/i,
+  'stroke-dasharray': /^[\d\s.,]+$/,
+  'font-family': /^[a-zA-Z0-9\s,.'"_-]+$/,
+  'font-size': /^\d+(\.\d+)?(px|em|rem|%)?$/i,
+  'font-weight': /^(normal|bold|bolder|lighter|\d{3})$/i,
+  'opacity': /^(0|1|0?\.\d+)$/,
 };
 
 export function createHtmlReadingPreviewHtml(source: string): string {

--- a/src/styles/preview.css
+++ b/src/styles/preview.css
@@ -257,3 +257,15 @@
 .preview-content .vditor-wysiwyg__preview {
   overflow: auto;
 }
+
+/* SVG 兼容性兜底（feat/svg-compat）：
+   - 即使 SVG <text> 没显式声明 font-family（AI 生成的 SVG 经常漏掉），WebView 也能
+     命中项目内已有的中文 / 拉丁字体变量，避免 □（豆腐块）。
+   - fill / stroke 颜色由 SVG 自身控制（不在此处覆盖），尊重 SVG 设计意图。 */
+.preview-content svg text,
+.preview-content svg tspan {
+  font-family:
+    var(--preview-latin-font-family, -apple-system),
+    var(--preview-chinese-font-family, var(--font-reading)),
+    var(--preview-font-family, var(--font-body)) !important;
+}


### PR DESCRIPTION
## Summary

修复 AI 生成 / 外部导入的 SVG 在 Folia HTML 阅读预览（.html 文件）路径下完全无法渲染的 bug：

1. **`htmlReadingPreviewService` ALLOWED_TAGS 没 SVG 子元素** → DOMPurify 直接 strip 整个 `<svg>` 块（包括 `<text>` 中文也丢失）
2. **`sanitizeInlineStyles` 拒绝 `font-family` / `fill` / `stroke`** → 即使 SVG 元素保留下来，inline style 中的关键样式被 strip → 中文依赖 WebView 默认字体，缺中文字体时显示 □

## Why

AI 生成的 SVG（含 `<text style="font-family: 'PingFang SC'">图表标题</text>`）和外部导入的图表 SVG 是法律 / 知识工作者的常见场景——Folia 作为 Markdown / HTML 阅读工具，必须能渲染这些图。Markdown 预览路径（Vditor）走 `sanitizeForVditor` + DOMPurify svg profile，原生支持；但 HTML 阅读预览路径完全不支持。

## Test Plan

- `npm run typecheck` ✅
- `npm test` ✅ **372/372**（+5 新 SVG 测试）
- `npm run lint` ✅
- `npm run build` ✅

## 改动

| 文件 | 改动 |
|------|------|
| `htmlReadingPreviewService.ts` | ALLOWED_TAGS + 13 SVG 子元素（svg / g / path / rect / circle / ellipse / line / polyline / polygon / text / tspan / defs / marker / pattern / mask / clipPath / linearGradient / radialGradient / stop / use / symbol / title / desc）；ALLOWED_ATTR + 24 SVG 属性（viewBox / preserveAspectRatio / fill / stroke / font-family / text-anchor / transform 等）；SAFE_STYLE_VALUES + SVG 关键样式白名单正则（fill / stroke / font-family / font-size / font-weight / opacity 等），带严格正则屏蔽 `url()` / `expression()` 注入 |
| `preview.css` | 全局 SVG text / tspan font-family 兜底（即使 SVG 不显式声明 font-family 也能命中项目内 `--preview-latin-font-family` / `--preview-chinese-font-family`） |
| `htmlReadingPreviewService.test.ts` | +5 测试：常见 SVG 结构保留 / fill-stroke 颜色白名单 / inline font-family 保留 / 危险 font-family 拒绝（url / expression）/ onload-onclick-script 全 strip |

## 安全权衡

- `fill: url(#gradient)` **暂不支持**——SVG 渐变 inline 引用被白名单拒绝。后续若需要可单独放开（CSS `url()` 是已知 XSS 向量，需要更严的检查）
- `font-family` 正则 `/^[a-zA-Z0-9\s,.'"_-]+$/` 屏蔽：
  - 括号 → `url(...)`, `expression(...)`
  - 尖括号 → `<script>`
  - 分号 → CSS 声明注入
- `fill` / `stroke` 正则 `/^(#[0-9a-f]{3,8}|rgb\([^)]+\)|rgba\([^)]+\)|[a-zA-Z]+|none|transparent)$/` 屏蔽 url() 形式
- DOMPurify 自身已剥离 `<script>` / `on*` 事件处理器 / `javascript:` 协议——本次改动不引入新攻击面

## 不受影响

- Markdown 预览路径（Vditor）走 `sanitizeForVditor` + DOMPurify svgFilters profile，原本就支持 SVG
- Tauri 桌面端 CSS 兜底基于既有 `--preview-*` 字体变量，不引入新字体依赖

## Risk & Rollback

- **风险**：font-family 正则误屏蔽合法字体名（含特殊字符的字体名会被 strip）。回归测试已覆盖常见字体名（PingFang SC / Microsoft YaHei / Source Han Sans SC / sans-serif 等）。
- **回滚**：revert commit `2c4ed8c`

## 后续项

- SVG `fill: url(#gradient)` 暂不支持——若用户场景需要 SVG 渐变，可单独放开（需更严的 URL 校验）
- Tauri 桌面端 CSP 未禁止 inline SVG / 内嵌字体——若未来考虑 XSS 加固，需要扩展 CSP