### PR TITLE
fix(preview): #93 编辑器内容区 padding vw→% 根治打开面板时内容被挤压

### DIFF
--- a/src/components/WechatPreviewPane.test.tsx
+++ b/src/components/WechatPreviewPane.test.tsx
@@ -426,4 +426,85 @@ describe('WechatPreviewPane', () => {
     expect(exportedBlobs).toHaveLength(1);
     await expect(exportedBlobs[0].text()).resolves.toContain('rgb(12, 88, 44)');
   });
+
+  it('auto-closes when the viewport is narrower than MIN_VIEWPORT (850px)', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 700,
+    });
+
+    const onClose = vi.fn();
+    await act(async () => {
+      root.render(<WechatPreviewPane source="# 标题" onClose={onClose} />);
+      await flushPromises();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: originalWidth,
+    });
+  });
+
+  it('does not auto-close when the viewport is wide enough (≥850px)', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1200,
+    });
+
+    const onClose = vi.fn();
+    await act(async () => {
+      root.render(<WechatPreviewPane source="# 标题" onClose={onClose} />);
+      await flushPromises();
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: originalWidth,
+    });
+  });
+
+  it('auto-closes on resize when the viewport shrinks below MIN_VIEWPORT', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1200,
+    });
+
+    const onClose = vi.fn();
+    await act(async () => {
+      root.render(<WechatPreviewPane source="# 标题" onClose={onClose} />);
+      await flushPromises();
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    await act(async () => {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: 600,
+      });
+      window.dispatchEvent(new Event('resize'));
+      await flushPromises();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: originalWidth,
+    });
+  });
 });

