### PR TITLE
fix(word): Markdown 单列表格被降级为普通段落 (ISS-77)

### DIFF
--- a/src/services/word/parser.test.ts
+++ b/src/services/word/parser.test.ts
@@ -59,4 +59,52 @@ describe('parseLines', () => {
 
     expect(children.map((child) => findDocxAttribute(child, 'left'))).toEqual([480, 480]);
   });
+
+  // ISS-77：单列 Markdown 表格此前被 `isMarkdownTableRow` 的 `length >= 2` 门
+  // 拦掉，3 行 `| 单列 |` / `| --- |` / `| 值 |` 全部降级为普通段落，管道符和
+  // 分隔线作为字符散落到 DOCX。修复后应识别为 `w:tbl`。
+  it('converts single-column markdown table to a single Word table', async () => {
+    const children = await parseLines(
+      [
+        '| 单列表头 |',
+        '| --- |',
+        '| 单列值 |',
+      ].join('\n'),
+      getPreset(DEFAULT_PRESET_ID),
+    );
+
+    expect(children.map((child) => child.rootKey)).toEqual(['w:tbl']);
+  });
+
+  it('converts user example 4-column markdown table to a single Word table', async () => {
+    const children = await parseLines(
+      [
+        '| 序号 | 整改事项 | 完成时限 | 主要成果及验收材料 |',
+        '| --- | --- | --- | --- |',
+        '| 1 | 示例事项 | 1个月内 | 示例材料 |',
+      ].join('\n'),
+      getPreset(DEFAULT_PRESET_ID),
+    );
+
+    expect(children.map((child) => child.rootKey)).toEqual(['w:tbl']);
+  });
+
+  it('preserves markdown table surrounded by paragraphs', async () => {
+    const children = await parseLines(
+      [
+        '# 标题',
+        '',
+        '正文段落。',
+        '',
+        '| 单列 |',
+        '| --- |',
+        '| 值 |',
+        '',
+        '结尾段落。',
+      ].join('\n'),
+      getPreset(DEFAULT_PRESET_ID),
+    );
+
+    expect(children.map((child) => child.rootKey)).toEqual(['w:p', 'w:p', 'w:tbl', 'w:p']);
+  });
 });

--- a/src/services/word/table-handler.test.ts
+++ b/src/services/word/table-handler.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_PRESET_ID, getPreset } from './config';
-import { createHtmlTable, createMarkdownTable, parseMarkdownTableRows } from './table-handler';
+import {
+  createHtmlTable,
+  createMarkdownTable,
+  isMarkdownSeparator,
+  isMarkdownTableRow,
+  parseMarkdownTableRows,
+} from './table-handler';
 import type { PresetConfig } from './types';
 
 describe('parseMarkdownTableRows', () => {
@@ -24,6 +30,35 @@ describe('parseMarkdownTableRows', () => {
       ['名称', '说明'],
       ['A|B', '含转义管道'],
     ]);
+  });
+});
+
+describe('isMarkdownTableRow / isMarkdownSeparator (ISS-77)', () => {
+  // 修复前：单列 Markdown 表格的 `isMarkdownTableRow` 在
+  // `splitMarkdownRow(...).length >= 2` 处直接拒绝，导致 parseMarkdownLines
+  // 把它们当成普通段落输出到 DOCX，管道符 `|` 与分隔线 `---` 变成纯文本。
+  it('detects single-column markdown table rows', () => {
+    expect(isMarkdownTableRow('| 单列表头 |')).toBe(true);
+    expect(isMarkdownTableRow('| 单列值 |')).toBe(true);
+    expect(isMarkdownTableRow('| --- |')).toBe(true);
+  });
+
+  it('detects single-column separator with alignment markers', () => {
+    expect(isMarkdownSeparator('| --- |')).toBe(true);
+    expect(isMarkdownSeparator('| :--- |')).toBe(true);
+    expect(isMarkdownSeparator('| ---: |')).toBe(true);
+    expect(isMarkdownSeparator('| :---: |')).toBe(true);
+  });
+
+  it('still rejects bare pipe and non-pipe lines', () => {
+    expect(isMarkdownTableRow('|')).toBe(false);
+    expect(isMarkdownTableRow('普通段落')).toBe(false);
+  });
+
+  it('still handles multi-column tables as before', () => {
+    expect(isMarkdownTableRow('| A | B |')).toBe(true);
+    expect(isMarkdownTableRow('| A | B | C | D |')).toBe(true);
+    expect(isMarkdownSeparator('| --- | --- |')).toBe(true);
   });
 });
 

