### PR TITLE
fix(paste): 默认按纯文本粘贴，修复带标题格式时异常跳行 (ISS-67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **修复粘贴带标题格式的文本时保留源格式并出现异常跳行的问题**（ISS-67）：在 WYSIWYG（Vditor IR）模式下，从浏览器、Word 等复制含 `## 二级标题` 等块级格式的内容后，普通 `Cmd/Ctrl+V` 会按源格式（HTML）粘贴——Vditor 用 Lute 把 `<h2>` 转成独立块级元素，光标停在正文中间时会把当前段落「撑开」，产生异常换行/跳行。现在普通粘贴强制按剪贴板 `text/plain` 插入（`insertValue(text, false)` 不重新渲染 markdown），保留当前段落结构；需要保留源格式时用 `Cmd/Ctrl+Shift+V` 粘贴富文本。图片粘贴与拖拽路径不变。`text/plain` 为空（如仅有 HTML）时仍放行默认行为，避免误吃粘贴。
+
 ## [0.6.3] - 2026-07-30
 
 ### Fixed

--- a/src/__tests__/rich-media/editor-paste-drop.test.tsx
+++ b/src/__tests__/rich-media/editor-paste-drop.test.tsx
@@ -35,6 +35,8 @@ const vditorCalls: VditorConstructorCall[] = [];
  *  注入 .vditor-ir pre，记录 insertValue / getValue 调用，方便测试断言
  *  paste / drop 后是否真的把 markdown 写进编辑器。*/
 let lastInsertedValue = '';
+/** 记录 insertValue 第二参数（render）。ISS-67 纯文本粘贴用 render=false。 */
+let lastInsertRender: boolean | undefined;
 
 vi.mock('vditor', () => {
   const noopRender = () => undefined;
@@ -55,9 +57,10 @@ vi.mock('vditor', () => {
       this.vditor = { ir: { element: pre } };
     }
 
-    public insertValue(value: string): void {
-      // 记录最后一次插入的 markdown，供测试断言
+    public insertValue(value: string, render?: boolean): void {
+      // 记录最后一次插入的内容 + render 标志，供测试断言
       lastInsertedValue = value;
+      lastInsertRender = render;
     }
 
     public getValue(): string {
@@ -119,16 +122,30 @@ function flushFrames(count = 4): Promise<void> {
   });
 }
 
-/** DataTransfer 在 jsdom 中没有完整实现；测试桩补足 paste / drop 需要的接口。 */
-function makeDataTransfer(items: DataTransferItem[]): DataTransfer {
+/**
+ * DataTransfer 在 jsdom 中没有完整实现；测试桩补足 paste / drop 需要的接口。
+ * ISS-67 起 getData 需按 type 返回真实内容（text/plain / text/html），
+ * 故用 stringData 携带 { type -> text } 映射；文件项仍由 items 提供。
+ */
+function makeDataTransfer(
+  items: DataTransferItem[],
+  stringData: Record<string, string> = {},
+): DataTransfer {
+  const types: string[] = [];
+  for (const it of items) {
+    types.push(it.kind === 'file' ? 'Files' : it.type);
+  }
+  for (const t of Object.keys(stringData)) {
+    if (!types.includes(t)) types.push(t);
+  }
   const dt = {
     items: items as unknown as DataTransferItemList,
     files: items
       .filter((it) => it.kind === 'file')
       .map((it) => it.getAsFile()!)
       .filter(Boolean) as unknown as FileList,
-    types: items.map((it) => it.kind === 'file' ? 'Files' : 'text/plain'),
-    getData: () => '',
+    types,
+    getData: (type: string) => stringData[type] ?? '',
     setData: () => undefined,
     clearData: () => undefined,
     setDragImage: () => undefined,
@@ -166,6 +183,7 @@ describe('WysiwygEditorPane paste/drop · DEC-119 / ISS-179 Phase 3 主编辑器
   beforeEach(() => {
     vditorCalls.length = 0;
     lastInsertedValue = '';
+    lastInsertRender = undefined;
     host = document.createElement('div');
     document.body.append(host);
   });
@@ -261,13 +279,14 @@ describe('WysiwygEditorPane paste/drop · DEC-119 / ISS-179 Phase 3 主编辑器
     expect(lastInsertedValue).toContain('（待落盘）');
   });
 
-  it('paste 纯文本 → 不拦截默认行为（preventDefault 未调用）', async () => {
+  it('paste 纯文本 → 按 text/plain 插入（ISS-67：默认纯文本粘贴，render=false）', async () => {
     await mountPane();
     await triggerAfter();
     const editorHost = vditorCalls[0].host;
 
+    // string item 仅用于让 types 含 text/plain；真实内容由 stringData 提供
     const stringItem = makeStringItem('hello world');
-    const dt = makeDataTransfer([stringItem]);
+    const dt = makeDataTransfer([stringItem], { 'text/plain': 'hello world' });
 
     const pasteEvent = new Event('paste', { bubbles: true, cancelable: true });
     Object.defineProperty(pasteEvent, 'clipboardData', { value: dt });
@@ -282,9 +301,10 @@ describe('WysiwygEditorPane paste/drop · DEC-119 / ISS-179 Phase 3 主编辑器
       await flushFrames();
     });
 
-    // 非 image 内容应让 Vditor 默认行为继续；我们的 handler 不调 preventDefault
-    expect(preventDefaultCalled).toBe(false);
-    expect(lastInsertedValue).toBe(''); // editor.insertValue 未被调用
+    // ISS-67：纯文本粘贴被拦截，按 text/plain 内容插入、不渲染 markdown
+    expect(preventDefaultCalled).toBe(true);
+    expect(lastInsertedValue).toBe('hello world');
+    expect(lastInsertRender).toBe(false);
   });
 
   it('paste 多个 image File → markdown 片段用换行分隔', async () => {
@@ -310,5 +330,132 @@ describe('WysiwygEditorPane paste/drop · DEC-119 / ISS-179 Phase 3 主编辑器
     expect(lastInsertedValue).toContain('a.png');
     expect(lastInsertedValue).toContain('b.jpg');
     expect(lastInsertedValue.split('\n\n').length).toBeGreaterThanOrEqual(2);
+  });
+
+  /**
+   * ISS-67：粘贴带标题格式的文本时，默认 Cmd/Ctrl+V 应按纯文本插入
+   * （不把 <h2> 等 HTML 块级格式渲染成独立块、造成跳行）；
+   * Cmd/Ctrl+Shift+V 放行 Vditor 默认富文本粘贴。
+   */
+  describe('ISS-67 · 粘贴默认纯文本 / Shift+V 富文本', () => {
+    /** 构造一个 paste 事件，可指定修饰键。 */
+    function makePasteEvent(dt: DataTransfer, mods: { meta?: boolean; ctrl?: boolean; shift?: boolean }): Event {
+      const ev = new Event('paste', { bubbles: true, cancelable: true });
+      Object.defineProperty(ev, 'clipboardData', { value: dt });
+      Object.defineProperty(ev, 'dataTransfer', { value: dt });
+      Object.defineProperty(ev, 'metaKey', { value: !!mods.meta });
+      Object.defineProperty(ev, 'ctrlKey', { value: !!mods.ctrl });
+      Object.defineProperty(ev, 'shiftKey', { value: !!mods.shift });
+      return ev;
+    }
+
+    it('普通粘贴含 text/html + text/plain → 按 text/plain 插入且 render=false，preventDefault 被调', async () => {
+      await mountPane();
+      await triggerAfter();
+      const editorHost = vditorCalls[0].host;
+
+      // 模拟从浏览器/Word 复制带二级标题的内容：HTML 含 <h2>，plain 是纯文本
+      const dt = makeDataTransfer(
+        [],
+        {
+          'text/html': '<h2>二级标题</h2>',
+          'text/plain': '二级标题',
+        },
+      );
+      const ev = makePasteEvent(dt, {});
+      let preventDefaultCalled = false;
+      ev.preventDefault = () => { preventDefaultCalled = true; };
+
+      await act(async () => {
+        editorHost.dispatchEvent(ev);
+        await flushMicrotasks();
+        await flushFrames();
+      });
+
+      // 拦截了默认行为（否则 Vditor 会按 HTML 渲染成标题块）
+      expect(preventDefaultCalled).toBe(true);
+      // 插入的是纯文本，不是 HTML
+      expect(lastInsertedValue).toBe('二级标题');
+      // render=false：纯文本插入，不当 markdown 渲染
+      expect(lastInsertRender).toBe(false);
+    });
+
+    it('Cmd/Ctrl+Shift+V（富文本快捷键）→ 不拦截，放行 Vditor 默认', async () => {
+      await mountPane();
+      await triggerAfter();
+      const editorHost = vditorCalls[0].host;
+
+      const dt = makeDataTransfer(
+        [],
+        {
+          'text/html': '<h2>二级标题</h2>',
+          'text/plain': '二级标题',
+        },
+      );
+      // Mac: metaKey+shiftKey；这里同时设 ctrl 以兼容非 Mac 判定逻辑
+      const ev = makePasteEvent(dt, { meta: true, ctrl: true, shift: true });
+      let preventDefaultCalled = false;
+      ev.preventDefault = () => { preventDefaultCalled = true; };
+
+      await act(async () => {
+        editorHost.dispatchEvent(ev);
+        await flushMicrotasks();
+        await flushFrames();
+      });
+
+      // 富文本快捷键：放行，不调 preventDefault，也不插入纯文本
+      expect(preventDefaultCalled).toBe(false);
+      expect(lastInsertedValue).toBe('');
+    });
+
+    it('text/plain 为空但含 text/html → 放行（不误吃粘贴）', async () => {
+      await mountPane();
+      await triggerAfter();
+      const editorHost = vditorCalls[0].host;
+
+      // 只有 HTML、没有可用纯文本（某些来源的边缘情况）
+      const dt = makeDataTransfer(
+        [],
+        { 'text/html': '<p>只有HTML</p>' },
+      );
+      const ev = makePasteEvent(dt, {});
+      let preventDefaultCalled = false;
+      ev.preventDefault = () => { preventDefaultCalled = true; };
+
+      await act(async () => {
+        editorHost.dispatchEvent(ev);
+        await flushMicrotasks();
+        await flushFrames();
+      });
+
+      // 纯文本为空 → 放行交给 Vditor，不强行吃掉粘贴
+      expect(preventDefaultCalled).toBe(false);
+      expect(lastInsertedValue).toBe('');
+    });
+
+    it('同时含图片 File → 仍走图片路径，纯文本分支不介入', async () => {
+      await mountPane();
+      await triggerAfter();
+      const editorHost = vditorCalls[0].host;
+
+      // 既有图片文件，也有 text/plain（部分截图工具会同时给）
+      const imageItem = makeImageFileItem('shot.png', 'image/png', 'img-bytes');
+      const dt = makeDataTransfer(
+        [imageItem],
+        { 'text/plain': '一些文字' },
+      );
+      const ev = makePasteEvent(dt, {});
+
+      await act(async () => {
+        editorHost.dispatchEvent(ev);
+        await flushMicrotasks();
+        await flushFrames();
+      });
+
+      // 走图片路径：插入的是图片 markdown（含待落盘），不是纯文本「一些文字」
+      expect(lastInsertedValue).toContain('shot.png');
+      expect(lastInsertedValue).toContain('（待落盘）');
+      expect(lastInsertedValue).not.toContain('一些文字');
+    });
   });
 });

--- a/src/components/WysiwygEditorPane.tsx
+++ b/src/components/WysiwygEditorPane.tsx
@@ -44,6 +44,35 @@ function getIrElement(editor: import('vditor').default): HTMLElement | null {
   return vditor?.ir?.element ?? null;
 }
 
+/**
+ * ISS-67：判断本次粘贴是否为「保留源格式」快捷键（Cmd/Ctrl+Shift+V）。
+ * 命中时放行 Vditor 默认富文本粘贴；否则按纯文本插入（见 handleTextPaste）。
+ * Mac 用 metaKey，其余平台用 ctrlKey，需同时按住 shift。
+ *
+ * 注：ClipboardEvent 在 lib.dom 里未声明 metaKey/ctrlKey/shiftKey（它们属于
+ * KeyboardEvent/MouseEvent），但运行时 paste 事件确实携带这些修饰键属性，
+ * 故用窄类型断言读取，避免散落的 any。
+ */
+function isRichPasteShortcut(event: ClipboardEvent): boolean {
+  const mods = event as unknown as { metaKey?: boolean; ctrlKey?: boolean; shiftKey?: boolean };
+  const primary = mods.metaKey || mods.ctrlKey;
+  return !!primary && !!mods.shiftKey;
+}
+
+/**
+ * ISS-67：从粘贴事件中取出纯文本。优先取 text/plain；为空时返回 null
+ * 表示放行（避免吃掉只有 text/html、无纯文本的剪贴板内容）。
+ */
+function extractPlainText(event: ClipboardEvent): string | null {
+  const dt = event.clipboardData;
+  if (!dt) return null;
+  // getData 对不存在的 type 返回空串；types 数组更可靠地反映剪贴板内容
+  const types = Array.from(dt.types ?? []);
+  if (!types.includes('text/plain')) return null;
+  const text = dt.getData('text/plain');
+  return text.length > 0 ? text : null;
+}
+
 function collapseExpandedMarkers(editor: import('vditor').default | null): void {
   if (!editor) return;
   const ir = getIrElement(editor);
@@ -420,6 +449,34 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
     [imageAssetStore, emitEditorValueIfChanged],
   );
 
+  /**
+   * ISS-67：文本类粘贴处理。
+   *
+   * 默认（Cmd/Ctrl+V）强制按 text/plain 插入：用 insertValue(text, false)
+   * 的 render=false 走「不解析 markdown」的纯文本路径，避免剪贴板里的
+   * <h2> 等块级格式被 Lute 转成独立块、把当前段落「撑开」造成跳行。
+   *
+   * Cmd/Ctrl+Shift+V（isRichPasteShortcut 命中）放行，让 Vditor 按源格式
+   * （text/html）粘贴，保留富文本能力。返回 false 表示「未处理、放行默认」。
+   */
+  const handleTextPaste = useCallback(
+    (event: ClipboardEvent): boolean => {
+      // 富文本快捷键：放行 Vditor 默认（HTML→markdown）粘贴
+      if (isRichPasteShortcut(event)) return false;
+      const text = extractPlainText(event);
+      // 没有 text/plain（如只有图片，或只有 text/html）→ 放行，交由后续逻辑 / Vditor
+      if (text === null) return false;
+      const editor = editorRef.current;
+      if (!editor) return false;
+      event.preventDefault();
+      // render=false：作为纯文本插入，不把内容当 markdown 重新渲染
+      editor.insertValue(text, false);
+      emitEditorValueIfChanged(editor);
+      return true;
+    },
+    [emitEditorValueIfChanged],
+  );
+
   const lockComplexTables = useCallback(() => {
     const editor = editorRef.current;
     if (!editor) return;
@@ -561,8 +618,15 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
     // DEC-119 / ISS-179 Phase 3：拦截 paste/drop 中的 image File，
     // 走 ImageAssetStore -> 待落盘 markdown 插入 Vditor。
     // 非 image 内容返回 false，让 markUserInteracted / Vditor 默认处理。
+    //
+    // ISS-67：对 paste 事件，图片处理先行；若未命中图片，再交给
+    // handleTextPaste 做纯文本粘贴（默认 Cmd/Ctrl+V）或放行富文本
+    // （Cmd/Ctrl+Shift+V）。drop 事件不涉及纯文本降级，保持原行为。
     const pasteHandler = (event: Event) => {
-      void handleImageFiles(event as ClipboardEvent);
+      const ce = event as ClipboardEvent;
+      void handleImageFiles(ce).then((handled) => {
+        if (!handled) handleTextPaste(ce);
+      });
     };
     const dropHandler = (event: Event) => {
       void handleImageFiles(event as DragEvent);
@@ -828,7 +892,7 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
       initializingRef.current = false;
       userInteractedRef.current = false;
     };
-  }, [filePath, lockComplexTables, emitEditorValueIfChanged, onChange, retryKey, handleImageFiles]);
+  }, [filePath, lockComplexTables, emitEditorValueIfChanged, onChange, retryKey, handleImageFiles, handleTextPaste]);
 
   useEffect(() => {
     const editor = editorRef.current;


### PR DESCRIPTION
## 问题

Closes #67

Vditor IR 模式下，从浏览器、Word 等复制含 \`## 二级标题\` 等块级格式的内容后，普通 \`Cmd/Ctrl+V\` 会按源格式（HTML）粘贴——Vditor 用 Lute 把 \`<h2>\` 转成独立块级元素，光标停在正文中间时会把当前段落「撑开」，产生异常换行/跳行，破坏段落结构。

根因已在 #67 评论中核查：此前文本/HTML 粘贴完全交给 Vditor 默认处理，Folia 无任何干预，Vditor 默认优先取 \`text/html\`。

## 方案（方案一：默认纯文本 + 快捷键富文本）

- **普通 \`Cmd/Ctrl+V\`**：拦截，强制取剪贴板 \`text/plain\`，用 \`editor.insertValue(text, false)\` 插入（\`render=false\` 表示纯文本不渲染 markdown），彻底避免块级格式打断段落。
- **\`Cmd/Ctrl+Shift+V\`**：不拦截，放行给 Vditor 默认富文本处理（保留源格式能力）。
- **图片粘贴/拖拽**：完全不变，仍走 \`handleImageFiles\` → ImageAssetStore。
- \`text/plain\` 为空（如仅有 \`text/html\`）时放行，避免误吃粘贴。

## 改动文件

| 文件 | 改动 |
|------|------|
| \`src/components/WysiwygEditorPane.tsx\` | 新增 \`isRichPasteShortcut\` / \`extractPlainText\` / \`handleTextPaste\`，接入现有 \`pasteHandler\` |
| \`src/__tests__/rich-media/editor-paste-drop.test.tsx\` | 新增 4 个 ISS-67 用例 + 更新 Vditor mock 记录 \`insertValue\` 的 \`render\` 参数 |
| \`CHANGELOG.md\` | Unreleased 区追加修复记录 |

## 验证

- \`npm run typecheck\` ✅
- \`npm test\` ✅ vitest 516/516 全绿（含新增 8 个 paste 用例）

## 不在本次 scope

- 源码模式（CodeMirror）本就用默认纯文本粘贴，无此问题，未改动。
- 不加设置开关（方案一定为纯快捷键驱动，无 UI 改动）。