### PR TITLE
feat(rich-media): DEC-119 Phase 3 前端契约 — MediaInsertionService

### DIFF
--- a/src/__tests__/rich-media/media-insertion-service.test.ts
+++ b/src/__tests__/rich-media/media-insertion-service.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+  pickImageFiles,
+  registerImageAsset,
+  registerImageAssetFromFile,
+} from '../../services/mediaInsertionService';
+import { ImageAssetStore } from '../../services/imageAssetService';
+
+describe('mediaInsertionService — Phase 3 图片插入契约', () => {
+  describe('registerImageAsset', () => {
+    it('注册并产出待落盘 markdown', async () => {
+      const store = new ImageAssetStore();
+      const bytes = new TextEncoder().encode('img-bytes');
+      const result = await registerImageAsset(store, {
+        bytes,
+        desiredName: 'photo.png',
+        mime: 'image/png',
+      });
+      expect(result.markdown).toContain('photo.png（待落盘）');
+      expect(result.asset.state).toBe('pending');
+      expect(result.asset.mime).toBe('image/png');
+    });
+
+    it('alt 文本默认包含完整文件名', async () => {
+      const store = new ImageAssetStore();
+      const result = await registerImageAsset(store, {
+        bytes: new Uint8Array([1, 2, 3]),
+        desiredName: 'cover-image.jpg',
+        mime: 'image/jpeg',
+      });
+      expect(result.markdown).toContain('cover-image.jpg（待落盘）');
+    });
+
+    it('alt 文本可显式覆盖且超过 200 字会被截断', async () => {
+      const store = new ImageAssetStore();
+      const long = 'x'.repeat(500);
+      const result = await registerImageAsset(store, {
+        bytes: new Uint8Array([1]),
+        desiredName: 'a.png',
+        mime: 'image/png',
+        altText: long,
+      });
+      // Markdown 形如 `![<alt>（待落盘）](objectUrl)`，alt 被截到 200 字符
+      const altInMd = result.markdown.match(/!\[([^\]]*)\]/)?.[1] ?? '';
+      // 205 = 200 (alt) + 5 (「（待落盘）」)
+      const altOnly = altInMd.replace(/（待落盘）$/u, '');
+      expect(altOnly.length).toBe(200);
+    });
+
+    it('文件名缺省时降级为 image', async () => {
+      const store = new ImageAssetStore();
+      const result = await registerImageAsset(store, {
+        bytes: new Uint8Array([1]),
+        desiredName: '',
+        mime: 'image/png',
+      });
+      expect(result.asset.fileName).toBe('image');
+    });
+
+    it('同内容 + 同 desiredName 只注册一次', async () => {
+      const store = new ImageAssetStore();
+      const bytes = new TextEncoder().encode('same');
+      const a = await registerImageAsset(store, {
+        bytes,
+        desiredName: 'x.png',
+        mime: 'image/png',
+      });
+      const b = await registerImageAsset(store, {
+        bytes,
+        desiredName: 'x.png',
+        mime: 'image/png',
+      });
+      expect(b.asset).toBe(a.asset);
+      expect(store.list()).toHaveLength(1);
+    });
+
+    it('同内容 + 不同 desiredName 也按 hash 去重', async () => {
+      const store = new ImageAssetStore();
+      const bytes = new TextEncoder().encode('same');
+      const a = await registerImageAsset(store, {
+        bytes,
+        desiredName: 'x.png',
+        mime: 'image/png',
+      });
+      const b = await registerImageAsset(store, {
+        bytes,
+        desiredName: 'y.png',
+        mime: 'image/png',
+      });
+      expect(b.asset).toBe(a.asset);
+      expect(a.asset.fileName).toBe('x.png');
+    });
+
+    it('persisted 阶段产出相对路径 markdown', async () => {
+      const store = new ImageAssetStore();
+      const bytes = new Uint8Array([1, 2, 3]);
+      const result = await registerImageAsset(store, {
+        bytes,
+        desiredName: 'doc-photo.png',
+        mime: 'image/png',
+      });
+      store.markPersisted(result.asset.hash);
+      const updated = store.get(result.asset.hash)!;
+      const { markdown } = store.insertForMarkdown(updated, 'main-doc', 'alt-text');
+      expect(markdown).toBe('![alt-text](./main-doc.assets/doc-photo.png)');
+    });
+  });
+
+  describe('registerImageAssetFromFile', () => {
+    it('从 File 对象读取字节并产出 markdown', async () => {
+      const store = new ImageAssetStore();
+      const file = new File([new Uint8Array([1, 2, 3, 4])], 'logo.png', {
+        type: 'image/png',
+      });
+      const result = await registerImageAssetFromFile(store, file, 'logo');
+      expect(result.asset.fileName).toBe('logo.png');
+      expect(result.markdown).toContain('logo（待落盘）');
+    });
+  });
+
+  describe('pickImageFiles', () => {
+    it('过滤非 image 文件', () => {
+      const dt = {
+        length: 3,
+        0: { kind: 'file', getAsFile: () => new File([], 'a.png', { type: 'image/png' }) },
+        1: { kind: 'file', getAsFile: () => new File([], 'b.txt', { type: 'text/plain' }) },
+        2: { kind: 'file', getAsFile: () => new File([], 'c.svg', { type: 'image/svg+xml' }) },
+      } as unknown as DataTransferItemList;
+      const files = pickImageFiles(dt);
+      expect(files).toHaveLength(2);
+      expect(files.map((f) => f.name).sort()).toEqual(['a.png', 'c.svg']);
+    });
+
+    it('跳过非 file 项', () => {
+      const dt = {
+        length: 2,
+        0: { kind: 'string', getAsFile: () => null },
+        1: { kind: 'file', getAsFile: () => new File([], 'a.png', { type: 'image/png' }) },
+      } as unknown as DataTransferItemList;
+      expect(pickImageFiles(dt)).toHaveLength(1);
+    });
+
+    it('空 DataTransferItemList 返回空数组', () => {
+      const dt = { length: 0 } as unknown as DataTransferItemList;
+      expect(pickImageFiles(dt)).toEqual([]);
+    });
+  });
+});

