### PR TITLE
fix(svg): DEC-114 修复部分多行 SVG 后方残留白色条 + 主编辑器 SVG 字体

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复部分多行 SVG 后方仍出现大段白色条的问题：Vditor IR 在清洗后会把部分 SVG 子片段（尤其是 `<path>`）降级成普通段落，旧的 SVG 修复器只沿相邻 IR HTML 节点收集，遇到普通段落就停止，导致“初版 Skill 的文件结构”等图后方残留空白源码块。现在 source-aware SVG 修复会按原始 Markdown SVG 源码顺序继续识别并隐藏后续残留片段，同时保留图注和正文；Playwright 注入用户 `ch07.md` 实测 7 张 SVG 全部恢复且无可见残留，session 仍保持未修改。
+- 修复主编辑器内 SVG 文本继承 `<pre>` 等宽字体的问题：部分 AI 生成 SVG 未指定 `font-family`，在 Vditor IR 预览中会继承代码块字体，导致长英文标签比原设计更宽，看起来像被框或白底截掉。现在修复后的 SVG 预览使用阅读正文字体；“初版 Skill 的文件结构”根节点文字宽度实测由约 285px 降为约 226.6px，可正常落在 240px 蓝框内。
+
 ## [0.4.4] - 2026-06-22
 
 ### Fixed

--- a/src/services/vditorIrSanitizeService.test.ts
+++ b/src/services/vditorIrSanitizeService.test.ts
@@ -210,6 +210,59 @@ describe('sanitizeVditorIrHtml', () => {
     expect(svg?.querySelector('marker')?.getAttribute('id')).toBe('arr');
   });
 
