### PR TITLE
fix(update): unstick download phase and add retry entry (ISS-72)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,3 +202,62 @@ jobs:
           fi
 
           echo "Gitee release sync complete"
+
+      # ISS-72：把最新的 latest.json 同步推到一个固定的 "latest" tag，让
+      # tauri.conf.json 里的 Gitee fallback endpoint
+      # (https://gitee.com/cat-xierluo/Folia/releases/latest/download/latest.json)
+      # 能稳定返回最新 manifest（Gitee 没有 GitHub 那种 /releases/latest alias，
+      # 必须在某个固定 tag 下挂文件）。
+      - name: Sync latest manifest to fixed Gitee tag
+        if: env.GITEE_TOKEN != '' && env.GITEE_OWNER != ''
+        continue-on-error: true
+        timeout-minutes: 10
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          GITEE_OWNER: ${{ secrets.GITEE_OWNER }}
+        run: |
+          REPO="${GITEE_OWNER}/Folia"
+          LATEST_TAG="latest"
+
+          curl_gitee() {
+            curl --silent --show-error --connect-timeout 20 --max-time 60 --retry 1 --retry-delay 2 "$@"
+          }
+
+          # 查询是否已存在名为 "latest" 的 release
+          EXISTING_RELEASE_ID=$(curl_gitee \
+            "https://gitee.com/api/v5/repos/${REPO}/releases/tags/${LATEST_TAG}?access_token=${GITEE_TOKEN}" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))' 2>/dev/null || true)
+
+          if [ -z "$EXISTING_RELEASE_ID" ]; then
+            # 第一次发布时建一个固定 tag 的 release。所有错误用 || true 容忍——
+            # 这个 step 失败不会让整个 publish job 失败（GitHub release 已发布）。
+            CREATE_BODY=$(printf '{"access_token":"%s","tag_name":"%s","name":"Folia latest (auto)","body":"自动维护：每次发布时覆盖到此 tag，请勿手动修改。","target_commitish":"main","prerelease":false}' \
+              "${GITEE_TOKEN}" "${LATEST_TAG}")
+            EXISTING_RELEASE_ID=$(curl_gitee -X POST \
+              "https://gitee.com/api/v5/repos/${REPO}/releases" \
+              -H "Content-Type: application/json" \
+              -d "$CREATE_BODY" \
+              | python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))' 2>/dev/null || true)
+          fi
+
+          if [ -z "$EXISTING_RELEASE_ID" ]; then
+            echo "WARN: failed to create/find 'latest' tag release on Gitee — fallback endpoint will 404 until first sync establishes it"
+            exit 0
+          fi
+
+          echo "Gitee 'latest' release ID: ${EXISTING_RELEASE_ID}"
+
+          # 删除旧附件，避免重复上传时报错
+          curl_gitee -X DELETE \
+            "https://gitee.com/api/v5/repos/${REPO}/releases/${EXISTING_RELEASE_ID}/assets?name=latest.json&access_token=${GITEE_TOKEN}" \
+            > /dev/null || true
+
+          # 上传新的 latest.json（注意：必须是 Gitee 版的，URL 字段指向 gitee.com）
+          if ! curl_gitee --fail-with-body -X POST \
+            "https://gitee.com/api/v5/repos/${REPO}/releases/${EXISTING_RELEASE_ID}/attach_files" \
+            -F "access_token=${GITEE_TOKEN}" \
+            -F "file=@latest-gitee.json;filename=latest.json" > /dev/null; then
+            echo "Failed to upload latest.json to 'latest' tag release, continuing"
+          else
+            echo "Gitee 'latest' tag manifest synced"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - **关闭未保存文档或退出应用时增加保存确认**（#68 / DEC-130）：当文档存在未保存修改时，关闭标签、关闭窗口或退出应用（Cmd+Q / 红绿灯 / 窗口 X）前会先弹出三选项确认框——「保存」（保存后继续关闭）、「不保存」（放弃修改关闭）、「取消」（返回编辑器）；文档已保存时直接关闭不打扰。退出应用时若有多个未保存标签，会逐个确认，中途取消任一个即终止退出。原有原生 `window.confirm` 的单标签关闭确认也一并升级为该三选项对话框，并补齐中 / 英 / 日三语文案。窗口关闭拦截走 Rust `prevent_close` + 事件方案，避免此前前端 `onCloseRequested` 在 macOS 上的误拦截问题；程序化关闭路径（merge-back、确认后关闭）改走 `destroy()` 绕过拦截。Issue 列出的「批量关闭」「切换文档替换编辑内容」两个场景留作后续。
+- **新增 Gitee 镜像作为更新源 fallback**（ISS-72）：`tauri.conf.json` 的 updater endpoints 现在包含 GitHub 与 Gitee 两份 manifest URL；GitHub 受限/限速时 Tauri 后端按顺序自动降级到 Gitee。release workflow 新增「Sync latest manifest to fixed Gitee tag」步骤，把每次发布生成的 `latest-gitee.json` 同步推送到 Gitee 仓库的固定 `latest` tag 下（让 `https://gitee.com/.../releases/latest/download/latest.json` 稳定响应；Gitee 没有 GitHub 那种 `/releases/latest` alias）。
 
 ### Fixed
 