--- a/src/services/mediaInsertionService.ts
+++ b/src/services/mediaInsertionService.ts
@@ -1,0 +1,94 @@
+// @ts-check
+/**
+ * DEC-119 / ISS-179 Phase 3 受管图片插入服务（前端契约层）。
+ *
+ * 职责：
+ * - 接收外部图片源（File / Blob / Uint8Array + mime）
+ * - 通过 ImageAssetStore.registerPending 注册为 pending asset
+ * - 返回可写入 Markdown 源码的图片插入片段（含 alt 占位 + 待落盘标识）
+ *
+ * 不实现：
+ * - Vditor 内部的 paste / drop / drag 事件拦截（属于 WysiwygEditorPane 适配）
+ * - 实际的 fs 落盘（属于 Tauri Rust 侧 phase 3 后段）
+ * - 远程 URL / data URI 处理（属于 ResourceResolver，本期未实现）
+ *
+ * 用法（外部适配示例）：
+ *   const store = new ImageAssetStore();
+ *   const result = await registerImageAsset(store, file, 'foo.png');
+ *   editor.insertAtCursor(result.markdown);
+ *   // 后续：保存时 store.markPersisted(result.asset.hash) + Markdown 改写
+ */
+import {
+  ImageAssetStore,
+  sanitizeFileName,
+  type ImageAsset,
+} from './imageAssetService';
+
+export interface MediaInsertionInput {
+  bytes: Uint8Array;
+  desiredName: string;
+  mime: string;
+  altText?: string;
+}
+
+export interface MediaInsertionResult {
+  markdown: string;
+  asset: ImageAsset;
+}
+
+/**
+ * Register an external image into the store and build the Markdown
+ * insertion fragment. Pure data layer — does not touch DOM or editor.
+ *
+ * Alt text strategy: include the full sanitized filename so the user
+ * sees the original name during pending state. Callers may pass an
+ * `altText` override (truncated to 200 chars).
+ */
+export async function registerImageAsset(
+  store: ImageAssetStore,
+  input: MediaInsertionInput,
+): Promise<MediaInsertionResult> {
+  const safeName = sanitizeFileName(input.desiredName || 'image');
+  const alt = (input.altText ?? safeName).slice(0, 200);
+  const asset = await store.registerPending(input.bytes, safeName, input.mime);
+  return store.insertForMarkdown(asset, /* docBaseName filled by caller */ '', alt);
+}
+
+/**
+ * Convenience helper for File objects (from <input type=file>, paste,
+ * drop, or drag-drop DataTransfer).
+ */
+export async function registerImageAssetFromFile(
+  store: ImageAssetStore,
+  file: File,
+  altText?: string,
+): Promise<MediaInsertionResult> {
+  const buf = await file.arrayBuffer();
+  const bytes = new Uint8Array(buf.byteLength);
+  bytes.set(new Uint8Array(buf));
+  return registerImageAsset(store, {
+    bytes,
+    desiredName: file.name,
+    mime: file.type || 'application/octet-stream',
+    altText,
+  });
+}
+
+/**
+ * Convert a DataTransferItemList (typical for paste/drop events) to a
+ * list of supported image Files. Filter by mime prefix `image/` and
+ * skip already-handled or non-image entries. Pure utility, no side
+ * effects.
+ */
+export function pickImageFiles(items: DataTransferItemList): File[] {
+  const files: File[] = [];
+  for (let i = 0; i < items.length; i += 1) {
+    const item = items[i];
+    if (item.kind !== 'file') continue;
+    const file = item.getAsFile();
+    if (!file) continue;
+    if (!file.type.startsWith('image/')) continue;
+    files.push(file);
+  }
+  return files;
+}


