### PR TITLE
fix(statusbar): #90 底栏长路径中段省略显示 + #91 pathInvalid 复制一致性

### DIFF
--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -3,6 +3,7 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { StatusBar } from './StatusBar';
+import { formatDisplayPath } from './statusPathFormat';
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -208,5 +209,113 @@ describe('StatusBar', () => {
   it('draftPersisted=true 正常状态不显示 notice', () => {
     render({ filePath: '/tmp/a.md', draftPersisted: true });
     expect(host.querySelector('.status-notice')).toBeNull();
+  });
+
+  // ===== ISS-90：长路径中段折叠显示 =====
+
+  it('短路径原样显示，不做折叠（ISS-90）', () => {
+    render({ filePath: '/Users/demo/case.md' });
+    expect(host.querySelector('.status-path')?.textContent).toBe('/Users/demo/case.md');
+  });
+
+  it('长路径折叠中段显示，保留首尾（ISS-90）', () => {
+    const longPath = '/Users/maoking/Library/Application Support/maoscripts/folia/notes/2026-08-04.md';
+    render({ filePath: longPath });
+
+    const path = host.querySelector<HTMLSpanElement>('.status-path');
+    const shown = path?.textContent ?? '';
+    expect(shown).not.toBe(longPath);
+    expect(shown.length).toBeLessThan(longPath.length);
+    expect(shown).toContain('…');
+    // 首段（根目录 / 用户名）与尾段（文件名）保留，识别性不丢。
+    expect(shown.startsWith('/Users/maoking')).toBe(true);
+    expect(shown.endsWith('notes/2026-08-04.md')).toBe(true);
+  });
+
+  it('长路径的 title 仍展示完整路径（ISS-90）', () => {
+    const longPath = '/Users/maoking/Library/Application Support/maoscripts/folia/notes/2026-08-04.md';
+    render({ filePath: longPath });
+    expect(host.querySelector('.status-path')?.getAttribute('title')).toContain(longPath);
+  });
+
+  it('长路径被折叠后，复制写入的仍是完整路径（ISS-90）', async () => {
+    const longPath = '/Users/maoking/Library/Application Support/maoscripts/folia/notes/2026-08-04.md';
+    render({ filePath: longPath });
+
+    const btn = host.querySelector<HTMLButtonElement>('.status-copy-button');
+    await act(async () => {
+      btn!.click();
+      await flushPromises();
+    });
+
+    expect(writeTextMock).toHaveBeenCalledWith(longPath);
+  });
+
+  describe('formatDisplayPath（ISS-90）', () => {
+    it('不超长的路径原样返回', () => {
+      expect(formatDisplayPath('/Users/demo/case.md')).toBe('/Users/demo/case.md');
+    });
+
+    it('POSIX 长路径折叠中段并保留前导斜杠', () => {
+      const shown = formatDisplayPath('/Users/maoking/Library/Application Support/maoscripts/folia/notes/a.md');
+      expect(shown).toBe('/Users/maoking/…/notes/a.md');
+    });
+
+    it('Windows 长路径按反斜杠折叠', () => {
+      const shown = formatDisplayPath('C:\\Users\\maoking\\Documents\\Projects\\folia\\notes\\report.md');
+      expect(shown).toBe('C:\\Users\\…\\notes\\report.md');
+    });
+
+    it('无分隔符的超长串退化为尾部省略', () => {
+      const shown = formatDisplayPath('a'.repeat(80));
+      expect(shown.endsWith('…')).toBe(true);
+      expect(shown.length).toBeLessThanOrEqual(48);
+    });
+
+    it('文件名本身极长时退化为尾部省略，不超出上限', () => {
+      const shown = formatDisplayPath(`/Users/demo/${'b'.repeat(120)}.md`);
+      expect(shown.endsWith('…')).toBe(true);
+      expect(shown.length).toBeLessThanOrEqual(48);
+    });
+  });
+
+  // ===== ISS-91：pathInvalid 时复制入口与右键菜单保持一致 =====
+
+  it('pathInvalid 时不渲染复制图标按钮（ISS-91）', () => {
+    render({ filePath: '/tmp/missing.md', pathInvalid: true });
+    expect(host.querySelector('.status-copy-button')).toBeNull();
+  });
+
+  it('pathInvalid 时双击路径不触发复制（ISS-91）', async () => {
+    render({ filePath: '/tmp/missing.md', pathInvalid: true });
+
+    const path = host.querySelector<HTMLSpanElement>('.status-path');
+    expect(path?.ondblclick).toBeNull();
+
+    await act(async () => {
+      path!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+      await flushPromises();
+    });
+
+    expect(writeTextMock).not.toHaveBeenCalled();
+    expect(host.querySelector('.status-copy-feedback')).toBeNull();
+  });
+
+  it('pathInvalid 时 title 只给完整路径、不含双击提示（ISS-91）', () => {
+    render({ filePath: '/tmp/missing.md', pathInvalid: true });
+    expect(host.querySelector('.status-path')?.getAttribute('title')).toBe('/tmp/missing.md');
+  });
+
+  it('路径有效时复制按钮与双击复制仍可用（ISS-91 回归）', async () => {
+    render({ filePath: '/tmp/ok.md', pathInvalid: false });
+    expect(host.querySelector('.status-copy-button')).not.toBeNull();
+
+    const path = host.querySelector<HTMLSpanElement>('.status-path');
+    await act(async () => {
+      path!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+      await flushPromises();
+    });
+
+    expect(writeTextMock).toHaveBeenCalledWith('/tmp/ok.md');
   });
 });

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -3,6 +3,7 @@ import { Copy } from 'lucide-react';
 import { writeText } from '../services/clipboardService';
 import { useSettings } from '../hooks/useSettings';
 import { translate } from '../services/i18n';
