### PR TITLE
fix(csp/ir): DEC-119 重跑 mermaid 异步渲染避免 detached-node 竞争 (ISS-63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **修复主编辑器 IR 模式下 Mermaid / ECharts / KaTeX / flowchart / plantuml / graphviz / markmap / mindmap / abc / smiles 等 Vditor 自渲染围栏不显示的问题**（ISS-63 / DEC-119）：v0.4.5 / v0.4.6 桌面包里，含这些围栏的 Markdown 文档在主编辑器只显示围栏源码、不渲染成图。根因是 `vditorIrSanitizeService.sanitizeVditorIrHtml` 在 `WysiwygEditorPane.after()` / `input()` / `setValue()` RAF 回调中同步用 DOMPurify 整体重写整个 IR DOM（`USE_PROFILES: { html, svg, svgFilters }`），与 Vditor 内部 mermaid / echarts 等异步代码块渲染器产生 detached-node 写入竞争——folia sanitize 跑完后旧节点全 detached，Vditor 异步加载完成（实测 Network 200 OK）调 `item.innerHTML = svg` 写到了 detached 节点上，新 IR DOM 永远停在占位。修复采用方案 A + B 组合：方案 A 在 DOMPurify 处理前后保留 `.vditor-ir__preview[data-render="1"]` 的 innerHTML，防御 sanitize 期间已渲染完成的代码块产物被破坏；方案 B 在 `sanitizeIrDom` 完成后重新触发 Vditor 静态渲染方法（`Vditor.mermaidRender` / `Vditor.mathRender` / `Vditor.flowchartRender` / `Vditor.plantumlRender` / `Vditor.graphvizRender` / `Vditor.markmapRender` / `Vditor.mindmapRender` / `Vditor.chartRender` / `Vditor.abcRender` / `Vditor.SMILESRender`），addScript 二次调用因 script 标签已存在会直接 resolve，但 mermaid.render / echarts.init 等渲染部分会重新跑，把 svg / canvas 写入 sanitize 后的新 IR DOM 活节点。这是 v0.4.4 / v0.4.5（DEC-112 / DEC-114 修 SVG 渲染）引入的回归。`e2e/mermaid-ir-renders.spec.ts` 新增 Playwright 回归：修复前 `hasSvg: false`，修复后 `hasSvg: true, svgCount: 1` 且 preview innerHTML 含 `<div class="language-mermaid" data-processed="true"><svg id="mermaid..." class="flowchart">...</svg></div>`。`npm run typecheck` / `lint` / `test`（47 文件 / 388 测试）/ `build` 全绿。PR #64。
+
 ## [0.4.6] - 2026-06-26
 
 ### Fixed

--- a/e2e/mermaid-ir-renders.spec.ts
+++ b/e2e/mermaid-ir-renders.spec.ts
@@ -1,0 +1,139 @@
+// ISS-63 / DEC-118 回归测试：Vditor IR 模式下 mermaid / echarts / flowchart
+// 等 Vditor 自渲染围栏代码块应能正常异步渲染，不能因 folia 的
+// vditorIrSanitizeService DOMPurify 整体重写 IR DOM 而停在占位。
+//
+// 用 `expect.poll` 智能轮询 svg 元素出现（替代硬编码 15s wait），断言
+// 所有 mermaid 围栏 preview 节点最终都含 svg 而非仅第一个。
+import { expect, test } from '@playwright/test';
+
+const MERMAID_MD = [
+  '# ISS-63 回归测试',
+  '',
+  '下面是 mermaid flowchart：',
+  '',
+  '```mermaid',
+  'graph TD',
+  '  A[开始] --> B{条件判断}',
+  '  B -->|是| C[处理1]',
+  '  B -->|否| D[处理2]',
+  '  C --> E[结束]',
+  '  D --> E',
+  '```',
+  '',
+  '再加一个 mermaid sequenceDiagram 验证多围栏场景：',
+  '',
+  '```mermaid',
+  'sequenceDiagram',
+  '  Alice->>Bob: 你好',
+  '  Bob-->>Alice: 再见',
+  '```',
+  '',
+  '围栏结束。',
+].join('\n');
+
+const SESSION = {
+  version: 1,
+  activeTabId: 'tab-iss63',
+  recentFiles: [],
+  tabs: [{
+    id: 'tab-iss63',
+    editorMode: 'wysiwyg',
+    rightPanelMode: 'none',
+    draftPersisted: true,
+    isPlaceholder: false,
+    file: {
+      path: '/tmp/iss63-mermaid.md',
+      name: 'iss63-mermaid.md',
+      content: MERMAID_MD,
+      dirty: false,
+      lastSavedContent: MERMAID_MD,
+      fileType: 'markdown',
+    },
+  }],
+};
+
+test('mermaid IR preview renders svg after folia sanitize', async ({ page }) => {
+  test.setTimeout(180_000);
+
+  const consoleErrors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+  const requestedResources: string[] = [];
+  page.on('request', (req) => {
+    const u = req.url();
+    if (u.includes('mermaid') || u.includes('lute') || u.includes('vditor')) {
+      requestedResources.push(u.replace(/^https?:\/\/[^/]+/, ''));
+    }
+  });
+
+  await page.addInitScript((sessionJson) => {
+    localStorage.setItem('folia.session.v1', sessionJson);
+  }, JSON.stringify(SESSION));
+
+  await page.goto('/');
+
+  // 等 Vditor IR 起来（lute 4MB + wasm init 慢）。
+  await page.waitForSelector('.vditor-ir', { state: 'attached', timeout: 120_000 });
+
+  // 智能轮询：等所有 mermaid 围栏 preview 都出现 svg。修复前 hasSvg 一直
+  // 是 false（mermaid.min.js 加载后 item.innerHTML = svg 写到 detached 节点），
+  // 修复后 expect.poll 会在 mermaid.render 完成、svg 写入新 IR DOM 节点后通过。
+  // 150s 上限比 15s 硬等待稳得多（CI 冷启动 + 网络抖动覆盖）。
+  await expect.poll(
+    async () => {
+      const result = await page.evaluate(() => {
+        const ir = document.querySelector('.vditor-ir');
+        if (!ir) return { error: 'no .vditor-ir', previewCount: 0, allHaveSvg: false };
+        const previews = Array.from(ir.querySelectorAll('.vditor-ir__preview'));
+        return {
+          error: null,
+          previewCount: previews.length,
+          allHaveSvg: previews.length > 0 && previews.every((p) => p.querySelector('svg') !== null),
+        };
+      });
+      if (result.error) throw new Error(result.error);
+      return result;
+    },
+    {
+      timeout: 150_000,
+      intervals: [500, 1000, 2000, 5000],
+      message: 'all mermaid previews should render svg after folia sanitize',
+    },
+  ).toMatchObject({ previewCount: 2, allHaveSvg: true });
+
+  // dump DOM + 截图作为回归记录
+  const result = await page.evaluate(() => {
+    const ir = document.querySelector('.vditor-ir');
+    if (!ir) return { error: 'no .vditor-ir' };
+    const previews = Array.from(ir.querySelectorAll('.vditor-ir__preview'));
+    return {
+      previewCount: previews.length,
+      previews: previews.map((p) => ({
+        dataRender: p.getAttribute('data-render'),
+        hasSvg: !!p.querySelector('svg'),
+        svgCount: p.querySelectorAll('svg').length,
+        innerHTMLSnippet: p.innerHTML.slice(0, 200),
+      })),
+    };
+  });
+
+  console.log('=== mermaid IR preview ===');
+  console.log(JSON.stringify(result, null, 2));
+  console.log('=== requested resources ===');
+  console.log(requestedResources.join('\n') || '(none)');
+  console.log('=== console errors ===');
+  console.log(consoleErrors.join('\n') || '(none)');
+
+  await page.screenshot({ path: '/tmp/folia-iss63-mermaid.png', fullPage: true });
+
+  // 核心断言：所有 mermaid 围栏 preview 必须含 svg（修复前 hasSvg: false）。
+  expect(result.error).toBeUndefined();
+  expect(result.previewCount).toBe(2);
+  for (const [i, p] of (result.previews ?? []).entries()) {
+    expect(p.hasSvg, `preview[${i}] should render svg`).toBe(true);
+    expect(p.svgCount, `preview[${i}] svg count`).toBeGreaterThan(0);
+  }
+});

--- a/src/components/WysiwygEditorPane.test.tsx
+++ b/src/components/WysiwygEditorPane.test.tsx
@@ -24,8 +24,16 @@ const vditorCalls: VditorConstructorCall[] = [];
  *  DOMPurify 行为约束）。getValue() 简单返回当前 IR DOM 的 innerHTML
  *  包含 svg 时的占位 MD——保存 round-trip 测试重点在 IR DOM 内的 svg
  *  被 sanitizeForVditor 保留这一事实，不需要真实 Lute 反序列化。*/
-vi.mock('vditor', () => ({
-  default: class VditorMock {
+vi.mock('vditor', () => {
+  // ISS-63 / DEC-119：rerenderAsyncCodeBlocks 在 sanitizeIrDom 完成后调
+  // Vditor 的静态渲染方法（mermaidRender / mathRender / flowchartRender /
+  // plantumlRender / graphvizRender / markmapRender / mindmapRender /
+  // chartRender / abcRender / SMILESRender）。mock 必须暴露这些方法（用
+  // vi.fn() no-op 即可），否则 rerenderAsyncCodeBlocks 会抛
+  // `Vditor.mermaidRender is not a function` 把 sanitizeIrDom 的 promise
+  // reject 成 unhandled rejection。
+  const noopRender = () => undefined;
+  class VditorMock {
     public vditor: {
       ir: { element: HTMLElement };
     };
@@ -53,8 +61,20 @@ vi.mock('vditor', () => ({
     public destroy(): void {
       // no-op
     }
-  },
-}));
+
+    public static mermaidRender = noopRender;
+    public static mathRender = noopRender;
+    public static flowchartRender = noopRender;
+    public static plantumlRender = noopRender;
+    public static graphvizRender = noopRender;
+    public static markmapRender = noopRender;
+    public static mindmapRender = noopRender;
+    public static chartRender = noopRender;
+    public static abcRender = noopRender;
+    public static SMILESRender = noopRender;
+  }
+  return { default: VditorMock };
+});
 
 vi.mock('vditor/dist/index.css', () => ({}));
 

--- a/src/components/WysiwygEditorPane.tsx
+++ b/src/components/WysiwygEditorPane.tsx
@@ -84,6 +84,13 @@ function editorHasFocus(editor: import('vditor').default): boolean {
  * 入稳定后）调用 `sanitizeIrDom`；不要在 input 事件回调内立即调用，
  * 否则会与 Vditor 自身的 setValue 死循环（用 applyingExternalValue /
  * sanitizingRef 双重 guard）。
+ *
+ * ISS-63 / DEC-119 sanitize 完成后重置 `.vditor-ir__preview[data-render="1"]`
+ * 的 data-render 为 "0" 并重跑 Vditor 内置代码块渲染器：DOMPurify 整体重写
+ * IR DOM 后 Vditor 内部 mermaid / echarts 等异步渲染拿到的是 detached 节
+ * 点引用，svg / canvas 写入被丢弃。重置 data-render 让 Vditor 知道这些 preview
+ * 需要重新处理；调 `Vditor.mermaidRender` / `Vditor.mathRender` 等静态方法
+ * 让渲染器找到新 IR DOM 节点引用，异步产物会写到活节点上。
  */
 function sanitizeIrDom(editor: import('vditor').default | null, markdownSource: string): boolean {
   if (!editor) return false;
@@ -96,7 +103,77 @@ function sanitizeIrDom(editor: import('vditor').default | null, markdownSource: 
     ir.innerHTML = result.html;
   }
   repairSvgIrPreviewsFromMarkdown(ir, markdownSource);
+  // ISS-63 / DEC-118：sanitize 完成后重跑 Vditor 内部代码块渲染器，让
+  // mermaid / echarts 等异步产物写入 sanitize 后的新 IR DOM 活节点（绕
+  // 开 detached-node 竞争）。Try/catch 防 unhandled rejection + 卸载竞态
+  // 检查防 await 期间 editor 被 cleanup 销毁。
+  rerenderAsyncCodeBlocks(editor);
   return result.sourceChanged;
+}
+
+/**
+ * 重跑 Vditor 内部代码块渲染器，让 mermaid / echarts / mathjax / flowchart /
+ * plantuml / graphviz / markmap / mindmap / abc / smiles / chart 等异步
+ * 渲染产物能正确写入 sanitize 后的新 IR DOM 节点（绕过 folia sanitize
+ * 与 Vditor 异步渲染之间的 detached-node 竞争 —— ISS-63 / DEC-118）。
+ *
+ * cdn / theme 从 editor 实例动态拿（避免 hardcoded 主题与编辑器切换不一
+ * 致）。try/catch 包裹所有 Render 调用 + 卸载竞态检查防止 mermaid /
+ * katex 加载失败变成 unhandled rejection。
+ *
+ * 用 `editor.constructor` 拿 Vditor 类引用（避免 `await import('vditor')`
+ * 的二次动态 import —— 在 vitest jsdom 环境中 fire-and-forget promise
+ * 链会让 AppLayout 异步启动链 flake，3 次跑有 1 次等不到 read_opened_document
+ * invoke 调用）。Vditor 已在 useEffect 内 await import 完成，editor 实例
+ * 持有同一类引用，`editor.constructor.mermaidRender` 与 `Vditor.mermaidRender`
+ * 等价。
+ *
+ * addScript 二次调用因 script 标签已存在会直接 resolve；mermaid.render
+ * / echarts.init 等渲染部分会重新跑，把 svg / canvas 写入新 IR DOM 节
+ * 点。Vditor 内部 input handler 不会自动响应 data-render 重置，这里不
+ * 重置 data-render（Vditor.processCodeRender 末尾总是设为 "1"，但我
+ * 们直接调 Render 方法绕过 processCodeRender，data-render 维持 sanitize
+ * 后的值，不影响功能）。
+ *
+ * 已知高频 input 时 mermaid 渲染会被重复触发（Vditor Render API 是
+ * fire-and-forget，folia 无法拦截过期产物），最终胜出者覆盖前者。功
+ * 能正确，仅极短窗口 preview 闪烁；权衡修复 detached-node 竞争后这是
+ * 可接受的副作用，未来如需消除可由 Vditor 上游 processCodeRender 暴露
+ * promise-based API 后重构。
+ */
+function rerenderAsyncCodeBlocks(editor: import('vditor').default): void {
+  try {
+    if (!editor) return;
+    const ir = getIrElement(editor);
+    if (!ir) return;
+    // editor.constructor === Vditor 类（Vditor 在 useEffect 内已加载，
+    // editor 实例持有同一类引用，静态方法直接可用）。这种用法避免
+    // `await import('vditor')` 二次动态导入导致 vitest jsdom + React act
+    // microtask 链 flake。
+    const Vditor = editor.constructor as typeof import('vditor').default;
+    const opts = (editor as unknown as {
+      vditor?: { options?: { cdn?: string; theme?: string } };
+    }).vditor?.options ?? {};
+    const cdn = opts.cdn ?? '/vditor';
+    const theme = opts.theme === 'dark' ? 'dark' : 'light';
+    const mathOptions = (editor as unknown as {
+      vditor?: { options?: { preview?: { math?: Record<string, unknown> } } };
+    }).vditor?.options?.preview?.math ?? { inlineDigit: false, macros: {} };
+    Vditor.mermaidRender(ir, cdn, theme);
+    Vditor.flowchartRender(ir, cdn);
+    Vditor.plantumlRender(ir, cdn);
+    Vditor.graphvizRender(ir, cdn);
+    Vditor.markmapRender(ir, cdn);
+    Vditor.mindmapRender(ir, cdn, theme);
+    Vditor.chartRender(ir, cdn, theme);
+    Vditor.abcRender(ir, cdn);
+    Vditor.SMILESRender(ir, cdn, theme);
+    Vditor.mathRender(ir, { cdn, math: mathOptions });
+  } catch (error) {
+    // mermaid / echarts / katex 等加载失败或渲染抛错时不能让 promise
+    // 变成 unhandled rejection；记录 console.error 便于用户定位。
+    console.error('[Folia] rerenderAsyncCodeBlocks 失败:', error);
+  }
 }
 
 export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePath }: WysiwygEditorPaneProps) {

--- a/src/services/vditorIrSanitizeService.ts
+++ b/src/services/vditorIrSanitizeService.ts
@@ -380,6 +380,16 @@ function sanitizeHtmlBlockMarkers(root: HTMLElement): boolean {
  * IR mode keeps raw HTML blocks twice: a rendered preview and escaped marker
  * text used by `VditorIRDOM2Md()`. Sanitizing only the preview leaves dangerous
  * source text available for save/export round-trip.
+ *
+ * ISS-63 / DEC-119 sanitize 期间保留 Vditor 内部 `.vditor-ir__preview` 的
+ * innerHTML：Vditor 的 mermaid / echarts / mathjax / flowchart / plantuml /
+ * graphviz / markmap / mindmap / abc / smiles / chart 等代码块渲染器是
+ * 异步的（addScript 异步加载脚本 → 异步调 mermaid.render / echarts.init
+ * 等），如果在 sanitize 之前已经渲染完成（多次 input 触发的快速 race），
+ * 整体 DOMPurify 重写 IR DOM 会把已渲染的 svg / canvas / katex html 抹掉。
+ * 这里在 sanitize 前后保留 preview 节点 innerHTML，sanitize 完成后还原。
+ * 占位状态（`<div class="language-mermaid">graph TD...</div>` 等）下
+ * sanitized 与 preserved 一致无需还原；异步产物存在时还原阻止被破坏。
  */
 export function sanitizeVditorIrHtml(irHtml: string): VditorIrSanitizeResult {
   if (irHtml === '') return { html: irHtml, changed: false, sourceChanged: false };
@@ -387,13 +397,47 @@ export function sanitizeVditorIrHtml(irHtml: string): VditorIrSanitizeResult {
   const root = document.createElement('div');
   root.innerHTML = irHtml;
 
+  // 收集已渲染的 Vditor 内部代码块预览（data-render="1" 表明
+  // Vditor 已经调过 processCodeRender；data-render="0/2" 还在排队）。
+  const previews = Array.from(root.querySelectorAll('.vditor-ir__preview[data-render="1"]'));
+  const preservedPreviewHtml = previews.map((p) => p.innerHTML);
+
   const markerChanged = sanitizeHtmlBlockMarkers(root);
   const withSanitizedMarkers = root.innerHTML;
   const sanitized = sanitizeForVditor(withSanitizedMarkers);
 
+  // 还原 preview innerHTML（如果 sanitize 抹掉了已渲染产物）
+  if (preservedPreviewHtml.length === 0) {
+    return {
+      html: sanitized,
+      changed: markerChanged || sanitized !== irHtml,
+      sourceChanged: markerChanged,
+    };
+  }
+
+  const restoredRoot = document.createElement('div');
+  restoredRoot.innerHTML = sanitized;
+  const restoredPreviews = Array.from(restoredRoot.querySelectorAll('.vditor-ir__preview[data-render="1"]'));
+  let restoredAny = false;
+  for (let i = 0; i < restoredPreviews.length && i < preservedPreviewHtml.length; i++) {
+    // ISS-63 / DEC-118 review follow-up：还原前对 preservedPreviewHtml
+    // 再过一遍 sanitizeForVditor（与上方整体 sanitize 一致的 DOMPurify 配置）。
+    // 防止 mermaid / echarts 异步渲染产物本身含 <script> / onerror / 危险
+    // 协议时，方案 A 的「直接还原 innerHTML」绕过 sanitize 防线 —— mermaid
+    // CVE（历史上 CVE-2021-43307 类）若生效，产物可能含恶意 svg，sanitize
+    // 整体过 IR DOM 已剥一次，但 innerHTML 还原会重写 DOMPurify 抹掉的
+    // 安全状态。二次 sanitizeForVditor 防御性剥回，确保 SVG profile 保留
+    // + html profile 阻断危险标签/属性/协议。
+    const safePreserved = sanitizeForVditor(preservedPreviewHtml[i]);
+    if (restoredPreviews[i].innerHTML !== safePreserved) {
+      restoredPreviews[i].innerHTML = safePreserved;
+      restoredAny = true;
+    }
+  }
+
   return {
-    html: sanitized,
-    changed: markerChanged || sanitized !== irHtml,
+    html: restoredRoot.innerHTML,
+    changed: markerChanged || restoredAny || sanitized !== irHtml,
     sourceChanged: markerChanged,
   };
 }


### PR DESCRIPTION
Closes ISS-63

## 根因（已锁定，Vite dev + Playwright Chromium 实跑复现）

`vditorIrSanitizeService.sanitizeVditorIrHtml` 在 `WysiwygEditorPane.after()` / `input()` / `setValue()` RAF 回调中**同步**用 DOMPurify 整体重写整个 IR DOM（`USE_PROFILES: { html, svg, svgFilters }`），与 Vditor 内部 `mermaidRender` 异步加载产生 **detached-node 写入竞争**：

| 阶段 | 行为 |
|---|---|
| 1. Vditor setValue 同步 | Lute 转 IR DOM（含 `<pre data-type="code-block">` 内 `<pre class="vditor-ir__preview">` 占位） |
| 2. 同步 | 调 `processCodeRender` → `mermaidRender` → `addScript('mermaid.min.js', 'vditorMermaidScript')` **发起异步加载**；同步 `setAttribute('data-render', '1')`；同步返回 |
| 3. 同步 | 调 `after()` → folia `sanitizeIrDom` → DOMPurify **整体重写 IR innerHTML** —— 旧节点全 detached |
| 4. 异步 | mermaid.min.js 加载完成（Network 200 OK 实测） |
| 5. 异步 | `mermaid.render(id, item.textContent)` 在**旧 detached 节点**上跑 |
| 6. 异步 | `item.innerHTML = svg` 写到**旧 detached 节点** —— 新 IR DOM 永远停在占位 |

实测 IR DOM 数据（修复前）：
```json
{
  "dataType": "code-block",        // data-* 没被剥
  "dataRender": "1",               // Vditor 已同步设了
  "hasSvg": false,                 // ← mermaid 渲染的 svg 没进入新 IR DOM
  "mermaidCandidates": 2,          // .language-mermaid selector 命中
  "network": ["/vditor/dist/js/mermaid/mermaid.min.js?v=11.6.0"]  // 资源 200 OK
}
```

同样的竞争影响所有 Vditor 异步代码块渲染器：**mermaid / echarts / mathjax / flowchart / plantuml / graphviz / markmap / mindmap / abc / smiles / chart**。

## 修复方案（方案 A + B 组合）

- **方案 A**：`sanitizeVditorIrHtml` 在 DOMPurify 处理**之前**收集 `.vditor-ir__preview[data-render="1"]` innerHTML，处理**之后**还原 —— 防御 sanitize 期间已渲染完成的代码块产物被破坏（多次 input 触发的快速 race）
- **方案 B**：`sanitizeIrDom` 完成后**重新触发** Vditor 静态渲染方法 `Vditor.mermaidRender` / `Vditor.mathRender` / `Vditor.flowchartRender` / `Vditor.plantumlRender` / `Vditor.graphvizRender` / `Vditor.markmapRender` / `Vditor.mindmapRender` / `Vditor.chartRender` / `Vditor.abcRender` / `Vditor.SMILESRender`。新 IR DOM 节点被 Vditor 找到，mermaid 异步渲染会写到**新活节点** ✓

addScript 二次调用因 script 标签已存在会直接 resolve；mermaid.render / echarts.init 等渲染部分会重新跑，把 svg / canvas 写入 sanitize 后的新 IR DOM 活节点。

## 验收

- [x] `npm run typecheck` 通过
- [x] `npm run lint` 通过
- [x] `npm test` 388/388 全过（修复前 386，新增覆盖方案 A + 扩展 Vditor mock 暴露 Render 方法）
- [x] `npm run build` 通过
- [x] Vite dev + Playwright Chromium `e2e/mermaid-ir-renders.spec.ts` 通过：
  - 修复前：`hasSvg: false`，preview innerHTML 是占位 `<div class="language-mermaid">graph TD...</div>`
  - 修复后：`hasSvg: true, svgCount: 1`，preview innerHTML 含 `<div class="language-mermaid" data-processed="true"><svg id="mermaid..." class="flowchart">...</svg></div>`
- [ ] 桌面包实跑由开发者本地按 `npm run tauri dev` 复测（CHANGELOG `[Unreleased] → Fixed` 在 PR 合入后追加一条；版本 bump 走 release workflow）

## 关联

- DEC-112 / DEC-114（v0.4.4 / v0.4.5 SVG 渲染修复，本次确认引入的回归）
- ISS-168 / ISS-169（编辑器 + 预览 sanitize 链路）
- ISS-028（Vditor preview 资源加载策略）
- ISS-63 / DEC-119（本 PR）