### PR TITLE
fix(svg): 修复 Markdown 内联 SVG 在编辑器与预览链路被截断（ISS-176 / DEC-112）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **修复 Markdown 内联 SVG 在主编辑器、HTML 预览、Word 预览中被截断或变白的问题**（ISS-176 / DEC-112）：Vditor IR / Lute 会把漂亮排版的多行 SVG 拆成多个 `html-block`，部分 SVG 的 marker 还会被截成只有背景 `<rect>` 的片段；旧清洗逻辑会把这些片段补闭合并回写到会话，导致右侧预览也拿到污染内容。Folia 现在按原始 Markdown SVG 块修复 IR 可见预览，安全跳过无害 SVG 片段 marker 的单独清洗，并在 Vditor preview 前用占位符保护完整 SVG；HTML/Word 预览会移除 Vditor 复制按钮等 preview chrome。Playwright Chromium 注入用户 `ch07.md` 实测：主编辑器、HTML 预览、Word 预览测量层和分页层均为 7 张完整 SVG，初始化后 session 仍保持干净。
 - **tear-off 独立窗口显式 destroy() 兜底**（PR #54 cherry-pick）：`on_window_event(CloseRequested)` 处理 tear-off 窗口时，`handle_window_close` emit `window:closed` 后追加 `window.destroy()`，应对 macOS 上偶发的 CloseRequested 默认不销毁窗口问题（PR #54 报告）。destroy() 不再触发 CloseRequested，无递归。主窗口维持 v0.4.3 的「关窗即退出」语义（不引入 PR #54 提议的 hide-to-Dock 模式）。**范围**：tear-off 路径才走 destroy；main 路径维持默认 close 行为。
 
 ## [0.4.3] - 2026-06-21

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -8,7 +8,7 @@ import { VDITOR_PREVIEW_I18N } from '../services/vditorPreviewConfig';
 import { createHtmlReadingPreviewHtml } from '../services/htmlReadingPreviewService';
 import { resolveLocalImages } from '../services/localImageResolver';
 import { openExternalUrl } from '../services/urlOpener';
