### PR TITLE
feat(close-confirm): 关闭未保存文档或退出应用时增加保存确认 (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **关闭未保存文档或退出应用时增加保存确认**（#68 / DEC-130）：当文档存在未保存修改时，关闭标签、关闭窗口或退出应用（Cmd+Q / 红绿灯 / 窗口 X）前会先弹出三选项确认框——「保存」（保存后继续关闭）、「不保存」（放弃修改关闭）、「取消」（返回编辑器）；文档已保存时直接关闭不打扰。退出应用时若有多个未保存标签，会逐个确认，中途取消任一个即终止退出。原有原生 `window.confirm` 的单标签关闭确认也一并升级为该三选项对话框，并补齐中 / 英 / 日三语文案。窗口关闭拦截走 Rust `prevent_close` + 事件方案，避免此前前端 `onCloseRequested` 在 macOS 上的误拦截问题；程序化关闭路径（merge-back、确认后关闭）改走 `destroy()` 绕过拦截。Issue 列出的「批量关闭」「切换文档替换编辑内容」两个场景留作后续。
+
 ### Fixed
 
 - **修复粘贴带标题格式的文本时保留源格式并出现异常跳行的问题**（ISS-67）：在 WYSIWYG（Vditor IR）模式下，从浏览器、Word 等复制含 `## 二级标题` 等块级格式的内容后，普通 `Cmd/Ctrl+V` 会按源格式（HTML）粘贴——Vditor 用 Lute 把 `<h2>` 转成独立块级元素，光标停在正文中间时会把当前段落「撑开」，产生异常换行/跳行。现在普通粘贴强制按剪贴板 `text/plain` 插入（`insertValue(text, false)` 不重新渲染 markdown），保留当前段落结构；需要保留源格式时用 `Cmd/Ctrl+Shift+V` 粘贴富文本。图片粘贴与拖拽路径不变。`text/plain` 为空（如仅有 HTML）时仍放行默认行为，避免误吃粘贴。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -492,22 +492,36 @@ fn take_tab_ids_for_window(app: &tauri::AppHandle, label: &str) -> Vec<String> {
 /// ISS-164：主动关闭某 label 的 tab 窗口（merge-back 时源窗口用）。
 /// 前端无法直接 `invoke` 关闭别的窗口，需走这条 command。
 ///
-/// 注意：本函数只触发 `window.close()`，**不**预取 tab_ids。CloseRequested
-/// handler（`handle_window_close`）是回收 tab 列表 + emit `window:closed` 的
-/// 唯一权威——若本函数提前 `take_tab_ids_for_window`，CloseRequested handler
-/// 拿到的就是空 Vec，会 emit `window:closed { remainingTabIds: [] }`，主窗口
-/// 误以为没 tab 要回收，导致用户丢 tab。这是 ISS-174 review 时发现的竞态，
-/// 修复方案：把回收职责彻底收敛到 CloseRequested 一处。
+/// 这是程序化关闭路径，走 destroy() 绕过 Issue #68 的 CloseRequested 拦截
+/// （destroy 不触发 CloseRequested，无递归）。回收职责由 finalize_window_close
+/// 在 destroy 前完成——必须在此处一次性 take + emit，不能由调用方预取，
+/// 否则主窗口会收到空 remainingTabIds（ISS-174 review 发现的竞态）。
 #[tauri::command]
 fn close_tab_window(label: String, app: tauri::AppHandle) -> Result<(), String> {
   if !is_valid_tab_window_label(&label) {
     return Err(format!("invalid tab window label '{label}'"));
   }
+  finalize_window_close(&app, &label);
   if let Some(window) = app.get_webview_window(&label) {
     window
-      .close()
+      .destroy()
       .map_err(|error| format!("failed to close tab window '{label}': {error}"))?;
   }
+  Ok(())
+}
+
+/// Issue #68：前端完成 dirty 确认（保存 / 不保存）后，调用本命令真正销毁
+/// 当前窗口。主窗口 destroy = 进程退出；tear-off 窗口 destroy 前先回收 tab。
+///
+/// 注意：本命令接收 `tauri::Window`（命令调用者所在窗口），而非 label——
+/// 这样无需前端回传 label，且天然只关闭「发起确认的那个窗口」。
+#[tauri::command]
+fn confirm_close(window: tauri::Window, app: tauri::AppHandle) -> Result<(), String> {
+  let label = window.label().to_string();
+  finalize_window_close(&app, &label);
+  window
+    .destroy()
+    .map_err(|error| format!("failed to close window '{label}': {error}"))?;
   Ok(())
 }
 
@@ -561,7 +575,8 @@ pub fn run() {
       unwatch_path,
       create_tab_window,
       update_tab_window_tabs,
-      close_tab_window
+      close_tab_window,
+      confirm_close
     ])
     .setup(|app| {
       if cfg!(debug_assertions) {
@@ -574,20 +589,25 @@ pub fn run() {
       Ok(())
     })
     .on_window_event(|window, event| {
-      // ISS-164：新窗口（包括 tear-off 出的独立窗口）创建时也挂上关闭监听。
-      if let tauri::WindowEvent::CloseRequested { .. } = event {
-        if window.label() == "main" {
-          // 主窗口：关窗即退出（不做 hide-to-Dock——见 DEC-110 设计：与用户「关窗即退出」
-          // 期望一致；macOS 标准 hide-to-Dock 是 UX 决策，需用户明确要求再合入）。
-          handle_window_close(window);
-          return;
-        }
-        // 独立 tear-off 窗口：emit window:closed 回收 tab，然后显式 destroy()。
-        // macOS 上偶发 CloseRequested 默认不销毁窗口（PR #54 报告），destroy() 强制销毁
-        // 且不再触发 CloseRequested（无递归）。如果 Rust 默认行为已稳定，destroy() 是
-        // 多余调用但不破坏行为——保留作为兜底。
-        handle_window_close(window);
-        let _ = window.destroy();
+      // Issue #68：用户请求关闭窗口（红绿灯 / Cmd+Q / 窗口 X）时，先交给前端
+      // 检查是否存在未保存修改（dirty 标签），由前端弹三选项确认框后决定真正
+      // 关闭还是取消。这里只 prevent_close 并 emit `request:confirm-close`，
+      // 真正的窗口销毁由前端 invoke `confirm_close`（内部 destroy()）完成。
+      //
+      // 必须走 Rust prevent_close 而非前端 onCloseRequested：历史教训（ISS-174
+      // review，见 useSession.ts 注释）——前端 onCloseRequested 在 macOS Tauri
+      // 2.11.0 上即便不调 preventDefault 也会误拦截 close，造成窗口无法销毁。
+      //
+      // 程序化关闭路径（merge-back 的 close_tab_window、确认后的 confirm_close）
+      // 直接调 destroy()，destroy() 不会再触发 CloseRequested（无递归，见 Tauri
+      // app.rs 注释），因此不会误触发本拦截逻辑。
+      if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+        api.prevent_close();
+        let label = window.label().to_string();
+        let _ = window.app_handle().emit(
+          "request:confirm-close",
+          serde_json::json!({ "label": label }),
+        );
       }
     })
     .build(tauri::generate_context!())
@@ -618,18 +638,17 @@ pub fn run() {
     });
 }
 
-/// ISS-164：tear-off 窗口关闭时回收 tab 列表并 emit `window:closed` 给主窗口。
+/// Issue #68 / ISS-164：tear-off 窗口关闭前回收 tab 列表并 emit `window:closed`
+/// 给主窗口。在真正 `destroy()` 之前调用——因为 destroy() 不再触发 CloseRequested
+/// （无递归，见 Tauri app.rs 注释），tab 回收职责需要从旧的 CloseRequested handler
+/// 迁移到程序化关闭路径（confirm_close / close_tab_window）。
 ///
-/// `on_window_event` 回调给的是 `&Window`（tao 抽象层），通过 `window.label()`
-/// 拿到 label，再用 `app.get_webview_window` 取 `WebviewWindow` 走状态查找。
-fn handle_window_close(window: &tauri::Window) {
-  let label = window.label().to_string();
-  // 主窗口关闭 = 应用退出，无需回收 tab（AppState 跟着进程销毁）。
+/// 主窗口关闭 = 应用退出，AppState 跟着进程销毁，无需 emit 回收。
+fn finalize_window_close(app: &tauri::AppHandle, label: &str) {
   if label == "main" {
     return;
   }
-  let app = window.app_handle();
-  let remaining = take_tab_ids_for_window(app, &label);
+  let remaining = take_tab_ids_for_window(app, label);
   let _ = app.emit(
     "window:closed",
     serde_json::json!({

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -331,6 +331,10 @@ export function AppLayout() {
   // 复用 saveFile 底层写盘 + 图片落盘逻辑，但不依赖 active 状态——直接从 session.tabs
   // 取出该 tab 的 file 处理。保存成功后该 tab 会立即被关闭，故无需更新 dirty 标志。
   // docx 不可写（write_opened_document 拒绝 docx），直接跳过。
+  //
+  // 当目标文件无 path（未保存过的新文件）时，saveFile → saveFileAs 会弹原生保存
+  // 对话框。若用户在该对话框里取消，saveFileAs 返回原 file（path 仍为空）——此时
+  // 抛错让上层 try/catch 终止关闭，避免「选了保存但实际没存」导致内容丢失。
   const saveDirtyTabById = useCallback(async (tabId: string) => {
     const target = tabs.find((t) => t.id === tabId);
     if (!target) return;
@@ -348,7 +352,10 @@ export function AppLayout() {
         fileToSave = { ...targetFile, content: nextContent };
       }
     }
-    await saveFile(fileToSave);
+    const saved = await saveFile(fileToSave);
+    if (!saved.path) {
+      throw new Error('save cancelled by user');
+    }
   }, [tabs, imageAssetStore]);
 
   const handleExportWord = useCallback(async () => {

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -40,6 +40,7 @@ import { TabBar } from '../components/TabBar';
 import type { TabDragPayload } from '../components/tabDragPayload';
 import { RecentFilesPage } from '../components/RecentFilesPage';
 import { ContextMenu } from '../components/ContextMenu';
+import { ConfirmCloseDialog, type ConfirmCloseResult } from '../components/ConfirmCloseDialog';
 import { SettingsPage } from '../components/SettingsPage';
 import type { SourceHeadingScrollRequest } from '../components/EditorPane';
 import { useSession } from '../hooks/useSession';
@@ -148,6 +149,7 @@ export function AppLayout() {
   const {
     activeFile: file,
     activeTab,
+    tabs,
     openInNewTab,
     closeTab,
     activeTabId,
@@ -155,7 +157,20 @@ export function AppLayout() {
     updateActiveTabMeta,
     tearOffViaDrag,
   } = session;
-  const confirmCloseDirty = useCallback(() => window.confirm('该标签有未保存改动，确定关闭吗？'), []);
+  // Issue #68：保存确认对话框挂载状态。resolve 由 confirmCloseDirty 触发——
+  // 它返回一个 Promise，把 resolve 回调暂存到 state，用户点按钮时回调兑现。
+  const [pendingClose, setPendingClose] = useState<{
+    fileName: string;
+    resolve: (result: ConfirmCloseResult) => void;
+  } | null>(null);
+  // Issue #68：把原来的同步 window.confirm 升级为异步三选项对话框。
+  // 返回 Promise，resolve 回调暂存到 pendingClose state，由 ConfirmCloseDialog
+  // 的按钮兑现。这样 closeTab / 退出循环可以 await 它。
+  const confirmCloseDirty = useCallback((fileName: string) => {
+    return new Promise<ConfirmCloseResult>((resolve) => {
+      setPendingClose({ fileName, resolve });
+    });
+  }, []);
   const windowLabel = useMemo(() => detectCurrentWindowLabel(), []);
   const isTearOffSupported = useMemo(
     () => '__TAURI_INTERNALS__' in window,
@@ -312,6 +327,30 @@ export function AppLayout() {
     }
   }, [file, updateActiveFile, imageAssetStore]);
 
+  // Issue #68：按 tabId 落盘指定标签（退出 / 关闭确认循环里用于保存非 active 标签）。
+  // 复用 saveFile 底层写盘 + 图片落盘逻辑，但不依赖 active 状态——直接从 session.tabs
+  // 取出该 tab 的 file 处理。保存成功后该 tab 会立即被关闭，故无需更新 dirty 标志。
+  // docx 不可写（write_opened_document 拒绝 docx），直接跳过。
+  const saveDirtyTabById = useCallback(async (tabId: string) => {
+    const target = tabs.find((t) => t.id === tabId);
+    if (!target) return;
+    const targetFile = target.file;
+    if (targetFile.fileType === 'docx') return;
+    const { saveFile } = await import('../services/fileService');
+    let fileToSave = targetFile;
+    if (targetFile.path) {
+      const { replacements, failures } = await persistPendingImageAssets(imageAssetStore, targetFile.path);
+      if (failures.length > 0) {
+        console.error('[Folia] 部分图片落盘失败:', failures);
+      }
+      if (replacements.length > 0) {
+        const nextContent = replaceBlobUrlsWithRelativePaths(targetFile.content, replacements);
+        fileToSave = { ...targetFile, content: nextContent };
+      }
+    }
+    await saveFile(fileToSave);
+  }, [tabs, imageAssetStore]);
+
   const handleExportWord = useCallback(async () => {
     if (!file.path || file.fileType === 'docx') return;
     try {
@@ -433,7 +472,7 @@ export function AppLayout() {
       if (e.key === 'm' && e.altKey && !e.shiftKey) { e.preventDefault(); handleToggleWechatPreview(); return; }
       if (e.key === 'w' && !e.shiftKey && !e.altKey) {
         e.preventDefault();
-        closeTab(activeTabId, { confirmDirty: confirmCloseDirty });
+        void closeTab(activeTabId, { confirmDirty: confirmCloseDirty, onSave: saveDirtyTabById });
         return;
       }
       if (e.key === ',' && !e.shiftKey && !e.altKey) {
@@ -446,7 +485,7 @@ export function AppLayout() {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [handleOpen, handleSave, handleSaveAs, handleExportWord, handleToggleEditorMode, handleToggleWordPreview, handleToggleWechatPreview, closeTab, activeTabId, confirmCloseDirty]);
+  }, [handleOpen, handleSave, handleSaveAs, handleExportWord, handleToggleEditorMode, handleToggleWordPreview, handleToggleWechatPreview, closeTab, activeTabId, confirmCloseDirty, saveDirtyTabById]);
 
   useEffect(() => {
     const handler = async (e: DragEvent) => {
@@ -544,6 +583,61 @@ export function AppLayout() {
       unlisten?.();
     };
   }, [handleOpenPath, isTauriRuntime]);
+
+  // Issue #68：拦截窗口关闭 / 应用退出。Rust 侧 CloseRequested → prevent_close +
+  // emit `request:confirm-close`（见 lib.rs），前端收到后逐个确认 dirty 标签：
+  // 任一「取消」则放弃关闭；全部「保存 / 不保存」处理后 invoke `confirm_close`
+  // 真正销毁窗口。无 dirty 时直接关闭，不打扰用户。
+  useEffect(() => {
+    if (!isTauriRuntime) return;
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+    let closing = false; // 防重入：用户连点红绿灯时只处理一次。
+
+    void Promise.all([
+      import('@tauri-apps/api/core'),
+      import('@tauri-apps/api/event'),
+    ]).then(async ([{ invoke }, { listen }]) => {
+      const listener = await listen<{ label: string }>('request:confirm-close', async (event) => {
+        // 只处理本窗口的关闭请求（多窗口场景下事件会广播，各窗口各管各的）。
+        if (event.payload.label !== windowLabel) return;
+        if (closing) return;
+        closing = true;
+        try {
+          const dirtyTabs = tabs.filter((t) => t.file.dirty);
+          for (const tab of dirtyTabs) {
+            const result = await confirmCloseDirty(tab.file.name);
+            if (result === 'cancel') {
+              closing = false;
+              return; // 用户取消，保持窗口打开。
+            }
+            if (result === 'save') {
+              await saveDirtyTabById(tab.id);
+            }
+            // 'discard' → 不保存，继续下一个。
+          }
+          // 全部处理完毕（或无 dirty）：真正关闭窗口。
+          await invoke('confirm_close');
+        } catch (error) {
+          console.warn('confirm-close flow failed:', error);
+          closing = false;
+        }
+      });
+
+      if (cancelled) {
+        listener();
+        return;
+      }
+      unlisten = listener;
+    }).catch((error) => {
+      console.warn('Failed to bind request:confirm-close:', error);
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [isTauriRuntime, windowLabel, tabs, confirmCloseDirty, saveDirtyTabById]);
 
   useEffect(() => {
     // session 已恢复持久化标签时，跳过旧的单文件重开逻辑（多标签会话已取代 reopenLastFile）。
@@ -811,7 +905,7 @@ export function AppLayout() {
             windowLabel={windowLabel}
             onSelect={session.switchTab}
             onContextMenu={(id, x, y) => setContextMenu({ tabId: id, x, y })}
-            onClose={(id) => session.closeTab(id, { confirmDirty: confirmCloseDirty })}
+            onClose={(id) => { void session.closeTab(id, { confirmDirty: confirmCloseDirty, onSave: saveDirtyTabById }); }}
             onNew={() => session.openInNewTab(createEmptyFile())}
             onTearOffViaDrag={isTearOffSupported ? tearOffViaDrag : undefined}
             onMergeBackDrop={isTearOffSupported ? handleMergeBackDrop : undefined}
@@ -893,7 +987,7 @@ export function AppLayout() {
           x={contextMenu.x}
           y={contextMenu.y}
           onClose={() => setContextMenu(null)}
-          onCloseTab={() => session.closeTab(contextMenu.tabId, { confirmDirty: confirmCloseDirty })}
+          onCloseTab={() => { void session.closeTab(contextMenu.tabId, { confirmDirty: confirmCloseDirty, onSave: saveDirtyTabById }); }}
           onCloseOthers={() => session.closeOthers(contextMenu.tabId)}
           onCloseToRight={() => session.closeToRight(contextMenu.tabId)}
           onCloseAll={() => session.closeAll()}
@@ -916,6 +1010,15 @@ export function AppLayout() {
             onClose={handleCloseHtmlTableViewer}
           />
         </Suspense>
+      )}
+      {pendingClose && (
+        <ConfirmCloseDialog
+          fileName={pendingClose.fileName}
+          onResolve={(result) => {
+            pendingClose.resolve(result);
+            setPendingClose(null);
+          }}
+        />
       )}
     </div>
     </ImageAssetStoreProvider>

--- a/src/components/ConfirmCloseDialog.tsx
+++ b/src/components/ConfirmCloseDialog.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef } from 'react';
+import { useSettings } from '../hooks/useSettings';
+import { translate } from '../services/i18n';
+
+export type ConfirmCloseResult = 'save' | 'discard' | 'cancel';
+
+type ConfirmCloseDialogProps = {
+  fileName: string;
+  onResolve: (result: ConfirmCloseResult) => void;
+};
+
+/**
+ * Issue #68：关闭未保存文档 / 退出应用前的三选项确认框（保存 / 不保存 / 取消）。
+ *
+ * 交互骨架参照 HtmlTableViewerOverlay / SettingsPage：
+ * - `role="dialog" aria-modal="true"` 全屏遮罩 + 居中面板；
+ * - Escape 键 = 取消，点击遮罩空白 = 取消；
+ * - 默认聚焦「取消」按钮（与 macOS 行为一致，避免误触销毁性操作）。
+ *
+ * 该组件不持有任何关闭逻辑，只通过 `onResolve` 把用户选择上抛给调用方
+ * （AppLayout）统一编排保存 / 关闭 / 取消。
+ */
+export function ConfirmCloseDialog({ fileName, onResolve }: ConfirmCloseDialogProps) {
+  const settings = useSettings();
+  const t = (key: Parameters<typeof translate>[1]) => translate(settings.locale, key);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  // 挂载时聚焦「取消」，键盘用户可直接回车放弃关闭。
+  useEffect(() => {
+    cancelButtonRef.current?.focus();
+  }, []);
+
+  // Escape = 取消（与点击遮罩一致）。
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onResolve('cancel');
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onResolve]);
+
+  const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onResolve('cancel');
+    }
+  };
+
+  const title = t('confirmCloseTitle').replace('{fileName}', fileName);
+  const message = t('confirmCloseMessage');
+
+  return (
+    <div
+      className="confirm-close-overlay"
+      role="presentation"
+      onClick={handleOverlayClick}
+    >
+      <div
+        className="confirm-close-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+      >
+        <div className="confirm-close-body">
+          <h2 className="confirm-close-title">{title}</h2>
+          <p className="confirm-close-message">{message}</p>
+        </div>
+        <div className="confirm-close-actions">
+          <button
+            ref={cancelButtonRef}
+            type="button"
+            className="confirm-close-button secondary-action-button"
+            onClick={() => onResolve('cancel')}
+          >
+            {t('confirmCloseCancel')}
+          </button>
+          <button
+            type="button"
+            className="confirm-close-button danger-action-button"
+            onClick={() => onResolve('discard')}
+          >
+            {t('confirmCloseDiscard')}
+          </button>
+          <button
+            type="button"
+            className="confirm-close-button primary-action-button"
+            onClick={() => onResolve('save')}
+          >
+            {t('confirmCloseSave')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -14,10 +14,19 @@ import {
   type TabMergeBackPayload,
   type TabTearOffPayload,
 } from '../services/tabWindowService';
+import type { ConfirmCloseResult } from '../components/ConfirmCloseDialog';
 
 export interface CloseOptions {
-  /** 关闭 dirty 标签前的确认回调；返回 false 取消关闭。无此回调时直接关闭。 */
-  confirmDirty?: () => boolean;
+  /**
+   * 关闭 dirty 标签前的确认回调（Issue #68）。异步三选项：
+   * - 'save'    → 调用 `onSave` 保存后继续关闭
+   * - 'discard' → 放弃修改并继续关闭
+   * - 'cancel'  → 取消本次关闭
+   * 无此回调时直接关闭（不确认）。
+   */
+  confirmDirty?: (fileName: string) => Promise<ConfirmCloseResult>;
+  /** 用户选「保存」时调用的保存逻辑（通常指向 AppLayout.handleSave，但需按指定 tab 落盘）。 */
+  onSave?: (tabId: string) => Promise<void>;
 }
 
 /**
@@ -192,10 +201,21 @@ export function useSession() {
   }, []);
 
   const closeTab = useCallback(
-    (id: string, options?: CloseOptions) => {
+    async (id: string, options?: CloseOptions) => {
       const tab = state.tabs.find((t) => t.id === id);
       if (!tab) return true;
-      if (tab.file.dirty && options?.confirmDirty && !options.confirmDirty()) return false;
+      if (tab.file.dirty && options?.confirmDirty) {
+        const result = await options.confirmDirty(tab.file.name);
+        // await 期间该 tab 可能已被关闭/切换，用最新 state 复核存在性，避免误关他页。
+        if (!stateRef.current.tabs.some((t) => t.id === id)) return false;
+        if (result === 'cancel') return false;
+        if (result === 'save') {
+          if (options.onSave) await options.onSave(id);
+          // 保存后再次复核：保存若失败或 tab 被移除，则放弃关闭。
+          if (!stateRef.current.tabs.some((t) => t.id === id)) return false;
+        }
+        // 'discard' → 直接关闭。
+      }
       dispatch({ type: 'closeTab', id, confirmed: true });
       return true;
     },
@@ -235,15 +255,22 @@ export function useSession() {
     async (id: string, options?: CloseOptions) => {
       const tab = state.tabs.find((t) => t.id === id);
       if (!tab) return false;
-      if (tab.file.dirty && options?.confirmDirty && !options.confirmDirty()) return false;
+      if (tab.file.dirty && options?.confirmDirty) {
+        const result = await options.confirmDirty(tab.file.name);
+        if (result === 'cancel') return false;
+        if (result === 'save' && options.onSave) await options.onSave(id);
+        // 保存 / 弹框期间 tab 可能已变，用最新 state 取最新快照。
+      }
 
+      // 重新读取 tab 快照：上面 await 后原 tab 引用可能已过期。
+      const current = stateRef.current.tabs.find((t) => t.id === id) ?? tab;
       const windowLabel = detectCurrentWindowLabel();
       const payload: TabMergeBackPayload = {
         tabId: id,
         sourceLabel: windowLabel,
         targetLabel: 'main',
-        dirty: tab.file.dirty,
-        tab,
+        dirty: current.file.dirty,
+        tab: current,
       };
       try {
         await mergeBackTab(payload);

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -149,6 +149,11 @@ const zhCN = {
   fileLostLabel: '文件已丢失',
   draftTooLargeLabel: '草稿过大未自动保存',
   statusBarSaveAs: '另存为',
+  confirmCloseTitle: '是否保存对「{fileName}」的更改？',
+  confirmCloseMessage: '如果不保存，关闭后将丢失本次修改。',
+  confirmCloseSave: '保存',
+  confirmCloseDiscard: '不保存',
+  confirmCloseCancel: '取消',
 };
 
 type I18nKey = keyof typeof zhCN;
@@ -296,6 +301,11 @@ const enUS: Record<I18nKey, string> = {
   fileLostLabel: 'File missing',
   draftTooLargeLabel: 'Draft too large to auto-save',
   statusBarSaveAs: 'Save as',
+  confirmCloseTitle: 'Save changes to “{fileName}”?',
+  confirmCloseMessage: 'Your changes will be lost if you don’t save them.',
+  confirmCloseSave: 'Save',
+  confirmCloseDiscard: 'Don’t Save',
+  confirmCloseCancel: 'Cancel',
 };
 
 const jaJP: Record<I18nKey, string> = {
@@ -441,6 +451,11 @@ const jaJP: Record<I18nKey, string> = {
   fileLostLabel: 'ファイルが見つかりません',
   draftTooLargeLabel: '下書きが大きすぎて自動保存できません',
   statusBarSaveAs: '名前を付けて保存',
+  confirmCloseTitle: '「{fileName}」への変更を保存しますか？',
+  confirmCloseMessage: '保存しない場合、変更は失われます。',
+  confirmCloseSave: '保存',
+  confirmCloseDiscard: '保存しない',
+  confirmCloseCancel: 'キャンセル',
 };
 
 const dictionaries: Record<AppLocale, Record<I18nKey, string>> = {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3509,3 +3509,96 @@ html[data-theme='dark'] .word-paper-content th,
 html[data-theme='dark'] .word-paper-content td {
   border-color: var(--border-soft);
 }
+
+/* ──────── Issue #68：关闭未保存文档 / 退出应用确认框 ──────── */
+/* 复用 .settings-overlay / .settings-modal 的遮罩 + 入场动画骨架，
+   z-index 取 2200 保证盖在设置面板（2000）与表格查看器（2100）之上。 */
+.confirm-close-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2200;
+  animation: settings-overlay-in 120ms ease-out both;
+}
+
+.confirm-close-dialog {
+  width: min(420px, calc(100vw - 48px));
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 22px 22px 18px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  box-shadow: 0 8px 36px var(--shadow-soft);
+  animation: settings-modal-in 140ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  will-change: transform;
+}
+
+.confirm-close-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.confirm-close-title {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--fg);
+}
+
+.confirm-close-message {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+/* 按钮区：右对齐，顺序与 macOS 一致（取消 · 不保存 · 保存）。 */
+.confirm-close-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.confirm-close-button {
+  min-width: 72px;
+}
+
+/* 「不保存」按钮：基于现有 .secondary-action-button 风格加 danger 强调。 */
+.danger-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border-radius: 5px;
+  border: 1px solid color-mix(in oklch, var(--danger) 42%, transparent);
+  background: color-mix(in oklch, var(--danger) 12%, transparent);
+  color: var(--danger);
+  font-family: var(--font-body);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.danger-action-button:hover {
+  background: color-mix(in oklch, var(--danger) 20%, transparent);
+  border-color: var(--danger);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .confirm-close-overlay,
+  .confirm-close-dialog {
+    animation: none;
+    will-change: auto;
+  }
+}


### PR DESCRIPTION
## Summary

- 文档存在未保存修改时，关闭标签、关闭窗口或退出应用（Cmd+Q / 红绿灯 / 窗口 X）前弹出三选项确认框（**保存 / 不保存 / 取消**）；已保存则直接关闭不打扰。
- 退出应用时若多个标签 dirty，逐个确认，中途取消任一即终止退出。
- 原有原生 `window.confirm` 的单标签关闭确认一并升级为该三选项对话框，补齐中 / 英 / 日三语文案。

## Why

- 关联 ISS: #68（[Feature] 关闭未保存文档或退出应用时增加保存确认）
- 触发场景: 用户改了文档后误关标签 / 误退应用 / 误按快捷键，修改内容直接丢失且无任何确认。Issue 要求三选项明确交互，且文档已保存时不打扰。

## Test Plan

```text
$ npm run typecheck
$ npm run lint
$ npm test
$ npm run build
$ cd src-tauri && cargo check && cargo test
$ npm run test:e2e -- <相关 spec>
```

实际结果（贴汇总行）:

- `npm run typecheck`: ✅ 通过（无输出）
- `npm run lint`（改动文件）: ✅ 0 errors（`app.css` 被 eslint 忽略属正常）
- `npm test`: ✅ `Test Files 57 passed (57) / Tests 512 passed (512)`
- `npm run build`: ✅ `built in 719ms`（仅有既有 `INEFFECTIVE_DYNAMIC_IMPORT` 警告，与本次无关）
- `cargo check` + `cargo test`: ✅ `34 passed; 0 failed`
- `npm run test:e2e`: ⚠️ **未跑**。本次未新增 E2E 用例；关窗拦截的核心时序涉及 Tauri IPC（prevent_close → emit → 前端确认 → confirm_close → destroy），浏览器版 Playwright 无法覆盖。
- 桌面端真机（`npm run etv:dev` + `etv:run`）: ⚠️ **未跑**。按 CONTRIBUTING §4 要求，涉及 Tauri IPC 应跑 etv 真实 WebView 断言，但本次实现阶段未执行，需 reviewer / 作者本地补测。

涉及 UI 时附 `npm run tauri dev` 本地手测结论: ⚠️ **未手测**。需补充验证的场景见下方 Risk 节。

## Risk & Rollback

- **触及的禁用项 / 决策**:
  - 重申并遵守 CONTRIBUTING §5 的「不要用 `prevent_close + hide` 模式让用户关不掉窗口」——本实现是 `prevent_close` 后由前端确认，用户选「不保存/取消」即可放行/取消，未做 hide-to-Dock。
  - 沿用 ISS-174 review 教训（见 `useSession.ts:48-53`）：**不复用前端 `onCloseRequested`**（macOS Tauri 2.11.0 误拦截），关窗拦截只走 Rust `prevent_close` + 事件。
- **主要风险点**:
  1. **tear-off 窗口 tab 回收时序**：tab 回收从原 `CloseRequested` 迁移到 `finalize_window_close`（在 `destroy()` 前调用）。逻辑上 `window:closed` 事件应在 destroy 前 emit，但主窗口能否稳定收到需真机确认。
  2. **关窗完整时序** `prevent_close → emit → 弹框 → 用户点按钮 → invoke confirm_close → destroy` 未做端到端真机验证。
  3. **`closeTab` 改 async** 后返回 Promise，三处调用点已用 `void` 处理；reducer 的 `confirmed` 双保险未变。
- **回滚方法**: `git revert <commit>`。改动集中在关闭/退出路径，不影响正常编辑、保存、打开文件流程；回滚后恢复为「关窗无确认 + 单标签原生 confirm」。

### 需 reviewer / 作者本地补测的场景
1. 改文档未保存 → Cmd+W / 点 X / 右键关闭 → 三选项各自行为
2. 改文档未保存 → Cmd+Q / 红绿灯 / 窗口 X → 保存退出 / 不保存退出 / 取消三路径
3. 多个 dirty 标签 → Cmd+Q → 逐个弹框，中途取消不退出
4. 文档已保存 → 所有关闭直接进行不弹框
5. **tear-off 窗口 dirty 时关闭 → tab 回收正常**（重点）
6. docx 文件选「保存」→ 跳过写盘直接关闭

## Checklist

- [x] 已读 `CONTRIBUTING.md` §3 / §5
- [x] `docs/TASKS.md` 中对应任务已勾选或已更新（后续 issue：批量关闭、切换文档确认已记入待处理区）
- [x] `docs/DECISIONS.md` 已记录本次工作摘要（DEC-130；注：docs/ 在 .gitignore 中，为本地文档）
- [x] 涉及用户可见变更时 `CHANGELOG.md` 已更新
- [x] 涉及 UI 时已对照 `docs/DESIGN.md`（复用既有弹层 design tokens：`--overlay-bg` / `--surface` / `--accent` / `--danger` / `--shadow-soft`，z-index 2200）
- [x] 未引入新依赖

## 范围说明

Issue #68 列出 4 个场景，本 PR 覆盖前 3 个核心场景（单标签关闭、关窗/退出、tear-off 窗口）；「批量关闭」「切换文档替换编辑内容」作为后续 issue（已记入 TASKS.md）。