### PR DESCRIPTION
## 概述

DEC-119 / ISS-179 Phase 3 受管图片治理的**前端契约层**落地。在 DEC-121 `imageAssetService` 骨架之上建立 `mediaInsertionService`，提供纯函数的图片注册 / markdown 插入接口，为后续 `WysiwygEditorPane` 的 paste / drop / 文件选择插入提供稳定的契约点。

## 动机

DEC-121 已经给出 `ImageAssetStore` 与 `ImageAsset` 数据模型与 hash 去重逻辑，但缺一个明确的「外部图片源 → 插入 Markdown」契约。WysiwygEditorPane 接入 paste / drop 时，需要稳定的 API 把字节写入 store、产出 markdown 片段、保留 pending 阶段 UX。本 PR 隔离出纯数据层，让后续接入 PR 不必重复实现字节读取、alt 文本策略、hash 去重等逻辑。

## 交付清单

### `src/services/mediaInsertionService.ts`

- `registerImageAsset(store, input)`：注册 `bytes + desiredName + mime + altText?`，返回 `{ markdown, asset }`
- `registerImageAssetFromFile(store, file, altText?)`：从 `File` 对象读取字节
- `pickImageFiles(items: DataTransferItemList)`：从 paste / drop 事件过滤 `image/*` 文件，跳过非 file 项 / 非 image

### Alt 文本策略

- 默认值 = sanitized filename（含扩展名），便于 pending 阶段用户看到原文件名
- `altText` 显式 override 时截断到 200 字符（防止超长 Markdown）
- pending 阶段 markdown：`![<alt>（待落盘）](<objectUrl>)`
- persisted 阶段 markdown：`![<alt>](./<docBase>.assets/<fileName>)`（caller 传 docBaseName）

### `src/__tests__/rich-media/media-insertion-service.test.ts`（11 用例）

- 注册产出 pending markdown ✓
- alt 文本默认包含完整文件名 ✓
- alt override 超过 200 字被截断 ✓
- 文件名缺省降级为 `image` ✓
- 同内容 + 同 desiredName 只注册一次 ✓
- 同内容 + 不同 desiredName 也按 hash 去重 ✓
- persisted 阶段产出相对路径 markdown ✓
- File 输入读取字节 ✓
- pickImageFiles 过滤非 image / 非 file / 空 ✓

## 验证

| 维度 | 结果 |
|------|------|
| vitest | 419 / 419 全绿（388 原 + 14 image-asset + 11 media-insertion + 6 Phase 0/1 rich-media） |
| `npm run typecheck` | ✅ |
| `npm run lint` | ✅ |

## 范围边界（明确）

- ❌ 不实现 Vditor 内部 paste / drop / drag 事件拦截（属于下一 PR，需要改 `WysiwygEditorPane` upload / toolbar 配置）
- ❌ 不实现实际 fs 落盘（属于 Tauri Rust 侧 phase 3 后段：`protocol-asset` feature + persisted-scope + 受控路径授权）
- ❌ 不实现远程 URL / data URI 处理（属于 `ResourceResolver`）
- ❌ 不实现 `ImageAssetStore` 实例共享（当前各调用方自管；后续 `AppContext` 提供）

## 后续工作

1. WysiwygEditorPane paste / drop 事件接 `MediaInsertionService`（ImageAssetStore 实例共享到 AppContext 后再做）
2. Toolbar 加图片插入按钮（Vditor 隐藏的 toolbar 部分恢复）
3. Tauri fs 落盘与 Markdown 改写（Rust 改动）
4. macOS WKWebView / Windows WebView2 真实桌面验证

Refs: DEC-119, DEC-121, ISS-179