### PR TITLE
fix(csp): DEC-116 修复 HTTPS 图片（含 WebP）在主编辑器不显示 (ISS-178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **修复 HTTPS 图片（含 WebP）在主编辑器 / 预览窗不显示的问题**（ISS-178 / DEC-116）：`src-tauri/tauri.conf.json` 的 CSP `img-src` / `media-src` 此前只放行 `'self' asset: http://asset.localhost data: blob: file:`，任何 `https://` 来源的 `<img>` / `<source>` / `<video>` 都会被 WebView 拒绝加载——`<img>` 节点能进 DOM，但浏览器拦截图片数据，表现为"图片语法在、图片本身没法渲染"。用户报告的具体场景是腾讯云 COS 上的 WebP（`https://xierluo-1257032130.cos.ap-shanghai.myqcloud.com/...webp`），但根因与 WebP 无关，是 CSP 不允许 `https:` 协议。修复：在 `img-src` / `media-src` 加上 `https:`；`connect-src` / `frame-src` / `font-src` 维持原状，避免放开脚本 fetch 与 iframe 来源。`src/services/tauriCapabilities.test.ts` 增加 `expect(csp).toMatch(/img-src [^;]*\bhttps:/)` 与 `expect(csp).toMatch(/media-src [^;]*\bhttps:/)` 两条断言守住，防止后续 CSS 改动再把 `https:` 删掉。
+
 ## [0.4.5] - 2026-06-23
 
 ### Fixed

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost data: blob: file:; font-src 'self' file:; connect-src 'self'; media-src 'self' asset: http://asset.localhost file:; frame-src 'self' data: blob:",
+      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost https: data: blob: file:; font-src 'self' file:; connect-src 'self'; media-src 'self' asset: http://asset.localhost https: file:; frame-src 'self' data: blob:",
       "assetProtocol": {
         "enable": true,
         "scope": {

--- a/src/services/localImageResolver.test.ts
+++ b/src/services/localImageResolver.test.ts
@@ -104,6 +104,31 @@ describe('resolveLocalImages', () => {
     expect(container.querySelector('img')?.getAttribute('src')).toBe('file:///Users/demo/photo.png');
   });
 
+  it('resolves local WebP via Markdown image syntax', async () => {
+    // ISS-178 follow-up: lock down that .webp goes through the same path as
+    // .png / .jpg — extension-agnostic. Real Tauri runtime verified via
+    // `folia-fresh-1.png` (test.md with `![](./sample.webp)`).
+    const { resolveLocalImages: resolve } = await importFresh();
+    const container = createContainerWithImages([{ src: './sample.webp' }]);
+    await resolve(container, '/tmp/folia-webp-test/test.md');
+    const src = container.querySelector('img')?.getAttribute('src');
+    expect(src).toContain('asset.localhost');
+    expect(src).toContain('/tmp/folia-webp-test/sample.webp');
+  });
+
+  it('resolves local WebP via inline HTML <img src> tag', async () => {
+    // Markdown允许直接写 HTML 标签。Folia 不应只走 Markdown 解析路径，
+    // inline <img> 也需要被 localImageResolver 接管。
+    const { resolveLocalImages: resolve } = await importFresh();
+    const container = document.createElement('div');
+    const img = document.createElement('img');
+    img.setAttribute('src', './sample.webp');
+    container.appendChild(img);
+    await resolve(container, '/tmp/folia-webp-test/test.md');
+    expect(img.getAttribute('src')).toContain('asset.localhost');
+    expect(img.getAttribute('src')).toContain('/tmp/folia-webp-test/sample.webp');
+  });
+
   it('handles multiple images in one container', async () => {
     const { resolveLocalImages: resolve } = await importFresh();
     const container = createContainerWithImages([

--- a/src/services/tauriCapabilities.test.ts
+++ b/src/services/tauriCapabilities.test.ts
@@ -27,6 +27,11 @@ describe('Tauri capabilities', () => {
     // DEC-096: img-src must include asset: / http://asset.localhost so that
     // convertFileSrc() URLs for local images can load in the WebView.
     expect(csp).toContain("img-src 'self' asset: http://asset.localhost");
+    // ISS-178: img-src / media-src must also include https: so external HTTPS
+    // images (e.g. WebP hosted on Tencent COS / S3 / CDN) are not blocked by
+    // CSP. connect-src / frame-src / font-src remain restrictive on purpose.
+    expect(csp).toMatch(/img-src [^;]*\bhttps:/);
+    expect(csp).toMatch(/media-src [^;]*\bhttps:/);
     expect(csp).toContain("frame-src 'self' data: blob:");
     expect(csp).toContain("connect-src 'self'");
   });


### PR DESCRIPTION
## 背景

用户在 Folia 主编辑器嵌入 `![alt](https://xierluo-1257032130.cos.ap-shanghai.myqcloud.com/20260625172416688.webp)` 这类 HTTPS 图片时，只看到图片语法、不显示图片本身。问题不只 WebP，是 CSP 协议白名单遗漏——任何 HTTPS 图（PNG/JPG/GIF/SVG）都被拦。

## 根因

`src-tauri/tauri.conf.json:31` 的 CSP `img-src` / `media-src` 此前只放行 `'self' asset: http://asset.localhost data: blob: file:`，**没有 `https:`**。Tauri 2.x WebView 严格强制 CSP。

`tauriCapabilities.test.ts:29` 的回归断言只覆盖 `asset:` / `http://asset.localhost`（DEC-096 加的），从未断言 `https:`，所以这个洞一直没被拦住。

## 修复

- `src-tauri/tauri.conf.json`: `img-src` / `media-src` 各加一个 `https:`
- `connect-src` / `frame-src` / `font-src` 维持原状——最小授权原则，避免连带放开脚本 fetch 与 iframe 来源
- `src/services/tauriCapabilities.test.ts` 追加 2 条 `toMatch(/... \bhttps:/)` 守卫

## 验证

- `npm test` 47 / 388 全绿
- `npm run typecheck` / `lint` / `build` 全绿
- `cargo check` 通过
- Vite dev + Playwright 探针 HTML 注入与 Tauri 一致 CSP：修复前 3 张 HTTPS 图 naturalW=0 + console 4 条 CSP error；修复后 COS WebP naturalW=1280×720、gstatic WebP naturalW=550×368、console 0 error
- Tauri dev + osascript 加载 `/tmp/folia-webp-test/test.md`（含 4 种引用方式：`![](./x.webp)` / inline HTML / HTTPS / 绝对路径）：本地 WebP 全部正常渲染
- 截图：`.playwright-mcp/csp-probe-BEFORE.png` / `AFTER.png` / `folia-fresh-1.png`

## 关联

- DEC-090 / DEC-096 / DEC-098 修复链路完全兼容：localImageResolver / asset protocol / scope 配置未改动
- 计划发版：v0.4.6（patch，距 v0.4.5 已 3 天，≥24h 红线通过）