+  it('从 Markdown 原文修复后隐藏被普通段落承载的 SVG 残留片段', () => {
+    const markdown = [
+      '<svg viewBox="0 0 120 80" width="120" height="80">',
+      '  <rect width="120" height="80" fill="#FFFFFF"/>',
+      '',
+      '  <!-- 标题 -->',
+      '  <text x="60" y="24" font-size="14">源标题</text>',
+      '',
+      '  <path d="M 10 40 L 110 40" stroke="#222222"/>',
+      '',
+      '  <text x="60" y="62" font-size="14">尾部</text>',
+      '</svg>',
+      '',
+      '**图：源标题**',
+    ].join('\n');
+    const root = document.createElement('div');
+    root.innerHTML = [
+      '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+      '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">',
+      '&lt;svg viewBox="0 0 120 80" width="120" height="80"&gt;\n',
+      '  &lt;rect width="120" height="80" fill="#FFFFFF"/&gt;',
+      '</code></pre>',
+      '<pre class="vditor-ir__preview" data-render="1"><svg viewBox="0 0 120 80"><rect width="120" height="80"></rect></svg></pre>',
+      '</div>',
+      '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+      '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">&lt;!-- 标题 --&gt;</code></pre>',
+      '<pre class="vditor-ir__preview" data-render="1"></pre>',
+      '</div>',
+      '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+      '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">&lt;text x="60" y="24" font-size="14"&gt;源标题&lt;/text&gt;</code></pre>',
+      '<pre class="vditor-ir__preview" data-render="1"></pre>',
+      '</div>',
+      '<p><code class="vditor-ir__marker">&lt;path d="M 10 40 L 110 40" stroke="#222222"/&gt;</code></p>',
+      '<div data-block="0" data-type="html-block" class="vditor-ir__node">',
+      '<pre class="vditor-ir__marker--pre vditor-ir__marker"><code data-type="html-block">&lt;text x="60" y="62" font-size="14"&gt;尾部&lt;/text&gt;\n&lt;/svg&gt;</code></pre>',
+      '<pre class="vditor-ir__preview" data-render="1"></pre>',
+      '</div>',
+      '<p>**图：源标题**</p>',
+    ].join('');
+
+    const changed = repairSvgIrPreviewsFromMarkdown(root, markdown);
+    const repairedRoot = root.querySelector(`.${FOLIA_IR_SVG_ROOT_CLASS} .vditor-ir__preview`);
+    const hiddenFragments = Array.from(root.querySelectorAll<HTMLElement>(`.${FOLIA_IR_SVG_FRAGMENT_CLASS}`));
+    const caption = Array.from(root.querySelectorAll('p')).find((node) => node.textContent?.includes('图：源标题'));
+
+    expect(changed).toBe(true);
+    expect(repairedRoot?.querySelector('svg text')?.textContent).toContain('源标题');
+    expect(repairedRoot?.querySelector('svg path')?.getAttribute('d')).toBe('M 10 40 L 110 40');
+    expect(hiddenFragments).toHaveLength(4);
+    expect(hiddenFragments.some((node) => node.tagName === 'P' && node.textContent?.includes('<path'))).toBe(true);
+    expect(caption?.classList.contains(FOLIA_IR_SVG_FRAGMENT_CLASS)).toBe(false);
+  });
+
   it('不会把安全的未闭合 SVG 起始 marker 补成截断完整 SVG', () => {
     const root = document.createElement('div');
     root.innerHTML = [

--- a/src/services/vditorIrSanitizeService.ts
+++ b/src/services/vditorIrSanitizeService.ts
@@ -72,6 +72,20 @@ function getIrHtmlMarkerText(node: HTMLElement): string | null {
   return marker.textContent ?? '';
 }
 
+function getHtmlMarkerTextFromElement(element: Element | null): string | null {
+  if (!(element instanceof HTMLElement)) return null;
+  const isHtmlNode = element.classList.contains('vditor-ir__node')
+    && (
+      element.getAttribute('data-type') === 'html-block'
+      || element.getAttribute('data-type') === 'html-inline'
+    );
+  if (isHtmlNode) return getIrHtmlMarkerText(element);
+
+  const marker = element.querySelector<HTMLElement>('code[data-type="html-block"], code.vditor-ir__marker');
+  if (!marker) return null;
+  return marker.textContent ?? '';
+}
+
 function isSvgStart(text: string): boolean {
   return /^<svg(?:\s|>)/i.test(text.trimStart());
 }
@@ -191,6 +205,81 @@ function renderSvgPreviewFromSource(node: HTMLElement, sourceSvg: string): boole
   firstPreview.innerHTML = repairedSvg;
   node.classList.add(FOLIA_IR_SVG_ROOT_CLASS);
   return true;
+}
+
+function clearSvgRepairClasses(root: ParentNode): boolean {
+  let changed = false;
+  root.querySelectorAll<HTMLElement>(`.${FOLIA_IR_SVG_ROOT_CLASS}, .${FOLIA_IR_SVG_FRAGMENT_CLASS}`)
+    .forEach((element) => {
+      if (element.classList.contains(FOLIA_IR_SVG_ROOT_CLASS)) {
+        element.classList.remove(FOLIA_IR_SVG_ROOT_CLASS);
+        changed = true;
+      }
+      if (element.classList.contains(FOLIA_IR_SVG_FRAGMENT_CLASS)) {
+        element.classList.remove(FOLIA_IR_SVG_FRAGMENT_CLASS);
+        changed = true;
+      }
+    });
+  return changed;
+}
+
+function findSvgMarkerInSource(sourceSvg: string, marker: string, startIndex: number): { index: number; length: number } | null {
+  const trimmed = marker.trim();
+  if (trimmed === '') return null;
+
+  const rawIndex = sourceSvg.indexOf(marker, startIndex);
+  if (rawIndex >= 0) {
+    return { index: rawIndex, length: marker.length };
+  }
+
+  const trimmedIndex = sourceSvg.indexOf(trimmed, startIndex);
+  if (trimmedIndex >= 0) {
+    return { index: trimmedIndex, length: trimmed.length };
+  }
+
+  return null;
+}
+
+function hideFollowingSvgSourceFragments(svgRoot: HTMLElement, sourceSvg: string): boolean {
+  const rootMarker = getIrHtmlMarkerText(svgRoot);
+  let sourceCursor = 0;
+  if (rootMarker !== null) {
+    const rootMatch = findSvgMarkerInSource(sourceSvg, rootMarker, 0);
+    if (rootMatch) {
+      sourceCursor = rootMatch.index + rootMatch.length;
+    }
+  }
+
+  let changed = false;
+  let hiddenAny = false;
+  let current = svgRoot.nextElementSibling;
+
+  while (current) {
+    const marker = getHtmlMarkerTextFromElement(current);
+    if (marker === null) break;
+    if (isSvgStart(marker)) break;
+    if (!isSvgFragmentLike(marker)) break;
+
+    const sourceMatch = findSvgMarkerInSource(sourceSvg, marker, sourceCursor);
+    if (!sourceMatch) break;
+
+    if (current instanceof HTMLElement && !current.classList.contains(FOLIA_IR_SVG_FRAGMENT_CLASS)) {
+      current.classList.add(FOLIA_IR_SVG_FRAGMENT_CLASS);
+      changed = true;
+    }
+    hiddenAny = true;
+    sourceCursor = sourceMatch.index + sourceMatch.length;
+
+    if (hasSvgEnd(marker)) break;
+    current = current.nextElementSibling;
+  }
+
+  if (hiddenAny && !svgRoot.classList.contains(FOLIA_IR_SVG_ROOT_CLASS)) {
+    svgRoot.classList.add(FOLIA_IR_SVG_ROOT_CLASS);
+    changed = true;
+  }
+
+  return changed;
 }
 
 function containsDangerousSvgMarkup(svg: string): boolean {
@@ -320,21 +409,9 @@ export function sanitizeVditorIrHtml(irHtml: string): VditorIrSanitizeResult {
  * by Vditor.
  */
 export function repairSplitSvgIrPreviews(root: ParentNode): boolean {
+  let changed = clearSvgRepairClasses(root);
   const nodes = getIrHtmlNodes(root);
-  if (nodes.length === 0) return false;
-
-  let changed = false;
-
-  nodes.forEach((node) => {
-    if (node.classList.contains(FOLIA_IR_SVG_ROOT_CLASS)) {
-      node.classList.remove(FOLIA_IR_SVG_ROOT_CLASS);
-      changed = true;
-    }
-    if (node.classList.contains(FOLIA_IR_SVG_FRAGMENT_CLASS)) {
-      node.classList.remove(FOLIA_IR_SVG_FRAGMENT_CLASS);
-      changed = true;
-    }
-  });
+  if (nodes.length === 0) return changed;
 
   collectSplitSvgGroups(nodes, { includeSingleClosed: true }).forEach((group) => {
     const firstPreview = group.nodes[0].querySelector<HTMLElement>('.vditor-ir__preview');
@@ -395,6 +472,9 @@ export function repairSvgIrPreviewsFromMarkdown(root: ParentNode, markdown: stri
     if (!sourceSvg) return;
 
     if (renderSvgPreviewFromSource(node, sourceSvg)) {
+      changed = true;
+    }
+    if (hideFollowingSvgSourceFragments(node, sourceSvg)) {
       changed = true;
     }
   });

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1231,6 +1231,7 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
   display: block;
   max-width: 100%;
   height: auto;
+  font-family: var(--reading-font-family, var(--font-reading));
 }
 
 /* ===== Preview Shell ===== */


### PR DESCRIPTION
## 摘要

DEC-114 收尾 v0.4.4 SVG 修复链路。v0.4.4 (DEC-112 / PR #60) 已能让大部分 SVG 在主编辑器与预览链路正常显示，但用户 `ch07.md` 中「初版 Skill 的文件结构」等部分图后方仍出现明显白色条；同时部分 AI 生成 SVG 未指定 `font-family`，在 Vditor IR 预览里继承 `<pre>` 等宽字体，长英文标签看起来像被框截掉。

本次 PR 完成两件事：

1. **修复残留白色条**：source-aware SVG 修复在按 Markdown 原文恢复 preview 后，按 SVG 原始源码顺序扫描后续相邻节点，支持 IR html-block / html-inline marker 和普通段落中的 `code.vditor-ir__marker`，把 `<path>` 等被 IR 拆到普通 `<p>` 的 SVG 子片段隐藏；遇到图注 / 正文 / 下一个 `<svg>` 立即停止，避免误吞。
2. **修复主编辑器 SVG 字体**：`.vditor-ir__preview` 内的 SVG 显式声明 `--reading-font-family`，不再继承 `<pre>` 等宽字体。

## 变更范围

- `src/services/vditorIrSanitizeService.ts`：
  - 新增 `getHtmlMarkerTextFromElement` / `findSvgMarkerInSource` / `hideFollowingSvgSourceFragments` 三个 helper；
  - `clearSvgRepairClasses` 从 `repairSplitSvgIrPreviews` 抽出复用，每次修复前先清理过期隐藏状态；
  - `repairSvgIrPreviewsFromMarkdown` 在恢复 preview 后调 `hideFollowingSvgSourceFragments`。
- `src/services/vditorIrSanitizeService.test.ts`：新增回归用例覆盖「普通 `<p>` 承载的 `<path>` 残留被隐藏、图注保留」。
- `src/styles/app.css`：`.vditor-ir__preview` 加 `font-family: var(--reading-font-family, var(--font-reading))`。
- `CHANGELOG.md`：`[Unreleased] → Fixed` 段补两条。

## 测试计划

- [x] `npm test`：47 files / 386 tests 通过（新增 1 个回归用例）。
- [x] `npm run lint`：0 warning。
- [x] `npm run build`：含 `typecheck` 全绿。
- [x] Vite dev + Playwright Chromium 注入用户 `ch07.md`：
  - 主编辑器 7 张 SVG 全部恢复，`folia-ir-svg-fragment-hidden` 命中 22 个残留节点全部 `display:none`，图注仍可见；
  - 主编辑器 / HTML 预览 / Word 预览三条链路 7 张 SVG 的 rect / path / text / line / marker / defs 计数与源文件一致；
  - 第 6 张 SVG 根节点文字宽度由约 285px 降为约 226.6px，落入 240px 蓝框内；
  - `dirty=false` 且 `content === lastSavedContent`；
  - 截图：`/tmp/folia-ch07-skill-svg-after-fix.png`、`/tmp/folia-ch07-svg-editor-06-font-fixed.png`、`/tmp/folia-ch07-svg-html-preview-all.png`、`/tmp/folia-ch07-svg-word-preview-all.png`。

## 关联决策

- DEC-114「修复 source-aware SVG 恢复后的残留白色条」（本 PR 落地）
- DEC-112「修复 Markdown 内联 SVG 在编辑与预览链路被截断」（前置 v0.4.4 已发布，本次收尾）

## Agent 归属

- Agent：Claude Fable 5（MiniMax-M3，当前 session）
- Git author：maoking
- 触发：用户在 v0.4.4 升级后报残留白色条与字体问题，按 SOP 4.1 登记为 DEC-114 并完成修复

## 风险与回退

- 风险：`hideFollowingSvgSourceFragments` 在 SVG fragment-like marker 文本中匹配源 SVG 顺序，理论上存在 marker 文本与源 SVG 重复导致错位的可能。**缓解**：连续两段相同 marker 文本会推进 sourceCursor，下一次 `findSvgMarkerInSource` 从更新后的位置继续搜索；遇到非 fragment-like marker / 下一个 `<svg>` 起始 / `</svg>` 闭合立即停止。
- 回退：`git revert <merge-commit>` 或 PR 内单独 revert 任一 commit；三个 commit 互相独立。