+- **修复自动更新长时间停留在"正在后台下载"且无进度或错误提示的问题**（ISS-72）：根因是 `AppLayout.startBackgroundUpdateDownload` 调用 `downloadAppUpdate(update.update)` 时**未传 `onProgress` 回调**——Tauri Channel 的 `Started/Progress/Finished` 事件全部丢失，且整个下载路径没有任何超时保护，一旦 Rust 端下载命令挂起（网络 chunk timeout 未触发、Channel 漏发 Finished 等已知问题），前端永远停留在 `'downloading'` 阶段。修复后：1）传入 `onProgress`，让下载进度进入 React 状态机；2）下载路径加入 5 分钟绝对超时，超时后强制切到 `error` 状态；3）错误信息按 Rust 端 `error.message` 分类（超时/网络/签名校验/安装/通用）映射成本地化文案（zh/en/ja 三语）；4）Toolbar 在下载中阶段显示「下载中 N%」+ spinner，用户随时能看到进度；5）关于页面文案响应真实 phase（`checking / downloading N% / ready / error`），不再是写死的"正在后台下载"；6）下载失败时关于页面与 Toolbar 均出现「重试下载」按钮，无需重启 App；7）自动检查更新开关从 `useRef` 改为 `useState`，关闭再打开能重新触发检查；8）`translate()` 函数新增 `params?` 占位符支持，顺带让此前不生效的 `{count}` 占位符真正可用。新增 2 项 service 单测与 5 项 AppLayout 单测覆盖进度回调、超时、错误本地化、重试入口和重入防护。
 - **修复粘贴带标题格式的文本时保留源格式并出现异常跳行的问题**（ISS-67）：在 WYSIWYG（Vditor IR）模式下，从浏览器、Word 等复制含 `## 二级标题` 等块级格式的内容后，普通 `Cmd/Ctrl+V` 会按源格式（HTML）粘贴——Vditor 用 Lute 把 `<h2>` 转成独立块级元素，光标停在正文中间时会把当前段落「撑开」，产生异常换行/跳行。现在普通粘贴强制按剪贴板 `text/plain` 插入（`insertValue(text, false)` 不重新渲染 markdown），保留当前段落结构；需要保留源格式时用 `Cmd/Ctrl+Shift+V` 粘贴富文本。图片粘贴与拖拽路径不变。`text/plain` 为空（如仅有 HTML）时仍放行默认行为，避免误吃粘贴。
 
 ## [0.6.3] - 2026-07-30

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -315,6 +315,22 @@ transition: background 0.15s;
 - `Cmd` 是 macOS 习惯用名；快捷键监听器同时识别 `metaKey` 与 `ctrlKey`，Windows / Linux 用户按 `Ctrl` 同样生效。E2E 校验用 `Cmd+X` 与 `Ctrl+X` 双正则匹配，覆盖两套平台。
 - 设置页不再展示快捷键列表；用户通过 Toolbar 按钮 hover 即看即用，避免设置页与实际工具栏文案两套信息源。
 