--- a/src/services/word/table-handler.test.ts
+++ b/src/services/word/table-handler.test.ts
@@ -53,6 +53,9 @@ describe('isMarkdownTableRow / isMarkdownSeparator (ISS-77)', () => {
   it('still rejects bare pipe and non-pipe lines', () => {
     expect(isMarkdownTableRow('|')).toBe(false);
     expect(isMarkdownTableRow('普通段落')).toBe(false);
+    expect(isMarkdownSeparator('|')).toBe(false);
+    expect(isMarkdownSeparator('普通段落')).toBe(false);
+    expect(isMarkdownSeparator('| 普通 |')).toBe(false);
   });
 
   it('still handles multi-column tables as before', () => {

--- a/src/services/word/table-handler.ts
+++ b/src/services/word/table-handler.ts
@@ -22,12 +22,16 @@ type MutableRunOptions = {
 // --- Markdown table ---
 
 export function isMarkdownTableRow(line: string): boolean {
-  return line.trimStart().startsWith('|') && splitMarkdownRow(line).length >= 2;
+  // 接受 1+ 列：单列 Markdown 表格（如 `| 标题 |` / `| --- |` / `| 值 |`）也
+  // 属于合法 Markdown 表格，必须在 parser 阶段被识别为表格而不是段落。`splitMarkdownRow`
+  // 会过滤掉首尾两侧的 `|` 产生的空 cell，单列时仍保留 1 个有效 cell，因此用 `>= 1`
+  // 作为最低门槛（`|` 单字符经 shift/pop 后得到空数组，长度 0 仍然不会误判）。
+  return line.trimStart().startsWith('|') && splitMarkdownRow(line).length >= 1;
 }
 
 export function isMarkdownSeparator(line: string): boolean {
   const cells = splitMarkdownRow(line);
-  return cells.length >= 2 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
+  return cells.length >= 1 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
 }
 
 export function parseMarkdownTableRows(lines: string[]): string[][] {

--- a/src/services/word/table-handler.ts
+++ b/src/services/word/table-handler.ts
@@ -30,6 +30,8 @@ export function isMarkdownTableRow(line: string): boolean {
 }
 
 export function isMarkdownSeparator(line: string): boolean {
+  // 门槛与 isMarkdownTableRow 对齐（>= 1）：单列分隔线 `| --- |` 也是合法
+  // Markdown 表格边界，1 个 cell 满足 `^:?-{3,}:?$` 即视为分隔行。
   const cells = splitMarkdownRow(line);
   return cells.length >= 1 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
 }


### PR DESCRIPTION
## 问题

按照 [ISS-77](https://github.com/cat-xierluo/Folia/issues/77) 反馈，Word 导出 Markdown 表格时，管道符 `|`、表头分隔线 `---` 以及各行内容被拆成普通文本和段落，未生成 Word 表格对象。问题在 Folia 内置模板与用户自定义导出格式上都可复现。

## 根因

`src/services/word/table-handler.ts` 的 `isMarkdownTableRow` / `isMarkdownSeparator` 都有 `splitMarkdownRow(line).length >= 2` 这道门槛。

`splitMarkdownRow` 在两端有 `|` 时会 `shift / pop` 掉两个空 cell，所以单列 Markdown 表格：

```markdown
| 单列 |
| --- |
| 值 |
```

切完后只剩 1 个有效 cell，被门槛拦掉 → `parseMarkdownLines` 走普通段落分支 → 管道符和分隔线作为字符散落到 DOCX。

`createMarkdownTable` 本身是用 `splitMarkdownRow` 直接解析列的（不依赖 `isMarkdownTableRow`），所以一旦前两关放行，1 列、2 列、N 列都能正常出 Word 表格。

issue 文本里给出的 4 列表例子在隔离测试里其实是工作的（≥ 2 列不进门槛），所以用户实际文档里大概率**混入至少一个单列 Markdown 表格**（或类似的 splitMarkdownRow 后只剩 1 cell 的稀疏表格），截图展示的 4 列只是说明症状的最小示意。

## 修复

`src/services/word/table-handler.ts`：

```diff
 export function isMarkdownTableRow(line: string): boolean {
-  return line.trimStart().startsWith('|') && splitMarkdownRow(line).length >= 2;
+  return line.trimStart().startsWith('|') && splitMarkdownRow(line).length >= 1;
 }
 
 export function isMarkdownSeparator(line: string): boolean {
   const cells = splitMarkdownRow(line);
-  return cells.length >= 2 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
+  return cells.length >= 1 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
 }
```

`length >= 1` 的安全性：单字符 `|` 进 `splitMarkdownRow` 后是 `['', '']`，shift+pop 后长度 0，仍然不会误判。

## 验证

- `npm run test -- --run`：57 文件 / 538 用例全绿（修复前后 word 相关 40 + 新增 7 = 47 用例全绿）
- `npm run typecheck`：✅
- 新增 4 个单元用例（`table-handler.test.ts`）：单列表头 / 单列分隔线（带 `:---` / `:---:` / `---:` 对齐标记）/ 多列兼容性 / 裸 `|` 仍然拒绝
- 新增 3 个端到端用例（`parser.test.ts`）：单列表 → `w:tbl`、用户 4 列表 → `w:tbl`、表格被段落包围 → `['w:p', 'w:p', 'w:tbl', 'w:p']`

## 改动文件

```
src/services/word/parser.test.ts        | 48 ++++++++++++++++++++
src/services/word/table-handler.test.ts | 37 ++++++++++++++++++-
src/services/word/table-handler.ts      |  8 ++++--
3 files changed, 90 insertions(+), 3 deletions(-)
```

## 已知未做

- 没在 Playwright e2e 跑通真实 Tauri 内的导出形态（启动较重）；逻辑覆盖完整，可在 review 时再补 e2e
- 没在浏览器里跑通 Vditor `Md2VditorIRDOM → VditorIRDOM2Md` 完整链路（wasm Lute 在 jsdom 下加载超时）。如果 `VditorIRDOM2Md` 把 IR DOM 里的 `<table>` 还原成 HTML 表格语法，会走 `findHtmlTableBlocks` 分支，那条链路在已有测试里就有覆盖（`parser.test.ts` 头两组）