-import { sanitizeForVditor } from '../services/sanitizeService';
+import { prepareMarkdownForVditorPreview } from '../services/markdownSvgPreviewService';
 
 type PreviewPaneProps = {
   source: string;
@@ -26,6 +26,10 @@ export function PreviewPane({ source, tocIds, wideTables = false, renderMode = '
   const settings = useSettings();
   const renderFeatures = useMemo(
     () => detectMarkdownRenderFeatures(deferredSource),
+    [deferredSource],
+  );
+  const markdownPreviewInput = useMemo(
+    () => prepareMarkdownForVditorPreview(deferredSource),
     [deferredSource],
   );
   const previewFontFamily = resolvePreviewFontFamily(settings);
@@ -68,7 +72,7 @@ export function PreviewPane({ source, tocIds, wideTables = false, renderMode = '
       // html + svg + svgFilters profile（见 sanitizeService.ts），保留
       // svg 子元素及滤镜，剥离 <script>/on*/javascript: 等。后处理再无
       // 必要（after 内不再 sanitize；保留给本地图片与 toc id 注入）。
-      Vditor.preview(el, deferredSource, {
+      Vditor.preview(el, markdownPreviewInput.markdown, {
         mode: 'light',
         anchor: 0,
         cdn: '/vditor',
@@ -86,9 +90,7 @@ export function PreviewPane({ source, tocIds, wideTables = false, renderMode = '
         markdown: {
           sanitize: false,
         },
-        transform(html) {
-          return sanitizeForVditor(html);
-        },
+        transform: markdownPreviewInput.transform,
         after() {
           if (cancelled) return;
           // ISS-169：sanitize 已由 transform 钩子在 innerHTML 设置前完成，
@@ -103,7 +105,7 @@ export function PreviewPane({ source, tocIds, wideTables = false, renderMode = '
     return () => {
       cancelled = true;
     };
-  }, [deferredSource, deferredTocIds, filePath, renderFeatures.hasHighlightableCode, renderMode]);
+  }, [deferredSource, deferredTocIds, filePath, markdownPreviewInput, renderFeatures.hasHighlightableCode, renderMode]);
 
   useEffect(() => {
     const shell = shellRef.current;

--- a/src/components/WechatPreviewPane.test.tsx
+++ b/src/components/WechatPreviewPane.test.tsx
@@ -13,6 +13,10 @@ type PreviewCall = {
   source: string;
   options: {
     after?: () => void;
+    markdown?: {
+      sanitize?: boolean;
+    };
+    transform?: (html: string) => string;
   };
   reject: (error: Error) => void;
   resolve: () => void;
@@ -197,6 +201,31 @@ describe('WechatPreviewPane', () => {
     });
     expect(host.querySelector('.wechat-preview-article-shell')?.textContent).toContain('恢复文章');
     expect(host.textContent).not.toContain('HTML 预览生成失败');
+  });
+
+  it('HTML 导出预览注册 transform 以保留安全 SVG 并剥离危险属性', async () => {
+    await act(async () => {
+      root.render(<WechatPreviewPane source="<svg></svg>" onClose={() => undefined} />);
+      await flushPromises();
+    });
+    await waitForPreviewCall(1);
+
+    const options = previewCalls[0].options;
+    expect(options.markdown?.sanitize).toBe(false);
+    expect(options.transform).toBeTypeOf('function');
+
+    const transformed = options.transform?.([
+      '<svg onload="alert(1)" viewBox="0 0 10 10">',
+      '<rect width="10" height="10" fill="#fff"></rect>',
+      '</svg>',
+      '<script>alert(2)</script>',
+    ].join('')) ?? '';
+
+    expect(transformed).toContain('<svg');
+    expect(transformed).toContain('<rect');
+    expect(transformed).not.toContain('onload');
+    expect(transformed).not.toContain('<script');
+    expect(transformed).not.toContain('alert(');
   });
 
   it('copies rich text HTML and plain text fallback to the clipboard when available', async () => {

--- a/src/components/WechatPreviewPane.tsx
+++ b/src/components/WechatPreviewPane.tsx
@@ -18,6 +18,7 @@ import {
 import { getHtmlExportPresetDefinition } from '../services/htmlExportPresets';
 import type { HtmlExportPresetId } from '../services/htmlExportPresets';
 import { resolveLocalImages } from '../services/localImageResolver';
+import { prepareMarkdownForVditorPreview } from '../services/markdownSvgPreviewService';
 
 type WechatPreviewPaneProps = {
   source: string;
@@ -45,6 +46,10 @@ export function WechatPreviewPane({ source, fileName = 'document.md', onClose, f
   );
   const renderFeatures = useMemo(
     () => detectMarkdownRenderFeatures(deferredSource),
+    [deferredSource],
+  );
+  const markdownPreviewInput = useMemo(
+    () => prepareMarkdownForVditorPreview(deferredSource),
     [deferredSource],
   );
   const htmlExportPreset = useMemo(
@@ -83,7 +88,7 @@ export function WechatPreviewPane({ source, fileName = 'document.md', onClose, f
       import('vditor'),
     ]).then(async ([, { default: Vditor }]) => {
       if (cancelled || renderIdRef.current !== renderId) return;
-      await Vditor.preview(el, deferredSource, {
+      await Vditor.preview(el, markdownPreviewInput.markdown, {
         mode: 'light',
         anchor: 0,
         cdn: '/vditor',
@@ -99,8 +104,9 @@ export function WechatPreviewPane({ source, fileName = 'document.md', onClose, f
           lineNumber: false,
         },
         markdown: {
-          sanitize: true,
+          sanitize: false,
         },
+        transform: markdownPreviewInput.transform,
         after() {
           if (cancelled || renderIdRef.current !== renderId) return;
           void resolveLocalImages(el, filePath);
@@ -122,7 +128,7 @@ export function WechatPreviewPane({ source, fileName = 'document.md', onClose, f
     return () => {
       cancelled = true;
     };
-  }, [deferredSource, fileName, filePath, htmlExportPreset, renderFeatures.hasHighlightableCode, sourceIsEmpty]);
+  }, [deferredSource, fileName, filePath, htmlExportPreset, markdownPreviewInput, renderFeatures.hasHighlightableCode, sourceIsEmpty]);
 
   const effectiveStatus = sourceIsEmpty ? 'empty' : status;
   const effectiveActionStatus = sourceIsEmpty ? null : actionStatus;

--- a/src/components/WysiwygEditorPane.test.tsx
+++ b/src/components/WysiwygEditorPane.test.tsx
@@ -3,6 +3,7 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WysiwygEditorPane } from './WysiwygEditorPane';
+import { FOLIA_IR_SVG_FRAGMENT_CLASS, FOLIA_IR_SVG_ROOT_CLASS } from '../services/vditorIrSanitizeService';
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -191,6 +192,54 @@ describe('WysiwygEditorPane 内联 SVG 显示 + sanitize (ISS-168 编辑器部�
       });
     });
 
+    it('after() 回调重组被 Vditor IR 按空行拆开的 SVG 预览', async () => {
+      let root: Root | null = null;
+
+      await act(async () => {
+        root = createRoot(host);
+        root.render(
+          React.createElement(WysiwygEditorPane, {
+            source: '',
+            onChange: () => undefined,
+          }),
+        );
+        await flushMicrotasks();
+      });
+
+      const call = vditorCalls[0];
+      const ir = call.host.querySelector<HTMLElement>('.vditor-ir pre');
+      expect(ir).not.toBeNull();
+
+      ir!.innerHTML = [
+        '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+        '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">&lt;svg viewBox="0 0 120 80" width="120" height="80"&gt;\n  &lt;rect width="120" height="80" fill="#FFFFFF"/&gt;</code></pre>',
+        '<pre class="vditor-ir__preview" data-render="1"><svg viewBox="0 0 120 80" width="120" height="80"><rect width="120" height="80" fill="#FFFFFF"></rect></svg></pre>',
+        '</div>',
+        '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+        '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block"></code></pre>',
+        '<pre class="vditor-ir__preview" data-render="1"></pre>',
+        '</div>',
+        '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+        '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">&lt;text x="60" y="24" font-size="14" fill="#111111" text-anchor="middle"&gt;标题&lt;/text&gt;\n&lt;/svg&gt;</code></pre>',
+        '<pre class="vditor-ir__preview" data-render="1"><text x="60" y="24" font-size="14" fill="#111111" text-anchor="middle">标题</text></pre>',
+        '</div>',
+      ].join('');
+
+      await act(async () => {
+        call.options.after?.();
+        await flushMicrotasks();
+        await flushFrames();
+      });
+
+      const repairedPreview = ir!.querySelector(`.${FOLIA_IR_SVG_ROOT_CLASS} .vditor-ir__preview`);
+      expect(repairedPreview?.querySelector('svg text')?.textContent).toBe('标题');
+      expect(ir!.querySelectorAll(`.${FOLIA_IR_SVG_FRAGMENT_CLASS}`)).toHaveLength(2);
+
+      await act(async () => {
+        root?.unmount();
+      });
+    });
+
     it('input() 回调跑 sanitizeIrDom 让用户输入后的 IR DOM 内 svg 保留 + onerror 剥离', async () => {
       let root: Root | null = null;
 
@@ -209,7 +258,7 @@ describe('WysiwygEditorPane 内联 SVG 显示 + sanitize (ISS-168 编辑器部�
       // 先跑一次 after() 让组件进入 ready 阶段
       await act(async () => {
         call.options.after?.();
-        await flushMicrotasks();
+        await flushFrames();
       });
 
       const ir = call.host.querySelector<HTMLElement>('.vditor-ir pre');
@@ -217,6 +266,8 @@ describe('WysiwygEditorPane 内联 SVG 显示 + sanitize (ISS-168 编辑器部�
 
       // 模拟用户输入后 Lute 把 svg + onerror 渲染到 IR DOM
       ir!.innerHTML = '<p data-block="0"><svg viewBox="0 0 5 5"><rect width="5" height="5"/></svg><img src="y" onerror="alert(1)"></p>';
+      ir!.focus();
+      ir!.dispatchEvent(new Event('beforeinput', { bubbles: true }));
 
       // 模拟 input(value) 回调触发 sanitize
       await act(async () => {
@@ -269,6 +320,8 @@ describe('WysiwygEditorPane 内联 SVG 显示 + sanitize (ISS-168 编辑器部�
         '<pre class="vditor-ir__preview" data-render="2"><div><img src="x" onerror="alert(1)"></div></pre>',
         '</div>',
       ].join('');
+      ir!.focus();
+      ir!.dispatchEvent(new Event('beforeinput', { bubbles: true }));
 
       await act(async () => {
         call.options.input?.('<div><img src="x" onerror="alert(1)"></div>');
@@ -279,6 +332,48 @@ describe('WysiwygEditorPane 内联 SVG 显示 + sanitize (ISS-168 编辑器部�
       expect(saved).toContain('<img src="x"');
       expect(saved).not.toContain('onerror');
       expect(saved).not.toContain('alert(');
+
+      await act(async () => {
+        root?.unmount();
+      });
+    });
+
+    it('忽略 Vditor 初始化完成前触发的 input，避免用 Lute 中间值覆盖原文', async () => {
+      let root: Root | null = null;
+      const onChange = vi.fn();
+
+      await act(async () => {
+        root = createRoot(host);
+        root.render(
+          React.createElement(WysiwygEditorPane, {
+            source: '<p data-block="0"><span data-type="text">init</span></p>',
+            onChange,
+          }),
+        );
+        await flushMicrotasks();
+      });
+
+      const call = vditorCalls[0];
+
+      await act(async () => {
+        call.options.input?.('<svg viewBox="0 0 10 10"><rect width="10"/></svg>');
+        await flushMicrotasks();
+      });
+      expect(onChange).not.toHaveBeenCalled();
+
+      await act(async () => {
+        call.options.after?.();
+        await flushMicrotasks();
+      });
+
+      await act(async () => {
+        const ir = call.host.querySelector<HTMLElement>('.vditor-ir pre');
+        ir?.focus();
+        ir?.dispatchEvent(new Event('beforeinput', { bubbles: true }));
+        call.options.input?.('用户输入');
+        await flushFrames();
+      });
+      expect(onChange).toHaveBeenLastCalledWith('用户输入');
 
       await act(async () => {
         root?.unmount();
@@ -328,6 +423,8 @@ describe('WysiwygEditorPane 内联 SVG 显示 + sanitize (ISS-168 编辑器部�
       // 让 nextBlocks 与 original.html 不一致——但因为 sanitized === true，
       // restore 必须被跳过，replaceHtmlTableBlock 不应被调用。
       ir!.innerHTML = '<p data-block="0"><span data-type="text">x</span></p>';
+      ir!.focus();
+      ir!.dispatchEvent(new Event('beforeinput', { bubbles: true }));
 
       await act(async () => {
         call.options.input?.('x');

--- a/src/components/WysiwygEditorPane.tsx
+++ b/src/components/WysiwygEditorPane.tsx
@@ -9,7 +9,7 @@ import { useSettings } from '../hooks/useSettings';
 import { translate } from '../services/i18n';
 import { resolveLocalImages } from '../services/localImageResolver';
 import { openExternalUrl } from '../services/urlOpener';
-import { sanitizeVditorIrHtml } from '../services/vditorIrSanitizeService';
+import { repairSvgIrPreviewsFromMarkdown, sanitizeVditorIrHtml } from '../services/vditorIrSanitizeService';
 
 type WysiwygEditorPaneProps = {
   source: string;
@@ -43,6 +43,11 @@ function collapseExpandedMarkers(editor: import('vditor').default | null): void 
   ir.querySelectorAll('.vditor-ir__node--expand').forEach((node) => {
     node.classList.remove('vditor-ir__node--expand');
   });
+}
+
+function editorHasFocus(editor: import('vditor').default): boolean {
+  const ir = getIrElement(editor);
+  return !!ir && (document.activeElement === ir || ir.contains(document.activeElement));
 }
 
 /**
@@ -80,7 +85,7 @@ function collapseExpandedMarkers(editor: import('vditor').default | null): void 
  * 否则会与 Vditor 自身的 setValue 死循环（用 applyingExternalValue /
  * sanitizingRef 双重 guard）。
  */
-function sanitizeIrDom(editor: import('vditor').default | null): boolean {
+function sanitizeIrDom(editor: import('vditor').default | null, markdownSource: string): boolean {
   if (!editor) return false;
   const ir = getIrElement(editor);
   if (!ir) return false;
@@ -90,7 +95,8 @@ function sanitizeIrDom(editor: import('vditor').default | null): boolean {
   if (result.changed) {
     ir.innerHTML = result.html;
   }
-  return result.changed;
+  repairSvgIrPreviewsFromMarkdown(ir, markdownSource);
+  return result.sourceChanged;
 }
 
 export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePath }: WysiwygEditorPaneProps) {
@@ -108,6 +114,8 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
   // ISS-168 编辑器部分：sanitize 写入 innerHTML 会触发 Vditor 自身的
   // 渲染回调，需要此 guard 防止 setValue -> sanitize -> input 死循环。
   const sanitizingRef = useRef(false);
+  const initializingRef = useRef(false);
+  const userInteractedRef = useRef(false);
   const [phase, setPhase] = useState<EditorPhase>('loading');
   // retryKey 递增时强制重新初始化 Vditor
   const [retryKey, setRetryKey] = useState(0);
@@ -171,12 +179,21 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
     let cancelled = false;
     setPhase('loading');
 
+    const markUserInteracted = () => {
+      userInteractedRef.current = true;
+    };
+    host.addEventListener('beforeinput', markUserInteracted, true);
+    host.addEventListener('paste', markUserInteracted, true);
+    host.addEventListener('drop', markUserInteracted, true);
+
     void Promise.all([
       import('vditor/dist/index.css'),
       import('vditor'),
     ]).then(([, { default: Vditor }]) => {
       if (cancelled || !hostRef.current) return;
 
+      initializingRef.current = true;
+      userInteractedRef.current = false;
       const editor = new Vditor(hostRef.current, {
         value: latestSource.current,
         mode: 'ir',
@@ -229,7 +246,7 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
             // DOMException 让 sanitizingRef 卡死（ISS-170 review follow-up）。
             sanitizingRef.current = true;
             try {
-              const sanitized = sanitizeIrDom(editor);
+              const sanitized = sanitizeIrDom(editor, latestSource.current);
               sanitizingRef.current = false;
               lockComplexTables();
               const host = hostRef.current;
@@ -238,6 +255,8 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
             } catch (error) {
               sanitizingRef.current = false;
               console.error('[Folia] after() queueMicrotask sanitize 失败:', error);
+            } finally {
+              initializingRef.current = false;
             }
           });
 
@@ -263,7 +282,7 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
                 applyingExternalValue.current = false;
                 sanitizingRef.current = true;
                 try {
-                  const sanitized = sanitizeIrDom(editor);
+                  const sanitized = sanitizeIrDom(editor, latestSource.current);
                   sanitizingRef.current = false;
                   lockComplexTables();
                   if (sanitized) emitEditorValueIfChanged(editor);
@@ -276,7 +295,9 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
           }
         },
         input(value) {
-          if (applyingExternalValue.current || sanitizingRef.current) return;
+          if (initializingRef.current || applyingExternalValue.current || sanitizingRef.current) return;
+          if (!editorHasFocus(editor)) return;
+          if (!userInteractedRef.current) return;
 
           // ISS-151: 每次 input 后安排折叠定时器。
           // 粘贴（insertText）不触发 keydown，所以需要在 input 中也安排折叠，
@@ -298,7 +319,7 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
           sanitizingRef.current = true;
           let sanitized = false;
           try {
-            sanitized = sanitizeIrDom(editor);
+            sanitized = sanitizeIrDom(editor, latestSource.current);
           } catch (error) {
             console.error('[Folia] input() sanitize 失败:', error);
           } finally {
@@ -347,7 +368,7 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
               applyingExternalValue.current = false;
               sanitizingRef.current = true;
               try {
-                const restoredSanitized = sanitizeIrDom(editor);
+                const restoredSanitized = sanitizeIrDom(editor, latestSource.current);
                 sanitizingRef.current = false;
                 lockComplexTables();
                 if (restoredSanitized) emitEditorValueIfChanged(editor);
@@ -368,6 +389,7 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
           onChange(nextValue);
         },
         keydown() {
+          userInteractedRef.current = true;
           // 每次按键重置折叠定时器，避免编辑过程中误折叠正在编辑的 IR 节点
           if (collapseTimerRef.current !== null) {
             window.clearTimeout(collapseTimerRef.current);
@@ -389,6 +411,7 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
       editorRef.current = editor;
     }).catch((error) => {
       console.error('[Folia] Vditor 初始化失败:', error);
+      initializingRef.current = false;
       if (!cancelled) {
         setPhase('error');
       }
@@ -396,6 +419,9 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
 
     return () => {
       cancelled = true;
+      host.removeEventListener('beforeinput', markUserInteracted, true);
+      host.removeEventListener('paste', markUserInteracted, true);
+      host.removeEventListener('drop', markUserInteracted, true);
       if (collapseTimerRef.current !== null) {
         window.clearTimeout(collapseTimerRef.current);
         collapseTimerRef.current = null;
@@ -404,6 +430,8 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
       editorRef.current = null;
       lastComplexBlocksRef.current = [];
       pendingSourceRef.current = null;
+      initializingRef.current = false;
+      userInteractedRef.current = false;
     };
   }, [filePath, lockComplexTables, emitEditorValueIfChanged, onChange, retryKey]);
 
@@ -431,7 +459,7 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
       // ISS-168 编辑器部分：外部 setValue 完成后 sanitize IR DOM。
       sanitizingRef.current = true;
       try {
-        const sanitized = sanitizeIrDom(editor);
+        const sanitized = sanitizeIrDom(editor, source);
         sanitizingRef.current = false;
         lockComplexTables();
         if (sanitized) emitEditorValueIfChanged(editor);

--- a/src/services/markdownSvgPreviewService.test.ts
+++ b/src/services/markdownSvgPreviewService.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import 'vditor/dist/js/lute/lute.min.js';
+import { describe, expect, it } from 'vitest';
+import { prepareMarkdownForVditorPreview } from './markdownSvgPreviewService';
+
+type LuteInstance = {
+  SetSanitize: (enable: boolean) => void;
+  Md2HTML: (markdown: string) => string;
+};
+
+const Lute = (globalThis as unknown as { Lute: { New: () => LuteInstance } }).Lute;
+
+function renderMarkdown(markdown: string): string {
+  const lute = Lute.New();
+  lute.SetSanitize(false);
+  return lute.Md2HTML(markdown);
+}
+
+describe('prepareMarkdownForVditorPreview', () => {
+  it('用占位符保护多行 SVG，transform 阶段恢复完整 SVG 并剥离危险属性', () => {
+    const markdown = [
+      '<svg onload="alert(1)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80" width="120" height="80">',
+      '  <rect width="120" height="80" fill="#FFFFFF"/>',
+      '',
+      '  <defs>',
+      '    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">',
+      '      <path d="M0,0 L10,5 L0,10 z" fill="#2C5282"/>',
+      '    </marker>',
+      '  </defs>',
+      '',
+      '  <text onclick="alert(2)" x="60" y="24" font-size="14" fill="#111111" text-anchor="middle">标题</text>',
+      '  <line x1="10" y1="48" x2="110" y2="48" stroke="#222222" stroke-width="2" marker-end="url(#arr)"/>',
+      '</svg>',
+    ].join('\n');
+
+    const prepared = prepareMarkdownForVditorPreview(markdown);
+    const transformed = prepared.transform(renderMarkdown(prepared.markdown));
+    const root = document.createElement('div');
+    root.innerHTML = transformed;
+
+    expect(prepared.markdown).toContain('data-folia-svg-placeholder="0"');
+    expect(prepared.markdown).not.toContain('<svg');
+    expect(root.querySelectorAll('svg')).toHaveLength(1);
+    expect(root.querySelector('svg text')?.textContent).toBe('标题');
+    expect(root.querySelector('svg marker')?.getAttribute('id')).toBe('arr');
+    expect(root.querySelector('svg line')?.getAttribute('marker-end')).toBe('url(#arr)');
+    expect(transformed).not.toContain('onload');
+    expect(transformed).not.toContain('onclick');
+    expect(transformed).not.toContain('alert(');
+  });
+
+  it('不替换代码块里的 SVG 文本', () => {
+    const markdown = [
+      '```html',
+      '<svg viewBox="0 0 10 10">',
+      '  <rect width="10" height="10"/>',
+      '</svg>',
+      '```',
+    ].join('\n');
+
+    const prepared = prepareMarkdownForVditorPreview(markdown);
+
+    expect(prepared.markdown).toBe(markdown);
+    expect(prepared.transform(renderMarkdown(prepared.markdown))).toContain('&lt;svg viewBox="0 0 10 10"&gt;');
+  });
+
+  it('代码围栏结束后继续保护后续多个 SVG 块', () => {
+    const markdown = [
+      '```text',
+      '识别场景 → 梳理流程',
+      '```',
+      '',
+      '<svg viewBox="0 0 20 20" width="20" height="20">',
+      '  <rect width="20" height="20"/>',
+      '</svg>',
+      '',
+      '<svg viewBox="0 0 120 80" width="120" height="80">',
+      '  <rect width="120" height="80" fill="#FFFFFF"/>',
+      '',
+      '  <defs>',
+      '    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">',
+      '      <path d="M0,0 L10,5 L0,10 z" fill="#2C5282"/>',
+      '    </marker>',
+      '  </defs>',
+      '',
+      '  <path d="M 10 40 L 110 40" stroke="#222222" marker-end="url(#arr)"/>',
+      '  <text x="60" y="60" font-size="14">尾注</text>',
+      '</svg>',
+    ].join('\n');
+
+    const prepared = prepareMarkdownForVditorPreview(markdown);
+    const transformed = prepared.transform(renderMarkdown(prepared.markdown));
+    const root = document.createElement('div');
+    root.innerHTML = transformed;
+    const svgs = root.querySelectorAll('svg');
+
+    expect(prepared.markdown.match(/data-folia-svg-placeholder/g)).toHaveLength(2);
+    expect(svgs).toHaveLength(2);
+    expect(svgs[1].querySelector('marker')?.getAttribute('id')).toBe('arr');
+    expect(svgs[1].querySelector('[marker-end]')?.getAttribute('marker-end')).toBe('url(#arr)');
+    expect(svgs[1].querySelector('text')?.textContent).toBe('尾注');
+  });
+});

--- a/src/services/markdownSvgPreviewService.ts
+++ b/src/services/markdownSvgPreviewService.ts
@@ -1,0 +1,108 @@
+import { sanitizeForVditor } from './sanitizeService';
+
+const SVG_PLACEHOLDER_ATTR = 'data-folia-svg-placeholder';
+const SVG_PLACEHOLDER_TAG_PATTERN = new RegExp(
+  `<(div|p)\\s+${SVG_PLACEHOLDER_ATTR}="(\\d+)"\\s*><\\/\\1>`,
+  'gi',
+);
+
+type SvgBlockProtection = {
+  markdown: string;
+  svgBlocks: string[];
+};
+
+export type MarkdownVditorPreviewInput = {
+  markdown: string;
+  transform: (html: string) => string;
+};
+
+function isFenceStart(line: string): RegExpMatchArray | null {
+  return line.match(/^\s{0,3}(`{3,}|~{3,})/);
+}
+
+function isFenceEnd(line: string, fence: string): boolean {
+  const marker = fence[0];
+  return new RegExp(`^\\s{0,3}${marker}{${fence.length},}\\s*$`).test(line);
+}
+
+function isSvgBlockStart(line: string): boolean {
+  return /^\s*<svg(?:\s|>)/i.test(line);
+}
+
+function hasSvgBlockEnd(line: string): boolean {
+  return /<\/svg\s*>/i.test(line);
+}
+
+function protectMarkdownSvgBlocks(markdown: string): SvgBlockProtection {
+  const lines = markdown.split('\n');
+  const output: string[] = [];
+  const svgBlocks: string[] = [];
+  let fence: string | null = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const fenceStart = isFenceStart(line);
+
+    if (fence) {
+      output.push(line);
+      if (isFenceEnd(line, fence)) fence = null;
+      continue;
+    }
+
+    if (fenceStart) {
+      fence = fenceStart[1];
+      output.push(line);
+      continue;
+    }
+
+    if (!isSvgBlockStart(line)) {
+      output.push(line);
+      continue;
+    }
+
+    const blockLines = [line];
+    let endFound = hasSvgBlockEnd(line);
+    while (!endFound && index + 1 < lines.length) {
+      index += 1;
+      blockLines.push(lines[index]);
+      endFound = hasSvgBlockEnd(lines[index]);
+    }
+
+    if (!endFound) {
+      output.push(...blockLines);
+      continue;
+    }
+
+    const placeholderIndex = svgBlocks.push(blockLines.join('\n')) - 1;
+    output.push(`<div ${SVG_PLACEHOLDER_ATTR}="${placeholderIndex}"></div>`);
+  }
+
+  return {
+    markdown: output.join('\n'),
+    svgBlocks,
+  };
+}
+
+function restoreSvgPlaceholders(html: string, svgBlocks: string[]): string {
+  if (svgBlocks.length === 0) return html;
+
+  return html.replace(SVG_PLACEHOLDER_TAG_PATTERN, (_match, _tag: string, indexText: string) => {
+    const index = Number(indexText);
+    return svgBlocks[index] ?? '';
+  });
+}
+
+export function extractMarkdownSvgBlocks(markdown: string): string[] {
+  return protectMarkdownSvgBlocks(markdown).svgBlocks;
+}
+
+export function prepareMarkdownForVditorPreview(markdown: string): MarkdownVditorPreviewInput {
+  const protectedInput = protectMarkdownSvgBlocks(markdown);
+
+  return {
+    markdown: protectedInput.markdown,
+    transform(html) {
+      return sanitizeForVditor(restoreSvgPlaceholders(html, protectedInput.svgBlocks));
+    },
+  };
+}

--- a/src/services/vditorIrSanitizeService.test.ts
+++ b/src/services/vditorIrSanitizeService.test.ts
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 import 'vditor/dist/js/lute/lute.min.js';
 import { describe, expect, it } from 'vitest';
-import { sanitizeVditorIrHtml } from './vditorIrSanitizeService';
+import {
+  FOLIA_IR_SVG_FRAGMENT_CLASS,
+  FOLIA_IR_SVG_ROOT_CLASS,
+  repairSvgIrPreviewsFromMarkdown,
+  repairSplitSvgIrPreviews,
+  sanitizeVditorIrHtml,
+} from './vditorIrSanitizeService';
 
 type LuteInstance = {
   SetSanitize: (enable: boolean) => void;
@@ -52,5 +58,198 @@ describe('sanitizeVditorIrHtml', () => {
     expect(result.html).toContain('data-type="html-block"');
     expect(result.html).toContain('vditor-ir__preview');
     expect(result.html.toLowerCase()).toContain('<svg');
+  });
+
+  it('重组被 Lute 按空行拆开的多行 SVG 预览，同时保留 marker round-trip', () => {
+    const markdown = [
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80" width="120" height="80">',
+      '  <rect width="120" height="80" fill="#FFFFFF"/>',
+      '',
+      '  <!-- 标题 -->',
+      '  <text x="60" y="24" font-size="14" fill="#111111" text-anchor="middle">标题</text>',
+      '',
+      '  <line x1="10" y1="48" x2="110" y2="48" stroke="#222222" stroke-width="2"/>',
+      '</svg>',
+    ].join('\n');
+    const { lute, html } = createIrHtml(markdown);
+    const sanitized = sanitizeVditorIrHtml(html);
+    const root = document.createElement('div');
+    root.innerHTML = sanitized.html;
+
+    const htmlBlockNodes = root.querySelectorAll('.vditor-ir__node[data-type="html-block"]');
+    expect(htmlBlockNodes.length).toBeGreaterThan(1);
+    expect(root.querySelector('.vditor-ir__preview svg text')).toBeNull();
+
+    const changed = repairSplitSvgIrPreviews(root);
+
+    expect(changed).toBe(true);
+    const repairedRoot = root.querySelector(`.${FOLIA_IR_SVG_ROOT_CLASS} .vditor-ir__preview`);
+    expect(repairedRoot?.querySelector('svg text')?.textContent).toBe('标题');
+    expect(repairedRoot?.querySelector('svg line')).not.toBeNull();
+    expect(root.querySelectorAll(`.${FOLIA_IR_SVG_FRAGMENT_CLASS}`).length).toBeGreaterThan(0);
+
+    const roundTrip = lute.VditorIRDOM2Md(root.innerHTML);
+    expect(roundTrip).toContain('<svg');
+    expect(roundTrip).toContain('<text');
+    expect(roundTrip).toContain('标题');
+    expect(roundTrip).toContain('</svg>');
+  });
+
+  it('清理被拆开的多行 SVG marker 中的危险属性，避免保存 round-trip 还原 onload/onclick', () => {
+    const markdown = [
+      '<svg onload="alert(1)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80" width="120" height="80">',
+      '  <rect width="120" height="80" fill="#FFFFFF"/>',
+      '',
+      '  <text onclick="alert(2)" x="60" y="24" font-size="14" fill="#111111" text-anchor="middle">标题</text>',
+      '</svg>',
+    ].join('\n');
+    const { lute, html } = createIrHtml(markdown);
+    const sanitized = sanitizeVditorIrHtml(html);
+    const root = document.createElement('div');
+    root.innerHTML = sanitized.html;
+
+    repairSplitSvgIrPreviews(root);
+    const roundTrip = lute.VditorIRDOM2Md(root.innerHTML);
+
+    expect(roundTrip).toContain('<svg');
+    expect(roundTrip).toContain('<text');
+    expect(roundTrip).toContain('标题');
+    expect(roundTrip).not.toContain('onload');
+    expect(roundTrip).not.toContain('onclick');
+    expect(roundTrip).not.toContain('alert(');
+  });
+
+  it('重组 SVG 时包含相邻 html-inline 片段且不会跨普通正文吞掉下一个 SVG', () => {
+    const root = document.createElement('div');
+    root.innerHTML = [
+      '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+      '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">&lt;svg viewBox="0 0 120 80" width="120" height="80"&gt;\n  &lt;rect width="120" height="80" fill="#FFFFFF"/&gt;</code></pre>',
+      '<pre class="vditor-ir__preview" data-render="1"><svg viewBox="0 0 120 80"><rect width="120" height="80"></rect></svg></pre>',
+      '</div>',
+      '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+      '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">&lt;!-- 末尾片段 --&gt;</code></pre>',
+      '<pre class="vditor-ir__preview" data-render="1"></pre>',
+      '</div>',
+      '<span data-type="html-inline" class="vditor-ir__node"><code class="vditor-ir__marker">&lt;path d="M 10 40 L 110 40" stroke="#222222"/&gt;</code></span>',
+      '<span data-type="html-inline" class="vditor-ir__node"><code class="vditor-ir__marker">&lt;text x="60" y="60" font-size="14"&gt;回流&lt;/text&gt;</code></span>',
+      '<span data-type="html-inline" class="vditor-ir__node"><code class="vditor-ir__marker">&lt;/svg&gt;</code></span>',
+      '<div data-type="strong" class="vditor-ir__node"><span data-type="strong-marker">**</span>图注<span data-type="strong-marker">**</span></div>',
+      '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+      '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">&lt;svg viewBox="0 0 50 50" width="50" height="50"&gt;\n  &lt;text x="25" y="25"&gt;第二图&lt;/text&gt;\n&lt;/svg&gt;</code></pre>',
+      '<pre class="vditor-ir__preview" data-render="1"><svg viewBox="0 0 50 50"><text x="25" y="25">第二图</text></svg></pre>',
+      '</div>',
+    ].join('');
+
+    const changed = repairSplitSvgIrPreviews(root);
+    const repairedRoots = root.querySelectorAll(`.${FOLIA_IR_SVG_ROOT_CLASS}`);
+    const firstSvg = repairedRoots[0]?.querySelector('svg');
+
+    expect(changed).toBe(true);
+    expect(repairedRoots).toHaveLength(1);
+    expect(firstSvg?.querySelector('path')).not.toBeNull();
+    expect(firstSvg?.querySelector('text')?.textContent).toBe('回流');
+    expect(firstSvg?.textContent).not.toContain('第二图');
+    expect(root.querySelectorAll(`.${FOLIA_IR_SVG_FRAGMENT_CLASS}`)).toHaveLength(4);
+  });
+
+  it('修复单个 html-block 中 marker 完整但 preview 只剩背景的 SVG', () => {
+    const root = document.createElement('div');
+    root.innerHTML = [
+      '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+      '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">',
+      '&lt;svg viewBox="0 0 120 80" width="120" height="80"&gt;\n',
+      '  &lt;rect width="120" height="80" fill="#FFFFFF"/&gt;\n',
+      '  &lt;defs&gt;&lt;marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"&gt;&lt;path d="M0,0 L10,5 L0,10 z"/&gt;&lt;/marker&gt;&lt;/defs&gt;\n',
+      '  &lt;line x1="10" y1="40" x2="110" y2="40" stroke="#222222" marker-end="url(#arr)"/&gt;\n',
+      '  &lt;text x="60" y="62" font-size="14"&gt;完整内容&lt;/text&gt;\n',
+      '&lt;/svg&gt;',
+      '</code></pre>',
+      '<pre class="vditor-ir__preview" data-render="1"><svg viewBox="0 0 120 80"><rect width="120" height="80"></rect></svg></pre>',
+      '</div>',
+    ].join('');
+
+    const changed = repairSplitSvgIrPreviews(root);
+    const repairedRoot = root.querySelector(`.${FOLIA_IR_SVG_ROOT_CLASS} .vditor-ir__preview`);
+    const svg = repairedRoot?.querySelector('svg');
+
+    expect(changed).toBe(true);
+    expect(svg?.querySelector('text')?.textContent).toBe('完整内容');
+    expect(svg?.querySelector('line')?.getAttribute('marker-end')).toBe('url(#arr)');
+    expect(svg?.querySelector('marker')?.getAttribute('id')).toBe('arr');
+    expect(root.querySelectorAll(`.${FOLIA_IR_SVG_FRAGMENT_CLASS}`)).toHaveLength(0);
+  });
+
+  it('从 Markdown 原文修复 Lute 已截断 marker 的 SVG 预览', () => {
+    const markdown = [
+      '<svg viewBox="0 0 120 80" width="120" height="80">',
+      '  <rect width="120" height="80" fill="#FFFFFF"/>',
+      '',
+      '  <defs><marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z"/></marker></defs>',
+      '  <line x1="10" y1="40" x2="110" y2="40" stroke="#222222" marker-end="url(#arr)"/>',
+      '  <text x="60" y="62" font-size="14">原文恢复</text>',
+      '</svg>',
+    ].join('\n');
+    const root = document.createElement('div');
+    root.innerHTML = [
+      '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+      '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">',
+      '&lt;svg viewBox="0 0 120 80" width="120" height="80"&gt;\n',
+      '  &lt;rect width="120" height="80" fill="#FFFFFF"&gt;&lt;/rect&gt;&lt;/svg&gt;',
+      '</code></pre>',
+      '<pre class="vditor-ir__preview" data-render="1"><svg viewBox="0 0 120 80"><rect width="120" height="80"></rect></svg></pre>',
+      '</div>',
+    ].join('');
+
+    const changed = repairSvgIrPreviewsFromMarkdown(root, markdown);
+    const repairedRoot = root.querySelector(`.${FOLIA_IR_SVG_ROOT_CLASS} .vditor-ir__preview`);
+    const svg = repairedRoot?.querySelector('svg');
+
+    expect(changed).toBe(true);
+    expect(svg?.querySelector('text')?.textContent).toBe('原文恢复');
+    expect(svg?.querySelector('line')?.getAttribute('marker-end')).toBe('url(#arr)');
+    expect(svg?.querySelector('marker')?.getAttribute('id')).toBe('arr');
+  });
+
+  it('不会把安全的未闭合 SVG 起始 marker 补成截断完整 SVG', () => {
+    const root = document.createElement('div');
+    root.innerHTML = [
+      '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+      '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">',
+      '&lt;svg viewBox="0 0 120 80" width="120" height="80"&gt;\n',
+      '  &lt;rect width="120" height="80" fill="#FFFFFF"/&gt;',
+      '</code></pre>',
+      '<pre class="vditor-ir__preview" data-render="1"><svg viewBox="0 0 120 80"><rect width="120" height="80"></rect></svg></pre>',
+      '</div>',
+    ].join('');
+
+    const result = sanitizeVditorIrHtml(root.innerHTML);
+    const sanitizedRoot = document.createElement('div');
+    sanitizedRoot.innerHTML = result.html;
+    const marker = sanitizedRoot.querySelector<HTMLElement>('code[data-type="html-block"]');
+
+    expect(result.sourceChanged).toBe(false);
+    expect(marker?.textContent).toContain('<svg viewBox="0 0 120 80" width="120" height="80">');
+    expect(marker?.textContent).toContain('<rect width="120" height="80" fill="#FFFFFF"/>');
+    expect(marker?.textContent).not.toContain('</svg>');
+  });
+
+  it('不会把安全 SVG 子片段 marker 当普通 HTML 清洗后触发 sourceChanged', () => {
+    const root = document.createElement('div');
+    root.innerHTML = [
+      '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+      '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">',
+      '&lt;text x="60" y="62" font-size="14" fill="#111111" text-anchor="middle"&gt;片段&lt;/text&gt;',
+      '</code></pre>',
+      '<pre class="vditor-ir__preview" data-render="1"></pre>',
+      '</div>',
+    ].join('');
+
+    const result = sanitizeVditorIrHtml(root.innerHTML);
+    const sanitizedRoot = document.createElement('div');
+    sanitizedRoot.innerHTML = result.html;
+    const marker = sanitizedRoot.querySelector<HTMLElement>('code[data-type="html-block"]');
+
+    expect(result.sourceChanged).toBe(false);
+    expect(marker?.textContent).toBe('<text x="60" y="62" font-size="14" fill="#111111" text-anchor="middle">片段</text>');
   });
 });

--- a/src/services/vditorIrSanitizeService.ts
+++ b/src/services/vditorIrSanitizeService.ts
@@ -1,15 +1,280 @@
 import { sanitizeForVditor } from './sanitizeService';
+import { extractMarkdownSvgBlocks } from './markdownSvgPreviewService';
 
 export type VditorIrSanitizeResult = {
   html: string;
   changed: boolean;
+  sourceChanged: boolean;
 };
+
+export const FOLIA_IR_SVG_ROOT_CLASS = 'folia-ir-svg-root';
+export const FOLIA_IR_SVG_FRAGMENT_CLASS = 'folia-ir-svg-fragment-hidden';
+
+type SplitSvgGroup = {
+  nodes: HTMLElement[];
+  parts: string[];
+};
+
+type SvgPreviewSummary = {
+  elementCount: number;
+  textContent: string;
+  markerReferenceCount: number;
+  tagCounts: Map<string, number>;
+};
+
+const SVG_PREVIEW_SUMMARY_TAGS = [
+  'defs',
+  'marker',
+  'path',
+  'rect',
+  'text',
+  'line',
+  'circle',
+  'ellipse',
+  'polygon',
+  'polyline',
+] as const;
+
+function isIrHtmlNode(element: Element | null): element is HTMLElement {
+  return element instanceof HTMLElement
+    && element.classList.contains('vditor-ir__node')
+    && (
+      element.getAttribute('data-type') === 'html-block'
+      || element.getAttribute('data-type') === 'html-inline'
+    );
+}
+
+function getIrHtmlNodes(root: ParentNode): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      '.vditor-ir__node[data-type="html-block"], .vditor-ir__node[data-type="html-inline"]',
+    ),
+  );
+}
+
+function getHtmlBlockNodes(root: ParentNode): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>('.vditor-ir__node[data-type="html-block"]'),
+  );
+}
+
+function getIrHtmlMarker(node: HTMLElement): HTMLElement | null {
+  if (node.getAttribute('data-type') === 'html-block') {
+    return node.querySelector<HTMLElement>('code[data-type="html-block"]');
+  }
+
+  return node.querySelector<HTMLElement>('code.vditor-ir__marker');
+}
+
+function getIrHtmlMarkerText(node: HTMLElement): string | null {
+  const marker = getIrHtmlMarker(node);
+  if (!marker) return null;
+  return marker.textContent ?? '';
+}
+
+function isSvgStart(text: string): boolean {
+  return /^<svg(?:\s|>)/i.test(text.trimStart());
+}
+
+function hasSvgEnd(text: string): boolean {
+  return /<\/svg\s*>/i.test(text);
+}
+
+function isSvgFragmentLike(text: string): boolean {
+  const trimmed = text.trimStart();
+  return isSvgStart(trimmed)
+    || /^<\/svg\s*>/i.test(trimmed)
+    || /^<(?:!--|defs|marker|path|rect|text|line|circle|ellipse|polygon|polyline|g|use)(?:\s|>|\/)/i.test(trimmed)
+    || /^<\/(?:defs|marker|g)\s*>/i.test(trimmed);
+}
+
+function getNextAdjacentIrHtmlNode(node: HTMLElement): HTMLElement | null {
+  const next = node.nextElementSibling;
+  return isIrHtmlNode(next) ? next : null;
+}
+
+function collectSplitSvgGroups(
+  nodes: HTMLElement[],
+  options: { includeSingleClosed?: boolean } = {},
+): SplitSvgGroup[] {
+  const groups: SplitSvgGroup[] = [];
+  const visited = new Set<HTMLElement>();
+
+  for (const node of nodes) {
+    if (visited.has(node)) continue;
+    const firstMarker = getIrHtmlMarkerText(node);
+    if (firstMarker === null || !isSvgStart(firstMarker)) continue;
+
+    const group: HTMLElement[] = [];
+    const parts: string[] = [];
+    let closed = false;
+    let current: HTMLElement | null = node;
+
+    while (current) {
+      const marker = getIrHtmlMarkerText(current);
+      if (marker === null) break;
+      group.push(current);
+      parts.push(marker);
+      visited.add(current);
+      if (hasSvgEnd(marker)) {
+        closed = true;
+        break;
+      }
+      current = getNextAdjacentIrHtmlNode(current);
+    }
+
+    if (closed && (group.length > 1 || options.includeSingleClosed)) {
+      groups.push({ nodes: group, parts });
+    }
+  }
+
+  return groups;
+}
+
+function createSvgPreviewSummary(svg: SVGSVGElement): SvgPreviewSummary {
+  return {
+    elementCount: svg.querySelectorAll('*').length,
+    textContent: (svg.textContent ?? '').trim(),
+    markerReferenceCount: svg.querySelectorAll('[marker-start], [marker-mid], [marker-end]').length,
+    tagCounts: new Map(
+      SVG_PREVIEW_SUMMARY_TAGS.map((tagName) => [
+        tagName,
+        svg.querySelectorAll(tagName).length,
+      ]),
+    ),
+  };
+}
+
+function createSvgPreviewSummaryFromHtml(html: string): SvgPreviewSummary | null {
+  const root = document.createElement('div');
+  root.innerHTML = html;
+  const svg = root.querySelector('svg');
+  if (!svg) return null;
+  return createSvgPreviewSummary(svg);
+}
+
+function createSvgPreviewSummaryFromElement(root: ParentNode): SvgPreviewSummary | null {
+  const svg = root.querySelector('svg');
+  if (!svg) return null;
+  return createSvgPreviewSummary(svg);
+}
+
+function needsSvgPreviewRepair(preview: HTMLElement, repairedSvg: string): boolean {
+  const expected = createSvgPreviewSummaryFromHtml(repairedSvg);
+  const actual = createSvgPreviewSummaryFromElement(preview);
+
+  if (!expected) return false;
+  if (!actual) return true;
+  if (actual.elementCount < expected.elementCount) return true;
+  if (actual.markerReferenceCount < expected.markerReferenceCount) return true;
+  if (actual.textContent !== expected.textContent) return true;
+
+  for (const [tagName, expectedCount] of expected.tagCounts) {
+    if ((actual.tagCounts.get(tagName) ?? 0) < expectedCount) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function renderSvgPreviewFromSource(node: HTMLElement, sourceSvg: string): boolean {
+  const firstPreview = node.querySelector<HTMLElement>('.vditor-ir__preview');
+  if (!firstPreview) return false;
+
+  const repairedSvg = sanitizeForVditor(sourceSvg);
+  if (!/<svg(?:\s|>)/i.test(repairedSvg)) return false;
+  if (!needsSvgPreviewRepair(firstPreview, repairedSvg) && firstPreview.innerHTML === repairedSvg) {
+    return false;
+  }
+
+  firstPreview.innerHTML = repairedSvg;
+  node.classList.add(FOLIA_IR_SVG_ROOT_CLASS);
+  return true;
+}
+
+function containsDangerousSvgMarkup(svg: string): boolean {
+  return /<script\b|<foreignObject\b|\son[a-z][\w:-]*\s*=|\s(?:href|xlink:href)\s*=\s*["']?\s*javascript:/i.test(svg);
+}
+
+function extractSvgInnerHtml(svgHtml: string): string {
+  const root = document.createElement('div');
+  root.innerHTML = svgHtml;
+  return root.querySelector('svg')?.innerHTML ?? '';
+}
+
+function sanitizeSvgMarkerPart(part: string, index: number, lastIndex: number): string {
+  const isFirst = index === 0;
+  const isLast = index === lastIndex;
+
+  if (isFirst) {
+    const needsClosingTag = !hasSvgEnd(part);
+    const sanitized = sanitizeForVditor(needsClosingTag ? `${part}\n</svg>` : part);
+    return needsClosingTag ? sanitized.replace(/\s*<\/svg\s*>\s*$/i, '') : sanitized;
+  }
+
+  const withoutClosingTag = part.replace(/\s*<\/svg\s*>\s*$/i, '');
+  const sanitizedInner = extractSvgInnerHtml(sanitizeForVditor(`<svg>${withoutClosingTag}</svg>`));
+  return isLast ? `${sanitizedInner}\n</svg>` : sanitizedInner;
+}
+
+function sanitizeSvgFragmentMarker(fragment: string): string {
+  if (isSvgStart(fragment) && !hasSvgEnd(fragment)) {
+    return sanitizeSvgMarkerPart(fragment, 0, 0);
+  }
+
+  return sanitizeSvgMarkerPart(fragment, 1, hasSvgEnd(fragment) ? 1 : 2);
+}
+
+function sanitizeSplitSvgMarkers(groups: SplitSvgGroup[]): boolean {
+  let changed = false;
+
+  groups.forEach((group) => {
+    const fullSvg = group.parts.join('\n');
+    if (!containsDangerousSvgMarkup(fullSvg)) return;
+
+    group.nodes.forEach((node, index) => {
+      const marker = getIrHtmlMarker(node);
+      if (!marker) return;
+      const original = marker.textContent ?? '';
+      const sanitized = sanitizeSvgMarkerPart(original, index, group.nodes.length - 1);
+      if (sanitized !== original) {
+        marker.textContent = sanitized;
+        changed = true;
+      }
+    });
+  });
+
+  return changed;
+}
 
 function sanitizeHtmlBlockMarkers(root: HTMLElement): boolean {
   let changed = false;
-  root.querySelectorAll<HTMLElement>('code[data-type="html-block"]').forEach((marker) => {
+  const splitSvgGroups = collectSplitSvgGroups(getIrHtmlNodes(root));
+  const splitSvgNodes = new Set(splitSvgGroups.flatMap((group) => group.nodes));
+
+  if (sanitizeSplitSvgMarkers(splitSvgGroups)) {
+    changed = true;
+  }
+
+  getHtmlBlockNodes(root).forEach((node) => {
+    if (splitSvgNodes.has(node)) return;
+
+    const marker = getIrHtmlMarker(node);
+    if (!marker) return;
     const original = marker.textContent ?? '';
     if (original === '') return;
+
+    if (isSvgFragmentLike(original)) {
+      if (!containsDangerousSvgMarkup(original)) return;
+
+      const sanitized = sanitizeSvgFragmentMarker(original);
+      if (sanitized !== original) {
+        marker.textContent = sanitized;
+        changed = true;
+      }
+      return;
+    }
 
     const sanitized = sanitizeForVditor(original);
     if (sanitized !== original) {
@@ -28,7 +293,7 @@ function sanitizeHtmlBlockMarkers(root: HTMLElement): boolean {
  * source text available for save/export round-trip.
  */
 export function sanitizeVditorIrHtml(irHtml: string): VditorIrSanitizeResult {
-  if (irHtml === '') return { html: irHtml, changed: false };
+  if (irHtml === '') return { html: irHtml, changed: false, sourceChanged: false };
 
   const root = document.createElement('div');
   root.innerHTML = irHtml;
@@ -40,5 +305,99 @@ export function sanitizeVditorIrHtml(irHtml: string): VditorIrSanitizeResult {
   return {
     html: sanitized,
     changed: markerChanged || sanitized !== irHtml,
+    sourceChanged: markerChanged,
   };
+}
+
+/**
+ * Repair Vditor IR previews for pretty-printed inline SVG.
+ *
+ * Lute's IR renderer splits an SVG HTML block at blank lines, which turns a
+ * single `<svg>...</svg>` into many `html-block` nodes. The first preview then
+ * often contains only the white background rect, while the real text/lines sit
+ * in later invalid fragments. Recompose the visible preview from the marker
+ * text only; marker text remains intact so save/round-trip semantics stay owned
+ * by Vditor.
+ */
+export function repairSplitSvgIrPreviews(root: ParentNode): boolean {
+  const nodes = getIrHtmlNodes(root);
+  if (nodes.length === 0) return false;
+
+  let changed = false;
+
+  nodes.forEach((node) => {
+    if (node.classList.contains(FOLIA_IR_SVG_ROOT_CLASS)) {
+      node.classList.remove(FOLIA_IR_SVG_ROOT_CLASS);
+      changed = true;
+    }
+    if (node.classList.contains(FOLIA_IR_SVG_FRAGMENT_CLASS)) {
+      node.classList.remove(FOLIA_IR_SVG_FRAGMENT_CLASS);
+      changed = true;
+    }
+  });
+
+  collectSplitSvgGroups(nodes, { includeSingleClosed: true }).forEach((group) => {
+    const firstPreview = group.nodes[0].querySelector<HTMLElement>('.vditor-ir__preview');
+    if (!firstPreview) {
+      return;
+    }
+
+    const repairedSvg = sanitizeForVditor(group.parts.join('\n'));
+    if (!/<svg(?:\s|>)/i.test(repairedSvg)) {
+      return;
+    }
+    if (group.nodes.length === 1 && !needsSvgPreviewRepair(firstPreview, repairedSvg)) {
+      return;
+    }
+
+    if (firstPreview.innerHTML !== repairedSvg) {
+      firstPreview.innerHTML = repairedSvg;
+      changed = true;
+    }
+    if (!group.nodes[0].classList.contains(FOLIA_IR_SVG_ROOT_CLASS)) {
+      group.nodes[0].classList.add(FOLIA_IR_SVG_ROOT_CLASS);
+      changed = true;
+    }
+
+    group.nodes.slice(1).forEach((node) => {
+      if (!node.classList.contains(FOLIA_IR_SVG_FRAGMENT_CLASS)) {
+        node.classList.add(FOLIA_IR_SVG_FRAGMENT_CLASS);
+        changed = true;
+      }
+    });
+  });
+
+  return changed;
+}
+
+/**
+ * Repair IR SVG previews against the original Markdown source.
+ *
+ * Some SVG blocks are not only split by Lute; their IR marker can be truncated
+ * to the opening `<svg>` plus the background rect. In that case marker-based
+ * repair has no complete source to rebuild from, so we use the original
+ * Markdown SVG blocks by document order for the visible preview only.
+ */
+export function repairSvgIrPreviewsFromMarkdown(root: ParentNode, markdown: string): boolean {
+  const sourceSvgBlocks = extractMarkdownSvgBlocks(markdown);
+  if (sourceSvgBlocks.length === 0) return repairSplitSvgIrPreviews(root);
+
+  let changed = repairSplitSvgIrPreviews(root);
+  const nodes = getIrHtmlNodes(root);
+  let sourceIndex = 0;
+
+  nodes.forEach((node) => {
+    const marker = getIrHtmlMarkerText(node);
+    if (marker === null || !isSvgStart(marker)) return;
+
+    const sourceSvg = sourceSvgBlocks[sourceIndex];
+    sourceIndex += 1;
+    if (!sourceSvg) return;
+
+    if (renderSvgPreviewFromSource(node, sourceSvg)) {
+      changed = true;
+    }
+  });
+
+  return changed;
 }

--- a/src/services/vditorPreviewChromeService.ts
+++ b/src/services/vditorPreviewChromeService.ts
@@ -1,0 +1,14 @@
+export function removeVditorPreviewChrome(root: ParentNode): void {
+  root.querySelectorAll(
+    '.vditor-tooltipped, .vditor-copy, .vditor-code-copy, [data-clipboard-text]',
+  ).forEach((element) => {
+    element.remove();
+  });
+}
+
+export function stripVditorPreviewChrome(html: string): string {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  removeVditorPreviewChrome(template.content);
+  return template.innerHTML;
+}

--- a/src/services/wechatPreviewService.test.ts
+++ b/src/services/wechatPreviewService.test.ts
@@ -116,6 +116,74 @@ describe('wechatPreviewService', () => {
     expect(html).not.toContain('<script');
   });
 
+  it('preserves safe inline SVG and marker references while removing dangerous SVG markup', () => {
+    const result = createHtmlExportResult('', `
+      <svg onload="alert(1)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" width="20" height="20">
+        <defs>
+          <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#2C5282"></path>
+          </marker>
+        </defs>
+        <line onclick="alert(2)" x1="1" y1="10" x2="18" y2="10" stroke="#2C5282" stroke-width="2" marker-end="url(#arr)"></line>
+        <script>alert(3)</script>
+      </svg>
+    `);
+
+    for (const html of [result.previewHtml, result.clipboardHtml]) {
+      expect(html).toContain('<svg');
+      expect(html).toContain('<marker');
+      expect(html).toContain('id="arr"');
+      expect(html).toContain('marker-end="url(#arr)"');
+      expect(html).not.toContain('onload');
+      expect(html).not.toContain('onclick');
+      expect(html).not.toContain('<script');
+      expect(html).not.toContain('alert(');
+    }
+
+    const svg = queryRequired<Element>(getDocumentBody(result.previewHtml), 'svg');
+    const marker = queryRequired<Element>(svg, 'marker');
+    const line = queryRequired<Element>(svg, 'line');
+
+    expect(svg.getAttribute('viewBox')).toBe('0 0 20 20');
+    expect(marker.getAttribute('id')).toBe('arr');
+    expect(line.getAttribute('marker-end')).toBe('url(#arr)');
+  });
+
+  it('does not create blank duplicate SVGs when sanitizing pretty-printed SVG blocks', () => {
+    const result = createHtmlExportResult('', [
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80" width="120" height="80">',
+      '  <rect width="120" height="80" fill="#FFFFFF"/>',
+      '',
+      '  <!-- 标题 -->',
+      '  <text x="60" y="24" font-size="14" fill="#111111" text-anchor="middle">标题</text>',
+      '',
+      '  <!-- 连接线 -->',
+      '  <line x1="10" y1="48" x2="110" y2="48" stroke="#222222" stroke-width="2"/>',
+      '</svg>',
+    ].join('\n'));
+    const body = getDocumentBody(result.previewHtml);
+    const svgs = body.querySelectorAll('svg');
+
+    expect(svgs).toHaveLength(1);
+    expect(svgs[0].querySelectorAll('text')).toHaveLength(1);
+    expect(svgs[0].querySelectorAll('line')).toHaveLength(1);
+    expect(svgs[0].querySelectorAll('rect')).toHaveLength(1);
+  });
+
+  it('removes Vditor preview chrome before wrapping export HTML', () => {
+    const result = createHtmlExportResult('', `
+      <pre><code class="language-ts hljs">const ok = true</code></pre>
+      <button class="vditor-tooltipped vditor-tooltipped__w" aria-label="复制">
+        <svg><use xlink:href="#vditor-icon-copy"></use></svg>
+      </button>
+    `);
+
+    expect(result.previewHtml).toContain('<pre><code class="language-ts hljs">');
+    expect(result.previewHtml).not.toContain('vditor-tooltipped');
+    expect(result.previewHtml).not.toContain('vditor-icon-copy');
+    expect(getDocumentBody(result.previewHtml).querySelectorAll('svg')).toHaveLength(0);
+  });
+
   it('detects local relative images that cannot be copied directly to WeChat', () => {
     const warnings = detectLocalRelativeImages(`
       <img src="./images/local.png" alt="local" />

--- a/src/services/wechatPreviewService.ts
+++ b/src/services/wechatPreviewService.ts
@@ -10,6 +10,10 @@ import {
   type CustomHtmlExportPresetId,
   type HtmlExportPreset,
 } from './htmlExportPresets';
+import {
+  removeVditorPreviewChrome,
+  stripVditorPreviewChrome,
+} from './vditorPreviewChromeService';
 
 export {
   HTML_EXPORT_ARTICLE_CLASS,
@@ -178,6 +182,12 @@ const ALLOWED_TAGS = [
   'div', 'section', 'span',
   'a', 'img',
   'details', 'summary',
+  'svg', 'g', 'defs', 'marker',
+  'path', 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon',
+  'text', 'tspan', 'title', 'desc',
+  'filter', 'fedropshadow', 'fegaussianblur', 'feoffset', 'feblend',
+  'fecolormatrix', 'feflood', 'fecomposite',
+  'lineargradient', 'radialgradient', 'stop',
 ];
 
 const ALLOWED_ATTR = [
@@ -185,6 +195,18 @@ const ALLOWED_ATTR = [
   'colspan', 'rowspan',
   'align', 'width', 'height',
   'class', 'style',
+  'id', 'xmlns', 'viewBox', 'viewbox', 'preserveAspectRatio', 'preserveaspectratio',
+  'x', 'y', 'x1', 'y1', 'x2', 'y2',
+  'cx', 'cy', 'r', 'rx', 'ry',
+  'd', 'points',
+  'fill', 'fill-opacity', 'stroke', 'stroke-width', 'stroke-linecap',
+  'stroke-linejoin', 'stroke-dasharray', 'stroke-opacity',
+  'font-family', 'font-size', 'font-weight', 'text-anchor', 'dominant-baseline',
+  'marker-start', 'marker-mid', 'marker-end',
+  'refX', 'refx', 'refY', 'refy',
+  'markerWidth', 'markerwidth', 'markerHeight', 'markerheight',
+  'orient', 'offset', 'opacity', 'transform',
+  'filter', 'stop-color', 'stop-opacity',
 ];
 
 const ALLOWED_CLASS_NAME = /^(?:hljs(?:-[a-z0-9_-]+)?|language-[a-z0-9_-]+)$/i;
@@ -197,6 +219,7 @@ const INLINEABLE_ARTICLE_TAGS = new Set([
   'strong', 'b', 'em', 'i', 'u', 's',
   'span', 'div', 'section', 'hr',
   'code', 'pre',
+  'svg',
 ]);
 
 export const DEFAULT_INLINE_STYLE_RULES: InlineStyleRule[] = [
@@ -250,6 +273,10 @@ export const DEFAULT_INLINE_STYLE_RULES: InlineStyleRule[] = [
   },
   {
     selectors: [`.${WECHAT_ARTICLE_CLASS} img`],
+    declarations: 'display: block; max-width: 100%; height: auto; margin: 1em auto',
+  },
+  {
+    selectors: [`.${WECHAT_ARTICLE_CLASS} svg`],
     declarations: 'display: block; max-width: 100%; height: auto; margin: 1em auto',
   },
   {
@@ -556,6 +583,43 @@ function isUnsafeHtmlUrl(value: string, attributeName: string): boolean {
   return normalized.startsWith('data:');
 }
 
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+const SVG_LOCAL_REFERENCE_ATTRS = [
+  'marker-start',
+  'marker-mid',
+  'marker-end',
+  'filter',
+  'fill',
+  'stroke',
+];
+
+function isSvgElement(element: Element): boolean {
+  return element.namespaceURI === SVG_NAMESPACE;
+}
+
+function isUnsafeSvgReferenceValue(value: string): boolean {
+  const normalized = Array.from(value).filter((character) => {
+    const code = character.charCodeAt(0);
+    return code > 31 && code !== 127 && !/\s/.test(character);
+  }).join('').toLowerCase();
+  if (/^(?:javascript|vbscript|data):/.test(normalized)) return true;
+  if (!/url\(/i.test(value)) return false;
+
+  return !/^url\((?:"#[A-Za-z][\w:.-]*"|'#[A-Za-z][\w:.-]*'|#[A-Za-z][\w:.-]*)\)$/i.test(value.trim());
+}
+
+function sanitizeSvgReferenceAttributes(root: ParentNode): void {
+  root.querySelectorAll('svg, svg *').forEach((element) => {
+    SVG_LOCAL_REFERENCE_ATTRS.forEach((attributeName) => {
+      const value = element.getAttribute(attributeName);
+      if (value && isUnsafeSvgReferenceValue(value)) {
+        element.removeAttribute(attributeName);
+      }
+    });
+  });
+}
+
 function normalizeSafeArticleClasses(root: ParentNode): void {
   root.querySelectorAll<HTMLElement>('[class]').forEach((element) => {
     const classNames = Array.from(element.classList);
@@ -596,7 +660,7 @@ function sanitizeUrlAttributes(root: ParentNode): void {
 }
 
 function sanitizeHtmlExportArticleFragment(articleHtml: string): string {
-  const sanitized = DOMPurify.sanitize(articleHtml, {
+  const sanitized = DOMPurify.sanitize(stripVditorPreviewChrome(articleHtml), {
     ALLOWED_TAGS,
     ALLOWED_ATTR,
     ALLOW_DATA_ATTR: false,
@@ -604,10 +668,14 @@ function sanitizeHtmlExportArticleFragment(articleHtml: string): string {
   const template = document.createElement('template');
   template.innerHTML = sanitized;
 
+  removeVditorPreviewChrome(template.content);
   template.content.querySelectorAll('[id]').forEach((element) => {
-    element.removeAttribute('id');
+    if (!isSvgElement(element)) {
+      element.removeAttribute('id');
+    }
   });
   sanitizeUrlAttributes(template.content);
+  sanitizeSvgReferenceAttributes(template.content);
   normalizeSafeArticleClasses(template.content);
   sanitizeInlineStyleAttributes(template.content);
 

--- a/src/services/wordPreviewArtifactService.test.ts
+++ b/src/services/wordPreviewArtifactService.test.ts
@@ -13,10 +13,14 @@ vi.mock('./word', () => ({
 
 vi.mock('vditor', () => ({
   default: {
-    preview: vi.fn((element: HTMLDivElement, markdown: string, options: { after?: () => void }) => {
-      element.innerHTML = markdown
+    preview: vi.fn((element: HTMLDivElement, markdown: string, options: {
+      after?: () => void;
+      transform?: (html: string) => string;
+    }) => {
+      const rendered = markdown
         .replace(/^# (.+)$/m, '<h1>$1</h1>')
         .replace(/\n\n(.+)$/m, '<p>$1</p>');
+      element.innerHTML = options.transform ? options.transform(rendered) : rendered;
       options.after?.();
     }),
   },
@@ -38,5 +42,36 @@ describe('createWordPreviewArtifact', () => {
     expect(artifact.html).toContain('正文段落');
     expect(markdownToDocxMock).not.toHaveBeenCalled();
     expect(Vditor.preview).toHaveBeenCalledWith(expect.any(HTMLDivElement), '# 标题\n\n正文段落', expect.any(Object));
+  });
+
+  it('preserves safe inline SVG in Word preview HTML and strips dangerous SVG attributes', async () => {
+    const artifact = await createWordPreviewArtifact([
+      '<svg onload="alert(1)" viewBox="0 0 10 10" width="10" height="10">',
+      '<rect onclick="alert(2)" width="10" height="10" fill="#fff"/>',
+      '</svg>',
+    ].join('\n'));
+
+    expect(artifact.html).toContain('<svg');
+    expect(artifact.html).toContain('<rect');
+    expect(artifact.html).toContain('viewBox');
+    expect(artifact.html).not.toContain('onload');
+    expect(artifact.html).not.toContain('onclick');
+    expect(artifact.html).not.toContain('alert(');
+  });
+
+  it('removes Vditor preview chrome from Word preview HTML', async () => {
+    const artifact = await createWordPreviewArtifact([
+      '<pre><code class="language-ts hljs">const ok = true</code></pre>',
+      '<button class="vditor-tooltipped vditor-tooltipped__w" aria-label="复制">',
+      '<svg><use xlink:href="#vditor-icon-copy"></use></svg>',
+      '</button>',
+    ].join('\n'));
+    const root = document.createElement('div');
+    root.innerHTML = artifact.html;
+
+    expect(artifact.html).toContain('<pre><code');
+    expect(artifact.html).not.toContain('vditor-tooltipped');
+    expect(artifact.html).not.toContain('vditor-icon-copy');
+    expect(root.querySelectorAll('svg')).toHaveLength(0);
   });
 });

--- a/src/services/wordPreviewArtifactService.ts
+++ b/src/services/wordPreviewArtifactService.ts
@@ -1,5 +1,6 @@
 import { detectMarkdownRenderFeatures } from './markdownFeatureDetector';
-import { sanitizeHtml } from './sanitizeService';
+import { prepareMarkdownForVditorPreview } from './markdownSvgPreviewService';
+import { stripVditorPreviewChrome } from './vditorPreviewChromeService';
 import { VDITOR_PREVIEW_I18N } from './vditorPreviewConfig';
 
 export interface MarkdownHtmlPreviewArtifact {
@@ -19,6 +20,7 @@ export async function createWordPreviewArtifact(
 
   const container = document.createElement('div');
   const renderFeatures = detectMarkdownRenderFeatures(markdown);
+  const markdownPreviewInput = prepareMarkdownForVditorPreview(markdown);
 
   await new Promise<void>((resolve, reject) => {
     let settled = false;
@@ -29,7 +31,7 @@ export async function createWordPreviewArtifact(
     };
 
     try {
-      const result = Vditor.preview(container, markdown, {
+      const result = Vditor.preview(container, markdownPreviewInput.markdown, {
         mode: 'light',
         anchor: 0,
         cdn: '/vditor',
@@ -45,8 +47,9 @@ export async function createWordPreviewArtifact(
           lineNumber: false,
         },
         markdown: {
-          sanitize: true,
+          sanitize: false,
         },
+        transform: markdownPreviewInput.transform,
         after: finish,
       });
 
@@ -58,5 +61,8 @@ export async function createWordPreviewArtifact(
     }
   });
 
-  return { source: 'markdown-html', html: sanitizeHtml(container.innerHTML) };
+  return {
+    source: 'markdown-html',
+    html: markdownPreviewInput.transform(stripVditorPreviewChrome(container.innerHTML)),
+  };
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1219,6 +1219,20 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
   overflow-wrap: anywhere;
 }
 
+.wysiwyg-editor-pane .folia-ir-svg-fragment-hidden {
+  display: none !important;
+}
+
+.wysiwyg-editor-pane .folia-ir-svg-root > .vditor-ir__preview {
+  overflow-x: auto;
+}
+
+.wysiwyg-editor-pane .folia-ir-svg-root > .vditor-ir__preview > svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
 /* ===== Preview Shell ===== */
 
 .preview-shell {


### PR DESCRIPTION
## 摘要
- 主编辑器 IR preview 引入 source-aware SVG 修复：拆块 marker 通过 `repairSplitSvgIrPreviews()` 重组可见 preview；marker 已被 Lute 截断时通过 `repairSvgIrPreviewsFromMarkdown()` 按文档顺序用原始 Markdown SVG block 重建；后续碎片节点只做视觉隐藏，不修改用户源文件。
- sanitize 策略收窄：安全的未闭合 SVG 起始片段、SVG 子片段不再触发 DOMPurify 补闭合或重排，避免初始化阶段把污染内容回写到 app state；命中危险内容（`<script>` / `<foreignObject>` / `on*` / `javascript:`）的片段仍按 SVG fragment 包裹清洗。
- Markdown preview 链路（HTML / WeChat / Word）共用 `prepareMarkdownForVditorPreview()`：交给 Vditor 前用占位符替换完整 SVG block，transform 阶段恢复并由 `sanitizeForVditor()` 剥离危险属性；`markdown.sanitize` 关闭内置清洗，由 Folia 的 transform 钩子接管。
- HTML / Word 预览新增 `vditorPreviewChromeService`，导出前 / DOMPurify 前后统一剥离 Vditor 复制按钮等 preview chrome，避免 SVG 图标进入文章 DOM。
- WeChat 导出放行 SVG 元素与必要属性，新增 `sanitizeSvgReferenceAttributes()` 校验 `marker-*` / `fill` / `stroke` / `filter` 等本地引用，剥离 `javascript:` / `vbscript:` / `data:` URL；新增 `svg` 内联样式规则。

## 测试计划
- [x] `npm test`：47 files / 385 tests 全绿（覆盖 `vditorIrSanitizeService` / `markdownSvgPreviewService` / `WechatPreviewPane` / `WysiwygEditorPane` / `wechatPreviewService` / `wordPreviewArtifactService` 新增与扩展用例）
- [x] `npm run typecheck` 通过
- [x] `npm run lint` 通过
- [x] 实操：Vite dev + Playwright Chromium 注入用户 `ch07.md`（7 张 AI 生成内联 SVG），主编辑器 / HTML 预览 / Word 预览测量层和分页层均为 7 张完整 SVG；初始化后 `dirty=false`、`content === lastSavedContent`，session 保持干净；preview chrome SVG / `<script>` / 事件属性计数为 0。截图 `/tmp/folia-svg-html-preview-verified.png` 与 `/tmp/folia-svg-word-preview-verified.png` 已留档。

## Agent 归属
- 本地 main 上未提交改动包装为 PR，对应决策 `docs/DECISIONS.md` DEC-112、Issue ISS-176
- 触发来源：用户要求把 main 上的修复改动总结成 PR、review、merge

## 关联任务
- ISS-176（Markdown 内联 SVG 渲染截断）
- DEC-112（修复决策）
- 与 PR #59 `feat/svg-compat`（仅 HTML 阅读预览）互补，本 PR 覆盖编辑器 + WeChat + Word 三条预览链路

## 风险
- 主编辑器 IR 修复涉及 sanitize 行为变更：仍保留 `containsDangerousSvgMarkup()` 检测 `<script>` / `<foreignObject>` / `on*` / `javascript:` 并按 SVG fragment 包裹清洗；新增 `initializingRef` 与 user-interaction 守卫，初始化期间与未触发交互的 `input()` 直接 return，防止 Vditor Lute 中间值覆盖原文。
- WeChat SVG 放行涉及 DOMPurify 配置变更：仅 `wechatPreviewService` 内部 `createHtmlExportResult` 路径生效，不影响主应用其他清洗入口；导出 HTML 仍经 `stripVditorPreviewChrome` + `sanitizeSvgReferenceAttributes` + 现有 URL / class 清洗。
- 用户 Markdown 文件不会被改写（不做压缩 SVG / 删空行 / 转图等预处理）。回退方式：revert 该 PR 即可恢复 main 上原 sanitize 行为。

## Commit log（5 个聚焦 commit）
- `5cf865f` feat(svg): 新增 Markdown SVG 占位保护与 preview chrome 剥离服务
- `5a25635` fix(ir-sanitize): 拆块 SVG IR preview 重组 + 安全 SVG 片段 sanitize 收窄
- `258bd8a` fix(svg): 主编辑器 / HTML / WeChat / Word 预览接入 SVG 占位保护与 chrome 清理
- `de7518f` docs(changelog): 记录 ISS-176 / DEC-112 SVG 渲染修复
- `f9a3c33` style(editor): IR 拆块 SVG fragment 节点视觉隐藏 + preview 横向滚动