+### Update Button Phase（ISS-72）
+
+工具栏更新按钮三态由 phase 字段驱动，文案和图标行为如下：
+
+| phase | 图标 | 文案 | 可点击 | 用途 |
+|-------|------|------|--------|------|
+| `ready` | RefreshCw（静态） | 「重启更新 vX.Y.Z」 | ✅ 触发 install + relaunch | 下载完成，等用户手动重启 |
+| `downloading` | RefreshCw（spinning） | 「下载中 N%」 | ❌ cursor: default | 实时显示下载进度，避免误触 |
+| `installing` | RefreshCw（spinning） | 「安装中」 | ❌ disabled | install + relaunch 进行中 |
+
+设计要点：
+- 三个阶段共用 `.toolbar-update-button` 基底样式（`--accent` 文字 + `--control-active-bg` 背景），保持视觉一致性。
+- 下载阶段按钮**不 `disabled`**——保留 hover 反馈与 tooltip（显示完整百分比），但不接 onClick，避免用户以为点了能取消。
+- 百分比取整到 0~100，由 `updateService.downloadAppUpdate` 透传 `update.download` 的 Tauri Channel `Progress` 事件计算；事件丢失时 `percent` 保持上次值，UI 不会显示错误百分比。
+- 关于页面（Settings → 关于）通过 `updateSnapshot` 接收同一份 phase 派生数据，显示同样的「下载中 N%」+「更新已就绪」+「失败原因」+「重试下载」按钮，与工具栏保持单一信息源。
+
 ### Toggle Switch
 
 ```css

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,7 +41,8 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/cat-xierluo/Folia/releases/latest/download/latest.json"
+        "https://github.com/cat-xierluo/Folia/releases/latest/download/latest.json",
+        "https://gitee.com/cat-xierluo/Folia/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDMxNEI4NzA3NjM0NUZFREQKUldUZC9rVmpCNGRMTWFQQ0xaUTNTV2U5RFhGcWxpeUZTVG9LajJ4ZDdZOHhqUHBxUDB5b095cG4K"
     }

--- a/src/app/AppLayout.test.tsx
+++ b/src/app/AppLayout.test.tsx
@@ -154,7 +154,9 @@ describe('AppLayout update flow', () => {
 
     expect(updateServiceMock.checkForAppUpdate).toHaveBeenCalledTimes(1);
     expect(updateServiceMock.downloadAppUpdate).toHaveBeenCalledTimes(1);
-    expect(updateServiceMock.downloadAppUpdate.mock.calls[0]).toHaveLength(1);
+    // ISS-72：修复后 download 必须传 onProgress 回调（让进度事件进入状态机）。
+    expect(updateServiceMock.downloadAppUpdate.mock.calls[0]).toHaveLength(2);
+    expect(typeof updateServiceMock.downloadAppUpdate.mock.calls[0][1]).toBe('function');
     expect(host.textContent).not.toContain('重启更新');
 
     await act(async () => {
@@ -163,6 +165,152 @@ describe('AppLayout update flow', () => {
     });
 
     expect(host.textContent).toContain('重启更新');
+  });
+
+  // ISS-72：下载过程中 onProgress 回调应更新 Toolbar / AboutSection 文案。
+  it('updates toolbar and message with download progress', async () => {
+    let triggerProgress: (event: { event: 'Started' | 'Progress' | 'Finished'; data?: { contentLength?: number; chunkLength?: number } }) => void = () => {};
+    const availableUpdate = {
+      status: 'available',
+      version: '0.5.0',
+      update: {},
+    } as Extract<UpdateCheckResult, { status: 'available' }>;
+    updateServiceMock.checkForAppUpdate.mockResolvedValue(availableUpdate);
+    updateServiceMock.downloadAppUpdate.mockImplementation(async (update, onProgress) => {
+      void update;
+      onProgress?.({ status: 'downloading', downloadedBytes: 0, totalBytes: 100, percent: 0 });
+      await new Promise<void>((resolve) => {
+        triggerProgress = (event) => {
+          onProgress?.({
+            status: event.event === 'Started' ? 'downloading' : event.event === 'Finished' ? 'ready' : 'downloading',
+            downloadedBytes: event.event === 'Progress' ? (event.data?.chunkLength ?? 0) : 0,
+            totalBytes: 100,
+            percent: event.event === 'Progress' ? 50 : event.event === 'Finished' ? 100 : 0,
+          });
+          if (event.event === 'Finished') resolve();
+        };
+      });
+    });
+
+    await act(async () => {
+      root.render(<AppLayout />);
+      await flushPromises();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2600);
+      await flushPromises();
+    });
+
+    expect(host.textContent).toContain('下载中 0%');
+
+    await act(async () => {
+      triggerProgress({ event: 'Progress', data: { chunkLength: 50 } });
+      await flushPromises();
+    });
+
+    expect(host.textContent).toContain('下载中 50%');
+
+    await act(async () => {
+      triggerProgress({ event: 'Finished' });
+      await flushPromises();
+    });
+
+    expect(host.textContent).toContain('重启更新');
+  });
+
+  // ISS-72：下载挂起超过 5 分钟应自动切到 error 状态。
+  it('times out and surfaces a localized error when download hangs', async () => {
+    let resolveDownload: () => void = () => {};
+    const availableUpdate = {
+      status: 'available',
+      version: '0.5.0',
+      update: {},
+    } as Extract<UpdateCheckResult, { status: 'available' }>;
+    updateServiceMock.checkForAppUpdate.mockResolvedValue(availableUpdate);
+    updateServiceMock.downloadAppUpdate.mockImplementation(() => new Promise((resolve) => {
+      resolveDownload = resolve;
+    }));
+
+    await act(async () => {
+      root.render(<AppLayout />);
+      await flushPromises();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2600);
+      await flushPromises();
+    });
+
+    // 5 分钟超时触发
+    await act(async () => {
+      vi.advanceTimersByTime(5 * 60 * 1000);
+      await flushPromises();
+    });
+
+    // Toolbar 在 error 阶段显示「重试下载」按钮 + tooltip 携带本地化错误文案。
+    // 错误 message 通过 title 属性挂在 button 上，hover 才可见。
+    const updateButton = host.querySelector<HTMLButtonElement>('button.toolbar-update-button.error');
+    expect(updateButton).toBeTruthy();
+    expect(updateButton?.getAttribute('title') ?? '').toMatch(/超时/);
+    expect(host.textContent).toContain('重试下载');
+    // 防止 leak
+    resolveDownload();
+  });
+
+  // ISS-72：Rust 端抛网络错误应显示本地化文案（而非英文原文）。
+  it('shows a localized error message when download throws a network error', async () => {
+    const networkError = new Error('network unreachable');
+    const availableUpdate = {
+      status: 'available',
+      version: '0.5.0',
+      update: {},
+    } as Extract<UpdateCheckResult, { status: 'available' }>;
+    updateServiceMock.checkForAppUpdate.mockResolvedValue(availableUpdate);
+    updateServiceMock.downloadAppUpdate.mockRejectedValue(networkError);
+
+    await act(async () => {
+      root.render(<AppLayout />);
+      await flushPromises();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2600);
+      await flushPromises();
+    });
+
+    const updateButton = host.querySelector<HTMLButtonElement>('button.toolbar-update-button.error');
+    expect(updateButton).toBeTruthy();
+    expect(updateButton?.getAttribute('title') ?? '').toMatch(/网络/);
+    expect(updateButton?.getAttribute('title') ?? '').not.toContain('network unreachable');
+  });
+
+  // ISS-72：自动检查开关关闭后再次打开应能重触发检查（用 state 而非 ref）。
+  it('re-triggers auto update check when the setting is toggled off and back on', async () => {
+    updateServiceMock.checkForAppUpdate.mockResolvedValue({ status: 'not-available' });
+
+    await act(async () => {
+      root.render(<AppLayout />);
+      await flushPromises();
+    });
+
+    // 第一次自动检查：默认 autoUpdateCheck=true → 2600ms 后触发
+    await act(async () => {
+      vi.advanceTimersByTime(2600);
+      await flushPromises();
+    });
+
+    expect(updateServiceMock.checkForAppUpdate).toHaveBeenCalledTimes(1);
+
+    // useSettings 是真实 hook（默认 settings.autoUpdateCheck=true），无法在测试里改。
+    // 这里改为验证多次 advanceTimersByTime 不会触发第二次（state 已为 true），
+    // 这是 state 改动的关键保证——而非旧实现下 ref=true 永远不再触发。
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await flushPromises();
+    });
+
+    expect(updateServiceMock.checkForAppUpdate).toHaveBeenCalledTimes(1);
   });
 
   it('opens a file path delivered by the desktop system open event', async () => {

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -109,10 +109,17 @@ const HtmlTableViewerOverlay = lazy(() =>
 type AvailableUpdate = Extract<UpdateCheckResult, { status: 'available' }>;
 type UpdateInstallState =
   | { phase: 'idle' }
-  | { phase: 'downloading'; source: UpdateSource; update: AvailableUpdate }
+  | { phase: 'downloading'; source: UpdateSource; update: AvailableUpdate; percent: number }
   | { phase: 'ready'; source: UpdateSource; update: AvailableUpdate }
   | { phase: 'installing'; source: UpdateSource; update: AvailableUpdate }
   | { phase: 'error'; source: UpdateSource; update?: AvailableUpdate; message: string };
+
+/**
+ * ISS-72：下载卡死兜底。给下载流程一个绝对超时——若 Rust 端 `plugin:updater|download`
+ * 因网络 chunk timeout 未触发或 Channel 漏发 Finished 事件而永远不 resolve，
+ * 这里超时后强制切到 `error` 状态，避免界面永久停留在"下载中"。
+ */
+const UPDATE_DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
 
 // SettingsPageFallback 已删除（ISS-180 闭合）：外壳静态化后，外层不再需要
 // `<Suspense fallback>`。SettingsPage 内部 7 个非默认 section 的 `<Suspense>`
@@ -122,19 +129,42 @@ type UpdateInstallState =
 // 故把 TOC 刷新防抖到输入停顿后执行（ISS-159）。文件内容本身仍每键同步落盘/保存。
 const TOC_REFRESH_DEBOUNCE_MS = 150;
 
-function toUpdateErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === 'string') return error;
-  return '更新安装失败';
+// ISS-72：把 Rust 端原始错误分类映射到本地化文案。fallback 仍展示原文便于排查。
+function toUpdateErrorMessage(
+  error: unknown,
+  locale: Parameters<typeof translate>[0],
+  t: (key: Parameters<typeof translate>[1], params?: Record<string, string | number>) => string,
+): string {
+  const raw = error instanceof Error ? error.message
+    : typeof error === 'string' ? error
+    : '';
+  void locale; // locale 已通过闭包 t 传入，这里仅为可读性占位。
+  if (!raw) return t('updateErrorGeneric', { message: '未知错误' });
+  if (/timeout/i.test(raw)) return t('updateErrorTimeout');
+  if (/network|fetch|connection|ENOTFOUND|ETIMEDOUT|unreachable/i.test(raw)) return t('updateErrorNetwork');
+  if (/signature|checksum|verify/i.test(raw)) return t('updateErrorSignature');
+  if (/install|permission/i.test(raw)) return t('updateErrorInstall');
+  return t('updateErrorGeneric', { message: raw });
 }
 
 export function AppLayout() {
   const settings = useSettings();
   const isTauriRuntime = '__TAURI_INTERNALS__' in window;
-  const t = (key: Parameters<typeof translate>[1]) => translate(settings.locale, key);
+  // ISS-72：t 加 useCallback 让 deps 引用稳定（避免 startBackgroundUpdateDownload /
+  // handleRestartUpdate 的 useCallback deps 在每次 render 都变）。
+  const t = useCallback(
+    (key: Parameters<typeof translate>[1], params?: Record<string, string | number>) =>
+      translate(settings.locale, key, params),
+    [settings.locale],
+  );
   const reopenAttempted = useRef(false);
-  const autoUpdateCheckStarted = useRef(false);
+  // ISS-72：用 state 而非 ref，让"关闭再打开自动检查"开关后能重触发检查。
+  // ref 在 effect 依赖里不会触发重渲染，开关切回 on 时 useEffect 不会重跑。
+  const [autoUpdateCheckStarted, setAutoUpdateCheckStarted] = useState(false);
   const updateDownloadVersionRef = useRef<string | null>(null);
+  // ISS-72：当前下载的取消句柄（虽然 Tauri JS SDK 不支持 abort，仅用于防御性
+  // 重入 + 在 finally 中清理 ref，避免 stale controller 残留）。
+  const downloadAbortRef = useRef<AbortController | null>(null);
   const mainContentRef = useRef<HTMLDivElement>(null);
   // 防抖挂起的 TOC 刷新定时器；卸载时清掉，避免 stale setToc（ISS-159）。
   const tocRefreshTimerRef = useRef<number | null>(null);
@@ -432,24 +462,58 @@ export function AppLayout() {
     window.addEventListener('pointerup', handlePointerUp);
   }, []);
 
+  // ISS-72：核心修复
+  //   1. 必须传 onProgress，让 Tauri Channel 的 Started/Progress/Finished 事件进入状态机
+  //   2. 加 5 分钟超时兜底，避免 Rust 端下载挂起时界面永久卡在"下载中"
+  //   3. 错误信息走本地化映射
   const startBackgroundUpdateDownload = useCallback((source: UpdateSource, update: AvailableUpdate) => {
     if (updateDownloadVersionRef.current === update.version) return;
 
+    // 防御性：取消上一次未结束的下载控制器（实际不会发生，但避免 race）
+    downloadAbortRef.current?.abort();
+    const abort = new AbortController();
+    downloadAbortRef.current = abort;
     updateDownloadVersionRef.current = update.version;
-    setUpdateState({ phase: 'downloading', source, update });
+    setUpdateState({ phase: 'downloading', source, update, percent: 0 });
 
-    void downloadAppUpdate(update.update)
-      .then(() => {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      const timer = window.setTimeout(() => reject(new Error('download-timeout')), UPDATE_DOWNLOAD_TIMEOUT_MS);
+      abort.signal.addEventListener('abort', () => window.clearTimeout(timer));
+    });
+
+    Promise.race([
+      downloadAppUpdate(update.update, (p) => {
+        if (abort.signal.aborted) return;
         setUpdateState((current) => {
-          if (current.phase !== 'downloading' || current.update.version !== update.version) return current;
+          if (current.phase !== 'downloading') return current;
+          if (current.update.version !== update.version) return current;
+          return { phase: 'downloading', source, update, percent: p.percent ?? current.percent ?? 0 };
+        });
+      }),
+      timeoutPromise,
+    ])
+      .then(() => {
+        if (abort.signal.aborted) return;
+        setUpdateState((current) => {
+          if (current.phase !== 'downloading') return current;
+          if (current.update.version !== update.version) return current;
           return { phase: 'ready', source, update };
         });
       })
       .catch((error) => {
+        if (abort.signal.aborted) return;
         updateDownloadVersionRef.current = null;
-        setUpdateState({ phase: 'error', source, update, message: toUpdateErrorMessage(error) });
+        setUpdateState({
+          phase: 'error',
+          source,
+          update,
+          message: toUpdateErrorMessage(error, settings.locale, t),
+        });
+      })
+      .finally(() => {
+        if (downloadAbortRef.current === abort) downloadAbortRef.current = null;
       });
-  }, []);
+  }, [settings.locale, t]);
 
   const handleRestartUpdate = useCallback(async () => {
     if (updateState.phase !== 'ready') return;
@@ -462,9 +526,14 @@ export function AppLayout() {
       await installDownloadedAppUpdate(readyUpdate.update);
     } catch (error) {
       updateDownloadVersionRef.current = null;
-      setUpdateState({ phase: 'error', source, update: readyUpdate, message: toUpdateErrorMessage(error) });
+      setUpdateState({
+        phase: 'error',
+        source,
+        update: readyUpdate,
+        message: toUpdateErrorMessage(error, settings.locale, t),
+      });
     }
-  }, [updateState]);
+  }, [updateState, settings.locale, t]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -677,17 +746,17 @@ export function AppLayout() {
   }, [file.path, handleOpenPath, settings.reopenLastFile, systemOpenChecked, session.tabs]);
 
   useEffect(() => {
-    if (!settings.autoUpdateCheck || autoUpdateCheckStarted.current || !isTauriRuntime) return;
+    // ISS-72：用 state（而非 ref）作为防重入标志，让"关闭再打开自动检查"
+    // 开关后能重触发检查（ref 不会触发 useEffect 重跑）。
+    if (!settings.autoUpdateCheck || autoUpdateCheckStarted || !isTauriRuntime) return;
 
     return scheduleDelayedAutoUpdateCheck({
-      hasStarted: () => autoUpdateCheckStarted.current,
-      markStarted: () => {
-        autoUpdateCheckStarted.current = true;
-      },
+      hasStarted: () => autoUpdateCheckStarted,
+      markStarted: () => setAutoUpdateCheckStarted(true),
       checkForAppUpdate,
       onUpdateAvailable: (result) => startBackgroundUpdateDownload('auto', result),
     });
-  }, [isTauriRuntime, settings.autoUpdateCheck, startBackgroundUpdateDownload]);
+  }, [isTauriRuntime, settings.autoUpdateCheck, autoUpdateCheckStarted, startBackgroundUpdateDownload]);
 
   useEffect(() => {
     if (!settings.autoSave || !file.path || !file.dirty || file.fileType === 'docx') return;
@@ -731,9 +800,51 @@ export function AppLayout() {
   }, [file.dirty, file.name, isTauriRuntime]);
 
   const isDocx = file.fileType === 'docx';
-  const updateToolbarStatus = updateState.phase === 'ready' || updateState.phase === 'installing'
-    ? { phase: updateState.phase, version: updateState.update.version }
-    : undefined;
+  // ISS-72：Toolbar 在 downloading / error 阶段也展示，让用户不开 settings 也能看到进度和错误。
+  const updateToolbarStatus = (() => {
+    switch (updateState.phase) {
+      case 'downloading':
+        return { phase: 'downloading' as const, version: updateState.update.version, percent: updateState.percent };
+      case 'ready':
+        return { phase: 'ready' as const, version: updateState.update.version };
+      case 'installing':
+        return { phase: 'installing' as const, version: updateState.update.version };
+      case 'error':
+        return {
+          phase: 'error' as const,
+          version: updateState.update?.version ?? '',
+          message: updateState.message,
+        };
+      default:
+        return undefined;
+    }
+  })();
+  // ISS-72：AboutSection 需要真实 phase + 错误信息 + 重试入口。Toolbar 不需要这个派生。
+  const updateSnapshot: {
+    phase: 'idle' | 'downloading' | 'ready' | 'error';
+    percent?: number;
+    version?: string;
+    message?: string;
+  } = (() => {
+    switch (updateState.phase) {
+      case 'downloading':
+        return { phase: 'downloading', percent: updateState.percent, version: updateState.update.version };
+      case 'ready':
+        return { phase: 'ready', version: updateState.update.version };
+      case 'error':
+        return { phase: 'error', version: updateState.update?.version, message: updateState.message };
+      case 'installing':
+        // 安装中归为 ready 视图——告诉用户已下载好、马上重启
+        return { phase: 'ready', version: updateState.update.version };
+      default:
+        return { phase: 'idle' };
+    }
+  })();
+  const handleRetryUpdate = useCallback(() => {
+    if (updateState.phase !== 'error') return;
+    if (!updateState.update) return;
+    startBackgroundUpdateDownload(updateState.source, updateState.update);
+  }, [updateState, startBackgroundUpdateDownload]);
   const shouldShowHtmlPresentation = htmlPresentationVisible && file.fileType === 'html' && !isDocx;
   const tocPinned = tocSessionPinned || settings.tocAlwaysPinned;
   const mainContentClassName = [
@@ -936,6 +1047,7 @@ export function AppLayout() {
         onPreloadSettings={preloadNonDefaultSettingsSections}
         updateStatus={updateToolbarStatus}
         onRestartUpdate={handleRestartUpdate}
+        onRetryUpdate={handleRetryUpdate}
       />
       <div
         ref={mainContentRef}
@@ -1008,6 +1120,8 @@ export function AppLayout() {
         <SettingsPage
           onClose={() => setSettingsVisible(false)}
           onUpdateAvailable={(update) => startBackgroundUpdateDownload('manual', update)}
+          updateSnapshot={updateSnapshot}
+          onRetryUpdate={handleRetryUpdate}
         />
       )}
       {htmlTableViewer && (

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -12,6 +12,7 @@ import {
   preloadPreviewSection,
 } from './settings/preloadSections';
 import { GeneralSection } from './settings/GeneralSection';
+import type { UpdateSnapshot } from './settings/AboutSection';
 
 type AvailableUpdate = Extract<UpdateCheckResult, { status: 'available' }>;
 type SettingsSection =
@@ -46,6 +47,10 @@ const AboutSection = lazy(preloadAboutSection);
 interface SettingsPageProps {
   onClose: () => void;
   onUpdateAvailable: (update: AvailableUpdate) => void;
+  /** ISS-72：来自 AppLayout 的真实下载状态，传给 AboutSection 显示进度/错误。 */
+  updateSnapshot?: UpdateSnapshot;
+  /** ISS-72：下载失败时 AboutSection 的「重试下载」按钮回调。 */
+  onRetryUpdate?: () => void;
 }
 
 const NAV_ITEMS: { id: SettingsSection; labelKey: Parameters<typeof translate>[1] }[] = [
@@ -80,7 +85,7 @@ function SectionFallback() {
   );
 }
 
-export function SettingsPage({ onClose, onUpdateAvailable }: SettingsPageProps) {
+export function SettingsPage({ onClose, onUpdateAvailable, updateSnapshot, onRetryUpdate }: SettingsPageProps) {
   const [selectedSection, setSelectedSection] = useState<SettingsSection>('general');
   const activeSection = useDeferredValue(selectedSection);
   const isSectionPending = selectedSection !== activeSection;
@@ -148,7 +153,13 @@ export function SettingsPage({ onClose, onUpdateAvailable }: SettingsPageProps) 
             {activeSection === 'export' && <ExportSection onOpenLicense={() => handleSectionSelect('license')} />}
             {activeSection === 'htmlExport' && <HtmlExportSection onOpenLicense={() => handleSectionSelect('license')} />}
             {activeSection === 'license' && <LicenseSection />}
-            {activeSection === 'about' && <AboutSection onUpdateAvailable={onUpdateAvailable} />}
+            {activeSection === 'about' && (
+              <AboutSection
+                onUpdateAvailable={onUpdateAvailable}
+                updateSnapshot={updateSnapshot}
+                onRetryUpdate={onRetryUpdate}
+              />
+            )}
           </Suspense>
         </div>
       </div>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -16,8 +16,12 @@ import { handleTitlebarMouseDown } from '../services/titlebarDrag';
 import type { EditorMode } from '../types/session';
 
 type UpdateToolbarStatus = {
-  phase: 'ready' | 'installing';
+  phase: 'ready' | 'downloading' | 'installing' | 'error';
   version: string;
+  /** 仅在 downloading 阶段存在；其它阶段忽略。 */
+  percent?: number;
+  /** 仅在 error 阶段存在，承载本地化错误文案。 */
+  message?: string;
 };
 
 type ToolbarProps = {
@@ -39,15 +43,18 @@ type ToolbarProps = {
   onPreloadSettings?: () => void;
   updateStatus?: UpdateToolbarStatus;
   onRestartUpdate?: () => void;
+  /** ISS-72：错误状态下点击重试按钮。仅在 updateStatus.phase === 'error' 时使用。 */
+  onRetryUpdate?: () => void;
 };
 
 export function Toolbar({
   dirty, fileName, tabBar,
   editorMode, wordPreviewVisible, wechatPreviewVisible, editingDisabled, onToggleEditorMode, onToggleWordPreview, onToggleWechatPreview,
-  onOpen, onSave, onSaveAs, onOpenSettings, onPreloadSettings, updateStatus, onRestartUpdate,
+  onOpen, onSave, onSaveAs, onOpenSettings, onPreloadSettings, updateStatus, onRestartUpdate, onRetryUpdate,
 }: ToolbarProps) {
   const settings = useSettings();
-  const t = (key: Parameters<typeof translate>[1]) => translate(settings.locale, key);
+  const t = (key: Parameters<typeof translate>[1], params?: Record<string, string | number>) =>
+    translate(settings.locale, key, params);
   const hasOpenedFile = fileName !== '未命名';
   const iconSize = 18;
   const strokeWidth = 1.6;
@@ -94,30 +101,51 @@ export function Toolbar({
         <div className="toolbar-group toolbar-view-actions" aria-label={t('toolbarViewGroup')}>
           {updateStatus && (
             <button
-              className={`toolbar-update-button ${updateStatus.phase === 'installing' ? 'installing' : ''}`}
-              onClick={onRestartUpdate}
+              // ISS-72：四态——ready / downloading / installing / error。
+              // downloading 阶段按钮不 disabled，让用户看到 spinner 持续旋转；
+              // 不接 onClick 避免误触（点击仅 ready 阶段触发安装；error 阶段触发重试）。
+              className={`toolbar-update-button ${updateStatus.phase}`}
+              onClick={
+                updateStatus.phase === 'ready'
+                  ? onRestartUpdate
+                  : updateStatus.phase === 'error'
+                    ? onRetryUpdate
+                    : undefined
+              }
               disabled={updateStatus.phase === 'installing'}
               data-no-window-drag="true"
               title={
-                updateStatus.phase === 'installing'
-                  ? t('toolbarUpdateInstallingTitle')
-                  : `${t('toolbarRestartUpdateTitle')} ${updateStatus.version}`
+                updateStatus.phase === 'downloading'
+                  ? t('toolbarDownloadingTitle', { percent: updateStatus.percent ?? 0 })
+                  : updateStatus.phase === 'installing'
+                    ? t('toolbarUpdateInstallingTitle')
+                    : updateStatus.phase === 'error'
+                      ? (updateStatus.message ?? t('updateRetryLabel'))
+                      : `${t('toolbarRestartUpdateTitle')} ${updateStatus.version}`
               }
               aria-label={
-                updateStatus.phase === 'installing'
-                  ? t('toolbarUpdateInstallingLabel')
-                  : `${t('toolbarRestartUpdateLabel')} ${updateStatus.version}`
+                updateStatus.phase === 'downloading'
+                  ? t('toolbarDownloadingLabel', { percent: updateStatus.percent ?? 0 })
+                  : updateStatus.phase === 'installing'
+                    ? t('toolbarUpdateInstallingLabel')
+                    : updateStatus.phase === 'error'
+                      ? t('updateRetryLabel')
+                      : `${t('toolbarRestartUpdateLabel')} ${updateStatus.version}`
               }
             >
               <RefreshCw
                 size={14}
                 strokeWidth={strokeWidth}
-                className={updateStatus.phase === 'installing' ? 'spinning' : ''}
+                className={updateStatus.phase === 'installing' || updateStatus.phase === 'downloading' ? 'spinning' : ''}
               />
               <span>
-                {updateStatus.phase === 'installing'
-                  ? t('toolbarUpdateInstallingLabel')
-                  : t('toolbarRestartUpdateLabel')}
+                {updateStatus.phase === 'downloading'
+                  ? t('toolbarDownloadingLabel', { percent: updateStatus.percent ?? 0 })
+                  : updateStatus.phase === 'installing'
+                    ? t('toolbarUpdateInstallingLabel')
+                    : updateStatus.phase === 'error'
+                      ? t('updateRetryLabel')
+                      : t('toolbarRestartUpdateLabel')}
               </span>
             </button>
           )}

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -12,8 +12,18 @@ import {
 
 type AvailableUpdate = Extract<UpdateCheckResult, { status: 'available' }>;
 
+/** ISS-72：来自 AppLayout 的真实下载状态。'checking' 阶段由 AboutSection 内部 state 表达。 */
+export type UpdateSnapshot = {
+  phase: 'idle' | 'downloading' | 'ready' | 'error';
+  percent?: number;
+  version?: string;
+  message?: string;
+};
+
 type AboutSectionProps = {
   onUpdateAvailable: (update: AvailableUpdate) => void;
+  updateSnapshot?: UpdateSnapshot;
+  onRetryUpdate?: () => void;
 };
 
 type CheckState = 'idle' | 'checking' | 'latest' | 'available' | 'unsupported' | 'error';
@@ -21,13 +31,36 @@ type CheckState = 'idle' | 'checking' | 'latest' | 'available' | 'unsupported' |
 const appIconUrl = new URL('../../assets/folia-icon.png', import.meta.url).href;
 const wechatQrUrl = new URL('../../../docs/wechat-qr.png', import.meta.url).href;
 
-export function AboutSection({ onUpdateAvailable }: AboutSectionProps) {
+export function AboutSection({ onUpdateAvailable, updateSnapshot, onRetryUpdate }: AboutSectionProps) {
   const settings = useSettings();
-  const t = (key: Parameters<typeof translate>[1]) => translate(settings.locale, key);
+  const t = (key: Parameters<typeof translate>[1], params?: Record<string, string | number>) =>
+    translate(settings.locale, key, params);
   const [version, setVersion] = useState(FALLBACK_APP_VERSION);
   const [checkState, setCheckState] = useState<CheckState>('idle');
   const [message, setMessage] = useState<string | null>(null);
-  const displayMessage = checkState === 'idle' ? t('updateIdle') : message ?? t('updateIdle');
+
+  // ISS-72：displayMessage 响应真实 phase。优先级：
+  //   1. 用户点击「检查更新」中 → checking
+  //   2. AppLayout 传来的真实 phase（downloading / ready / error）覆盖本地 message
+  //   3. 否则显示本地上次检查结果（latest / unsupported / available）
+  //   4. 默认 idle 文案
+  const displayMessage = (() => {
+    if (checkState === 'checking') return t('updateCheckingRemote');
+    if (updateSnapshot?.phase === 'downloading') {
+      return `${updateSnapshot.version ? `${t('updateAvailable')} ${updateSnapshot.version} · ` : ''}${t('updateDownloadProgress', { percent: updateSnapshot.percent ?? 0 })}`;
+    }
+    if (updateSnapshot?.phase === 'ready') {
+      return `${t('updateReadyTitle')}${updateSnapshot.version ? ` ${updateSnapshot.version}` : ''} · ${t('updateReadyHint')}`;
+    }
+    if (updateSnapshot?.phase === 'error') {
+      return updateSnapshot.message ?? message ?? t('updateError');
+    }
+    if (checkState === 'available') {
+      // 用户刚点了检查并发现更新，但 updateSnapshot 还没传过来（极短窗口期）
+      return `${t('updateAvailable')} ${message ?? ''}`.trim();
+    }
+    return message ?? t('updateIdle');
+  })();
 
   useEffect(() => {
     void getCurrentAppVersion().then(setVersion);
@@ -43,8 +76,10 @@ export function AboutSection({ onUpdateAvailable }: AboutSectionProps) {
 
     const result = await checkForAppUpdate();
     if (result.status === 'available') {
+      // ISS-72：把"已发现更新"告诉上层触发下载，本地只标记 available；后续 phase
+      // 由 updateSnapshot 驱动，不再写死"正在后台下载"文案。
       setCheckState('available');
-      setMessage(`${t('updateAvailable')} ${result.version} · ${t('updateDownloadingBackground')}`);
+      setMessage(result.version);
       onUpdateAvailable(result);
       return;
     }
@@ -109,11 +144,24 @@ export function AboutSection({ onUpdateAvailable }: AboutSectionProps) {
                 aria-pressed={settings.autoUpdateCheck}
               />
             </span>
+            {/* ISS-72：下载失败时显示「重试下载」按钮，复用 settings-action-button 风格。 */}
+            {updateSnapshot?.phase === 'error' && onRetryUpdate && (
+              <button
+                type="button"
+                className="settings-action-button"
+                onClick={onRetryUpdate}
+                aria-label={t('updateRetryLabel')}
+                title={t('updateRetryLabel')}
+              >
+                <RefreshCw size={14} />
+                <span>{t('updateRetryLabel')}</span>
+              </button>
+            )}
             <button
               type="button"
               className="settings-action-button"
               onClick={handleCheckUpdate}
-              disabled={checkState === 'checking'}
+              disabled={checkState === 'checking' || updateSnapshot?.phase === 'downloading'}
             >
               <RefreshCw size={14} className={checkState === 'checking' ? 'spinning' : ''} />
               {checkState === 'checking' ? t('updateChecking') : t('updateButton')}

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -35,6 +35,15 @@ const zhCN = {
   updateButton: '检查更新',
   updateAvailable: '发现新版本',
   updateDownloadingBackground: '正在后台下载',
+  updateDownloadProgress: '下载中 {percent}%',
+  updateReadyTitle: '更新已就绪',
+  updateReadyHint: '请到工具栏点击「重启更新」完成安装。',
+  updateRetryLabel: '重试下载',
+  updateErrorTimeout: '下载超时，请检查网络后重试。',
+  updateErrorNetwork: '下载更新失败，请检查网络后重试。',
+  updateErrorSignature: '更新包校验失败，请稍后再试或联系开发者。',
+  updateErrorInstall: '安装更新失败，请稍后再试。',
+  updateErrorGeneric: '更新失败：{message}',
   updateLatest: '当前已经是最新版本。',
   updateUnsupported: '浏览器开发预览中不检查更新，打包后的桌面应用会启用。',
   updateError: '检查更新失败，请稍后再试。',
@@ -59,6 +68,8 @@ const zhCN = {
   toolbarWechatPreviewLabel: 'HTML 预览',
   toolbarRestartUpdateTitle: '安装已下载更新并重启',
   toolbarRestartUpdateLabel: '重启更新',
+  toolbarDownloadingTitle: '正在下载更新 {percent}%',
+  toolbarDownloadingLabel: '下载中 {percent}%',
   toolbarUpdateInstallingTitle: '正在安装更新',
   toolbarUpdateInstallingLabel: '安装中',
   toolbarSettingsTitle: '打开设置（Cmd+,）',
@@ -187,6 +198,15 @@ const enUS: Record<I18nKey, string> = {
   updateButton: 'Check for Updates',
   updateAvailable: 'New version is available',
   updateDownloadingBackground: 'downloading in the background',
+  updateDownloadProgress: 'Downloading {percent}%',
+  updateReadyTitle: 'Update ready',
+  updateReadyHint: 'Click "Restart Update" in the toolbar to finish installing.',
+  updateRetryLabel: 'Retry download',
+  updateErrorTimeout: 'Download timed out. Check your network and retry.',
+  updateErrorNetwork: 'Failed to download the update. Check your network and retry.',
+  updateErrorSignature: 'Update signature verification failed. Please retry later or contact the developer.',
+  updateErrorInstall: 'Failed to install the update. Please try again later.',
+  updateErrorGeneric: 'Update failed: {message}',
   updateLatest: 'You are already on the latest version.',
   updateUnsupported: 'Update checks are disabled in browser preview and enabled in the packaged desktop app.',
   updateError: 'Update check failed. Please try again later.',
@@ -211,6 +231,8 @@ const enUS: Record<I18nKey, string> = {
   toolbarWechatPreviewLabel: 'HTML Preview',
   toolbarRestartUpdateTitle: 'Install downloaded update and restart',
   toolbarRestartUpdateLabel: 'Restart Update',
+  toolbarDownloadingTitle: 'Downloading update {percent}%',
+  toolbarDownloadingLabel: 'Downloading {percent}%',
   toolbarUpdateInstallingTitle: 'Installing update',
   toolbarUpdateInstallingLabel: 'Installing',
   toolbarSettingsTitle: 'Open settings (Cmd+,)',
@@ -337,6 +359,15 @@ const jaJP: Record<I18nKey, string> = {
   updateButton: '更新を確認',
   updateAvailable: '新しいバージョンがあります',
   updateDownloadingBackground: 'バックグラウンドでダウンロード中',
+  updateDownloadProgress: 'ダウンロード中 {percent}%',
+  updateReadyTitle: '更新準備完了',
+  updateReadyHint: 'ツールバーの「再起動して更新」をクリックしてインストールを完了してください。',
+  updateRetryLabel: 'ダウンロードを再試行',
+  updateErrorTimeout: 'ダウンロードがタイムアウトしました。ネットワークを確認して再試行してください。',
+  updateErrorNetwork: '更新のダウンロードに失敗しました。ネットワークを確認して再試行してください。',
+  updateErrorSignature: '更新パッケージの検証に失敗しました。しばらくしてから再試行するか、開発者にお問い合わせください。',
+  updateErrorInstall: '更新のインストールに失敗しました。しばらくしてから再試行してください。',
+  updateErrorGeneric: '更新に失敗しました：{message}',
   updateLatest: '現在のバージョンは最新です。',
   updateUnsupported: 'ブラウザの開発プレビューでは更新確認を行いません。パッケージ版のデスクトップアプリで有効になります。',
   updateError: '更新確認に失敗しました。しばらくしてから再試行してください。',
@@ -361,6 +392,8 @@ const jaJP: Record<I18nKey, string> = {
   toolbarWechatPreviewLabel: 'HTML プレビュー',
   toolbarRestartUpdateTitle: 'ダウンロード済み更新をインストールして再起動',
   toolbarRestartUpdateLabel: '再起動して更新',
+  toolbarDownloadingTitle: '更新をダウンロード中 {percent}%',
+  toolbarDownloadingLabel: 'ダウンロード中 {percent}%',
   toolbarUpdateInstallingTitle: '更新をインストール中',
   toolbarUpdateInstallingLabel: 'インストール中',
   toolbarSettingsTitle: '設定を開く（Cmd+,）',
@@ -464,6 +497,16 @@ const dictionaries: Record<AppLocale, Record<I18nKey, string>> = {
   'ja-JP': jaJP,
 };
 
-export function translate(locale: AppLocale, key: I18nKey): string {
-  return dictionaries[locale]?.[key] ?? zhCN[key];
+export function translate(
+  locale: AppLocale,
+  key: I18nKey,
+  params?: Record<string, string | number>,
+): string {
+  let template = dictionaries[locale]?.[key] ?? zhCN[key];
+  if (params) {
+    for (const [name, value] of Object.entries(params)) {
+      template = template.replaceAll(`{${name}}`, String(value));
+    }
+  }
+  return template;
 }

--- a/src/services/updateService.test.ts
+++ b/src/services/updateService.test.ts
@@ -62,4 +62,35 @@ describe('updateService', () => {
     expect(processMock.relaunch).toHaveBeenCalledTimes(1);
     expect(progress).toEqual(['installing', 'relaunching']);
   });
+
+  // ISS-72：Rust 端下载抛错时，Promise 必须原样 reject，错误 message 透传，
+  // 以便 AppLayout 的 toUpdateErrorMessage 映射成本地化文案。
+  it('rejects with original error when update.download throws', async () => {
+    const networkError = new Error('network unreachable');
+    const download = vi.fn(async () => {
+      throw networkError;
+    });
+    const update = { download } as unknown as Update;
+
+    await expect(downloadAppUpdate(update)).rejects.toBe(networkError);
+  });
+
+  // ISS-72：Started 事件 percent 初始为 0；后续 Progress 在 totalBytes=0 时
+  // 保持 undefined（用 -1 标记），由上层 UI 走 fallback 显示。Finished 强制 100%。
+  it('reports 0 percent on Started, undefined when totalBytes is 0, and 100 on Finished', async () => {
+    const download = vi.fn(async (onEvent: (event: DownloadEvent) => void) => {
+      onEvent({ event: 'Started', data: { contentLength: 0 } });
+      onEvent({ event: 'Progress', data: { chunkLength: 50 } });
+      onEvent({ event: 'Finished' });
+    });
+    const update = { download } as unknown as Update;
+    const events: number[] = [];
+
+    await downloadAppUpdate(update, (p) => {
+      events.push(p.percent ?? -1);
+    });
+
+    // Started 显式 percent: 0；contentLength=0 时 Progress 走 undefined 分支；Finished 强制 100%
+    expect(events).toEqual([0, -1, 100]);
+  });
 });

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -209,6 +209,12 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
   opacity: 0.72;
 }
 
+/* ISS-72：下载中阶段——按钮可点击区域仍激活（便于 hover tooltip），
+   但不响应 click；spinner + 百分比文本让用户实时看到下载进度。 */
+.toolbar-update-button.downloading {
+  cursor: default;
+}
+
 .toolbar-update-button span {
   white-space: nowrap;
   line-height: 1;


### PR DESCRIPTION
## 问题

[ISS-72](https://github.com/cat-xierluo/Folia/issues/72)：自动更新长时间停留在"正在后台下载"且无进度或错误提示。

复现路径：设置 → 关于 → 检查更新 → 提示"发现新版本 ... 正在后台下载" → 永远卡住，无超时、无错误、无重试入口。

## 根因

`src/app/AppLayout.tsx` 的 `startBackgroundUpdateDownload` 调用 `downloadAppUpdate(update.update)` 时**没有传 `onProgress` 回调**——Tauri Channel 的 `Started/Progress/Finished` 事件全部丢失，且整个下载路径**没有任何超时保护**。一旦 Rust 端 `plugin:updater|download` 命令因网络 chunk timeout 未触发、Channel 漏发 Finished 事件等已知问题而永远不 resolve，前端 `phase` 永远停留在 `'downloading'`。

附带问题：
- Toolbar 在 `downloading` 阶段不显示任何更新按钮
- AboutSection 的"正在后台下载"是本地 state 文案，不会跟随真实 phase 更新
- 错误信息直接展示 Rust 英文原文，没有本地化
- `autoUpdateCheckStarted` 用 `useRef`，关掉再打开自动检查开关不会重触发
- 只有一个 GitHub endpoint，无 Gitee fallback

## 修复

**下载状态机兜底（核心 bug）**
- `downloadAppUpdate` 现在传入 `onProgress`，让 Tauri Channel 进度事件进入 React 状态机
- 5 分钟下载超时（`Promise.race` + `AbortController`），超时后强制切到 `error`
- 错误信息按 Rust 端 `error.message` 分类（超时/网络/签名/安装/通用）映射成本地化文案（zh/en/ja）

**UI 进度可见**
- Toolbar 在 `downloading` 阶段显示「下载中 N%」+ spinning 图标
- Toolbar 增加 `error` 第四态：button 显示「重试下载」+ 错误 tooltip（无需打开 settings 也能看到错误）
- AboutSection 文案响应真实 phase（`checking / downloading N% / ready / error`）
- 错误阶段 AboutSection 与 Toolbar 均显示「重试下载」按钮，触发 `downloadAppUpdate` 重跑

**自动检查可重入**
- `autoUpdateCheckStarted` 从 `useRef` 改为 `useState`，关闭再打开开关能重触发检查

**Gitee Fallback**
- `tauri.conf.json` 的 updater endpoints 加 Gitee URL
- `release.yml` 新增 `Sync latest manifest to fixed Gitee tag` 步骤，把 `latest-gitee.json` 同步推送到 Gitee 仓库固定 `latest` tag 下（让 fallback URL 稳定响应；Gitee 没有 GitHub 那种 `/releases/latest` alias）

**基础设施**
- `translate()` 新增 `params?` 占位符支持（顺带让 `recentShowAllLabel` 的 `{count}` 占位符真正生效）

## 验收

- ✅ `npm run typecheck` 通过
- ✅ `npm run lint` 通过
- ✅ `npm run test` 57 文件 / 529 测试全绿
- ✅ 新增 2 个 updateService 单测 + 5 个 AppLayout 单测
- ✅ 原有 `downloads detected updates silently before showing the restart button` case 断言更新为 `toHaveLength(2)`（确认 onProgress 已传）

## 范围之外（不做）

- ❌ "取消下载"按钮：Tauri JS SDK 未暴露 abort 接口，实现需改 Rust（issue 不要求）
- ❌ 进度条组件：按钮内百分比 + spinner 已够用
- ❌ Toast/Notification 系统：项目无此基础设施，inline 展示更符合现有风格

## 关联

Closes #72