+import { formatDisplayPath } from './statusPathFormat';
 
 type StatusBarProps = {
   filePath: string;
@@ -27,6 +28,8 @@ export function StatusBar({ filePath, dirty, draftPersisted, pathInvalid, reload
   const settings = useSettings();
   const t = (key: Parameters<typeof translate>[1]) => translate(settings.locale, key);
   const hasPath = filePath.length > 0;
+  // ISS-91：路径失效时复制无意义，与右键菜单 canRevealFile 的 `!pathInvalid` 约定保持一致。
+  const canCopy = hasPath && !pathInvalid;
   const [copyMarker, setCopyMarker] = useState<CopyMarker>(null);
   const resetTimerRef = useRef<number | null>(null);
 
@@ -51,7 +54,7 @@ export function StatusBar({ filePath, dirty, draftPersisted, pathInvalid, reload
 
   // ISS-85：复制逻辑抽成 handleCopy，供「双击路径」与「单击复制图标」共用。
   const handleCopy = () => {
-    if (!hasPath) return;
+    if (!canCopy) return;
     void writeText(filePath)
       .then(() => {
         setCopyMarker({ path: filePath, outcome: 'copied' });
@@ -65,7 +68,7 @@ export function StatusBar({ filePath, dirty, draftPersisted, pathInvalid, reload
   };
 
   const copyState: 'idle' | CopyOutcome =
-    copyMarker && copyMarker.path === filePath && hasPath
+    copyMarker && copyMarker.path === filePath && canCopy
       ? copyMarker.outcome
       : 'idle';
 
@@ -83,15 +86,16 @@ export function StatusBar({ filePath, dirty, draftPersisted, pathInvalid, reload
       <span
         className="status-path"
         data-copy-state={copyState}
-        onDoubleClick={hasPath ? handleCopy : undefined}
-        title={hasPath ? t('statusBarCopyHint') : undefined}
+        onDoubleClick={canCopy ? handleCopy : undefined}
+        // 显示可能是折叠后的短形式，title 始终给出完整路径。
+        title={hasPath ? (canCopy ? `${filePath}\n${t('statusBarCopyHint')}` : filePath) : undefined}
         style={
           hasPath ? { cursor: 'text', userSelect: 'text' } : undefined
         }
       >
-        {hasPath ? filePath : t('statusBarNoFile')}
+        {hasPath ? formatDisplayPath(filePath) : t('statusBarNoFile')}
       </span>
-      {hasPath && (
+      {canCopy && (
         <button
           type="button"
           className="status-copy-button"

--- a/src/components/statusPathFormat.ts
+++ b/src/components/statusPathFormat.ts
@@ -1,0 +1,31 @@
+/** ISS-90：超过该长度的路径折叠中段显示，避免长路径撑满状态栏。 */
+const PATH_DISPLAY_MAX_LENGTH = 48;
+/** 中段折叠时保留的尾部片段数（文件名 + 其上一层目录）。 */
+const PATH_TAIL_SEGMENTS = 2;
+/** 中段折叠时保留的头部片段数（如 `/Users/maoking`：根目录 + 用户名）。 */
+const PATH_HEAD_SEGMENTS = 2;
+const PATH_ELLIPSIS = '…';
+
+/**
+ * ISS-90：把过长的绝对路径折叠成 `/Users/maoking/…/notes/2026-08-04.md` 形式。
+ * 路径首尾识别价值最高（根目录 / 用户名 + 文件名），因此折叠中段而非尾部。
+ * 纯函数，仅用于显示；复制与 title 始终使用完整路径。
+ */
+export function formatDisplayPath(path: string, maxLength = PATH_DISPLAY_MAX_LENGTH): string {
+  if (path.length <= maxLength) return path;
+
+  const separator = path.includes('/') ? '/' : '\\';
+  const segments = path.split(separator);
+  // 绝对路径以分隔符开头时 segments[0] 为空串，保留它才能还原前导 `/`。
+  const headCount = segments[0] === '' ? PATH_HEAD_SEGMENTS + 1 : PATH_HEAD_SEGMENTS;
+  // 头尾片段之间至少要有一段可折叠，否则没有中段可省，退化为尾部省略。
+  if (segments.length <= headCount + PATH_TAIL_SEGMENTS) {
+    return `${path.slice(0, maxLength - 1)}${PATH_ELLIPSIS}`;
+  }
+
+  const tail = segments.slice(-PATH_TAIL_SEGMENTS).join(separator);
+  const head = segments.slice(0, headCount).join(separator);
+  const folded = `${head}${separator}${PATH_ELLIPSIS}${separator}${tail}`;
+  // 折叠后仍超长（例如文件名本身极长）时，退化为尾部省略保证不撑破布局。
+  return folded.length <= maxLength ? folded : `${path.slice(0, maxLength - 1)}${PATH_ELLIPSIS}`;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2274,9 +2274,19 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
   letter-spacing: 0;
 }
 
+/* ISS-90：路径过长时不得撑破状态栏。显示层已做中段折叠（formatDisplayPath），
+   这里再兜一层尾部省略，防止窄窗口下折叠后的短形式仍溢出。 */
+.status-path {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .status-dirty {
   color: var(--accent);
   font-weight: 500;
+  flex-shrink: 0;
 }
 
 /* ISS-85：地址栏常驻复制图标，单击复制完整路径。视觉上与路径文本成组。 */
@@ -2297,6 +2307,12 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 }
 .status-copy-button:hover { background: var(--control-hover-bg); color: var(--fg); }
 .status-copy-button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+
+/* ISS-90：「已复制 / 复制失败」反馈被长路径挤压时会断成两行错位，禁止换行与收缩。 */
+.status-copy-feedback {
+  white-space: nowrap;
+  flex-shrink: 0;
+}
 
 .status-notice {
   display: inline-flex;


### PR DESCRIPTION
Closes #90, Closes #91

## 改动
- **#90**：`.status-path` 长路径中段省略（`/Users/maoking/…/notes/2026-08-04.md`，保留根目录+文件名）；复制仍写完整路径（handleCopy 不变），title 显示完整路径；`.status-copy-feedback` 加 nowrap+flex-shrink:0 修「已/复制」断行；补 `.status-path` CSS（原本完全无定义）。
- **#91**：`canCopy = hasPath && !pathInvalid`，文件丢失时不渲染复制图标、双击不复制，与右键菜单 canRevealFile 的 !pathInvalid 对齐。

## 新增文件
- `src/components/statusPathFormat.ts`：路径截断纯函数（react-refresh lint 禁止组件文件导出非组件，参照 contextMenuPosition.ts 约定）。

## 验证
typecheck / lint / test 全过（+13 测试）。真机确认待做。

## 执行
Wave-1 Worker A（codebuddy/hy3）。