--- a/src/components/WechatPreviewPane.tsx
+++ b/src/components/WechatPreviewPane.tsx
@@ -64,6 +64,25 @@ export function WechatPreviewPane({ source, fileName = 'document.md', onClose, f
   );
   const sourceIsEmpty = deferredSource.trim() === '';
 
+  /* ISS-93: auto-collapse the HTML export preview panel when the viewport
+     is too narrow to host both the 480px main editor and the 360px right
+     panel together — mirrors the WordPaperPreviewPane MIN_VIEWPORT logic.
+     The CSS layout makes sure the main editor never gets squeezed below the
+     readable line length, but if this panel is forced open at a narrow
+     viewport the only way to keep that promise is to close this side panel.
+     The user can still reopen it once the window grows back. */
+  useEffect(() => {
+    const MIN_VIEWPORT = 850;
+    const handleResize = () => {
+      if (window.innerWidth < MIN_VIEWPORT) {
+        onClose();
+      }
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [onClose]);
+
   useEffect(() => {
     const el = renderRef.current;
     if (!el) return;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -567,6 +567,10 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
      is open. The variable is reused by the right-panel clamp below to make
      sure the panel never claims more width than the viewport allows. */
   --main-min-width: 480px;
+  /* ISS-93: Markdown 预览（.preview-shell）也有可读下限。三栏布局
+     （编辑器 + 预览 + 导出面板）中，预览独自承担全部挤压会被挤到不可读，
+     因此给它一个 320px 的底线，与编辑器 480px 对称保护。 */
+  --preview-min-width: 320px;
   --main-resizer-gap: 9px;
 }
 
@@ -582,13 +586,22 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 /* When a right panel is open, every writing-layout pane (including the HTML
    presentation pane that replaces the editor in `html-presentation-layout`)
    must refuse to shrink below the readable threshold. The right panel
-   instead takes the flex-shrink burden — see the clamp below. */
+   instead takes the flex-shrink burden — see the clamp below.
+   ISS-93: `.preview-shell`（Markdown 阅读预览）也纳入保护——三栏布局
+   （编辑器 + 预览 + 导出面板）中它原先是唯一 min-width:0 的 pane，
+   被挤到不可读。现在用 --preview-min-width(320px) 给它一个可读底线，
+   与编辑器 480px 对称。极窄窗口下若三栏总和超视口，父容器横向滚动
+   （与 .html-presentation-pane 既有处理一致），不让内容被裁切。 */
 .right-panel-open .writing-layout > .editor-pane,
 .right-panel-open .writing-layout > .wysiwyg-editor-pane,
 .right-panel-open .writing-layout > .markdown-editing-pane,
 .right-panel-open .writing-layout > .html-presentation-pane,
 .right-panel-open .writing-layout > .html-reading-pane {
   min-width: var(--main-min-width);
+}
+
+.right-panel-open .writing-layout > .preview-shell {
+  min-width: var(--preview-min-width, 320px);
 }
 
 .writing-layout .preview-shell {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -567,10 +567,6 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
      is open. The variable is reused by the right-panel clamp below to make
      sure the panel never claims more width than the viewport allows. */
   --main-min-width: 480px;
-  /* ISS-93: Markdown 预览（.preview-shell）也有可读下限。三栏布局
-     （编辑器 + 预览 + 导出面板）中，预览独自承担全部挤压会被挤到不可读，
-     因此给它一个 320px 的底线，与编辑器 480px 对称保护。 */
-  --preview-min-width: 320px;
   --main-resizer-gap: 9px;
 }
 
@@ -586,22 +582,13 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 /* When a right panel is open, every writing-layout pane (including the HTML
    presentation pane that replaces the editor in `html-presentation-layout`)
    must refuse to shrink below the readable threshold. The right panel
-   instead takes the flex-shrink burden — see the clamp below.
-   ISS-93: `.preview-shell`（Markdown 阅读预览）也纳入保护——三栏布局
-   （编辑器 + 预览 + 导出面板）中它原先是唯一 min-width:0 的 pane，
-   被挤到不可读。现在用 --preview-min-width(320px) 给它一个可读底线，
-   与编辑器 480px 对称。极窄窗口下若三栏总和超视口，父容器横向滚动
-   （与 .html-presentation-pane 既有处理一致），不让内容被裁切。 */
+   instead takes the flex-shrink burden — see the clamp below. */
 .right-panel-open .writing-layout > .editor-pane,
 .right-panel-open .writing-layout > .wysiwyg-editor-pane,
 .right-panel-open .writing-layout > .markdown-editing-pane,
 .right-panel-open .writing-layout > .html-presentation-pane,
 .right-panel-open .writing-layout > .html-reading-pane {
   min-width: var(--main-min-width);
-}
-
-.right-panel-open .writing-layout > .preview-shell {
-  min-width: var(--preview-min-width, 320px);
 }
 
 .writing-layout .preview-shell {
@@ -1193,7 +1180,11 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 .wysiwyg-editor-pane .vditor-ir,
 .wysiwyg-editor-pane .vditor-wysiwyg {
   height: 100%;
-  padding: 10px clamp(24px, 7vw, 104px);
+  /* ISS-93: padding 用 %（基于编辑器容器宽度）而非 vw（视口宽度）。
+     打开转 Word/HTML 面板时编辑器容器变窄，但 vw padding 仍按整个窗口算，
+     两侧大 padding 把内容挤窄（"容器够宽、内容被挤压"）。
+     改 % 后 padding 随编辑器容器缩放，内容区不再被两侧 padding 挤压。 */
+  padding: 10px clamp(24px, 7%, 104px);
   background: var(--bg);
   color: var(--fg);
   font-family: var(--reading-font-family, var(--font-reading));


### PR DESCRIPTION
Closes #93

## 根因
`.vditor-ir` 的 `padding: 10px clamp(24px, 7vw, 104px)` 用 **vw（视口宽度）**。打开转 Word/HTML 面板时编辑器容器变窄，但 vw padding 仍按整个窗口算，两侧大 padding 把内容挤窄（「容器够宽、内容被挤压」）。

## 改动
- padding `7vw` → `7%`（% 基于编辑器容器宽度，随容器缩放，容器变窄 padding 等比缩小）。
- 微信面板 WechatPreviewPane 补齐 MIN_VIEWPORT=850 自动关闭（与 Word 面板一致，两面板一致性）。

## 说明（PM 收口纠偏）
Worker B 初版基于 PM 错误 Background（误判 .preview-shell 三栏被挤，实际 PreviewPane 不在 folia 主布局渲染），加了无效的 .preview-shell min-width 死规则。PM 复核后撤掉死规则、改为 padding 根因修复。方向错是 PM 责任，非 worker 失败。

## 验证
typecheck / lint / test 全过（微信面板 +3 测试）。padding % 基于包含块（.vditor-content → 编辑器容器）理论正确；**真机最终确认待做**。