### PR TITLE
feat(editor): #94 新建空白文件编辑器自动聚焦

### DIFF
--- a/src/components/EditorPane.test.tsx
+++ b/src/components/EditorPane.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * ISS-94 EditorPane 自动聚焦测试。
+ *
+ * 策略：mock @uiw/react-codemirror，让它在挂载时调用 onCreateEditor 并传入一个
+ * 带 focus spy 的伪 EditorView。这样测试可以精确断言「空内容时 focus 被调用」、
+ * 「非空内容时 focus 不被调用」，不依赖 jsdom 对真实 CodeMirror 的支持度。
+ *
+ * useSettings 也需 mock，因为 EditorPane 读取多个 settings 字段用于 extensions/theme。
+ */
+
+const focusSpy = vi.fn();
+
+/** 伪 EditorView：只暴露 EditorPane 关心的接口（focus / dispatch / state 等）。 */
+function createFakeView(): unknown {
+  return {
+    focus: focusSpy,
+    dispatch: vi.fn(),
+    state: { selection: { main: { anchor: 0 } } },
+    dom: document.createElement('div'),
+  };
+}
+
+vi.mock('@uiw/react-codemirror', () => {
+  // 挂载时同步调用 onCreateEditor，模拟 @uiw/react-codemirror 的行为。
+  // 必须命名为大写开头的组件名，否则 react-hooks/rules-of-hooks 会报错。
+  function MockCodeMirror(props: {
+    onCreateEditor?: (view: unknown) => void;
+    value?: string;
+  }): React.ReactElement {
+    React.useEffect(() => {
+      if (props.onCreateEditor) {
+        props.onCreateEditor(createFakeView());
+      }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return React.createElement('div', { 'data-testid': 'cm-mock' }, props.value ?? '');
+  }
+  return { default: MockCodeMirror };
+});
+
+vi.mock('@codemirror/lang-markdown', () => ({ markdown: () => ({} as never) }));
+vi.mock('@codemirror/state', () => ({ EditorState: { tabSize: { of: () => ({}) } } }));
+vi.mock('@codemirror/view', () => ({
+  EditorView: {
+    lineWrapping: {},
+    theme: () => ({}),
+    scrollIntoView: () => ({}),
+  },
+}));
+
+vi.mock('../hooks/useSettings', () => ({
+  useSettings: () => ({
+    editorFontFamily: 'IBM Plex Mono',
+    editorFontSize: 13,
+    editorTabSize: 4,
+    editorWordWrap: true,
+    editorLineNumbers: true,
+    editorSpellCheck: false,
+    locale: 'zh-CN',
+  }),
+}));
+
+vi.mock('../services/tocService', () => ({ findMarkdownHeadingPosition: () => null }));
+
+// 在 mock 之后导入组件，确保 mock 生效
+import { EditorPane } from './EditorPane';
+
+describe('EditorPane 自动聚焦 (ISS-94)', () => {
+  let host: HTMLDivElement;
+
+  beforeEach(() => {
+    focusSpy.mockClear();
+    host = document.createElement('div');
+    document.body.append(host);
+  });
+
+  afterEach(() => {
+    host.remove();
+    vi.clearAllMocks();
+  });
+
+  it('空内容（新建空白文件）挂载后调用 view.focus()', async () => {
+    let root: Root | null = null;
+    await act(async () => {
+      root = createRoot(host);
+      root.render(
+        React.createElement(EditorPane, { source: '', onChange: () => undefined }),
+      );
+    });
+
+    // ISS-94：空内容时 auto-focus 一次
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+
+  it('仅含空白的 source 也视为空内容，挂载后调用 view.focus()', async () => {
+    let root: Root | null = null;
+    await act(async () => {
+      root = createRoot(host);
+      root.render(
+        React.createElement(EditorPane, { source: '   \n  \t ', onChange: () => undefined }),
+      );
+    });
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+
+  it('非空内容挂载后不调用 view.focus()（不抢焦点）', async () => {
+    let root: Root | null = null;
+    await act(async () => {
+      root = createRoot(host);
+      root.render(
+        React.createElement(EditorPane, {
+          source: '# 已有标题\n\n正文内容',
+          onChange: () => undefined,
+        }),
+      );
+    });
+
+    // ISS-94：打开已有文档不应抢焦点
+    expect(focusSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+});

--- a/src/components/EditorPane.tsx
+++ b/src/components/EditorPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { markdown } from '@codemirror/lang-markdown';
 import { EditorState } from '@codemirror/state';
@@ -21,6 +21,10 @@ export function EditorPane({ source, onChange, headingScrollRequest }: EditorPan
   const settings = useSettings();
   const [editorView, setEditorView] = useState<EditorView | null>(null);
   const handledHeadingScrollRequestRef = useRef<number | null>(null);
+  // ISS-94：新建空白文件时编辑器初始化完成后自动 focus 一次。
+  // ref 标记「已 focus 过一次」，避免组件重渲染 / onCreateEditor 重入时反复抢焦点。
+  // EditorPane 随标签切换 unmount/remount，新组件实例 ref 默认 false，新空白文件可再次 auto-focus。
+  const focusedOnceRef = useRef(false);
   const editorFontFamily = settings.editorFontFamily === 'System Default'
     ? 'var(--font-mono)'
     : `'${settings.editorFontFamily}', var(--font-mono)`;
@@ -68,6 +72,22 @@ export function EditorPane({ source, onChange, headingScrollRequest }: EditorPan
     });
   }, [editorView, headingScrollRequest, source]);
 
+  // ISS-94：CodeMirror 编辑器创建后，若文件内容为空（新建空白文件）则自动 focus，
+  // 让用户挂载后即可键盘输入。仅 focus 一次（focusedOnceRef guard），打开已有文档
+  // 不抢焦点。onCreateEditor 仅在组件挂载时触发一次，此处闭包捕获的 source 即初始 source。
+  const handleCreateEditor = useCallback((view: EditorView) => {
+    setEditorView(view);
+    if (!focusedOnceRef.current && source.trim() === '') {
+      focusedOnceRef.current = true;
+      try {
+        view.focus();
+      } catch (error) {
+        // focus 失败不应阻塞编辑器正常工作，静默降级
+        console.error('[Folia] onCreateEditor view.focus 失败:', error);
+      }
+    }
+  }, [source]);
+
   return (
     <div className="editor-pane">
       <CodeMirror
@@ -75,7 +95,7 @@ export function EditorPane({ source, onChange, headingScrollRequest }: EditorPan
         height="100%"
         extensions={extensions}
         onChange={onChange}
-        onCreateEditor={setEditorView}
+        onCreateEditor={handleCreateEditor}
         spellCheck={settings.editorSpellCheck}
         theme="light"
         basicSetup={{

--- a/src/components/WysiwygEditorPane.test.tsx
+++ b/src/components/WysiwygEditorPane.test.tsx
@@ -31,10 +31,14 @@ type VditorInstanceOptions = Record<string, unknown> & {
 type VditorConstructorCall = {
   host: HTMLElement;
   options: VditorInstanceOptions;
+  // ISS-94：暴露 mock 实例让测试可以断言 focus 是否被调用
+  instance: { focus: () => void };
 };
 
 const vditorCalls: VditorConstructorCall[] = [];
 const setValueCalls: string[] = [];
+// ISS-94：记录每个 Vditor mock 实例的 focus 调用次数，与 vditorCalls 一一对应
+const focusCalls: number[] = [];
 
 /** Minimal Vditor mock: 构造时往 host 注入一个真实可操作的 .vditor-ir pre，
  *  让 sanitizeIrDom 能在真实 DOM 子树上工作（保留 sanitizeForVditor 的
@@ -54,9 +58,13 @@ vi.mock('vditor', () => {
     public vditor: {
       ir: { element: HTMLElement };
     };
+    private readonly index: number;
 
     constructor(host: HTMLElement, options: VditorInstanceOptions) {
-      vditorCalls.push({ host, options });
+      const index = vditorCalls.length;
+      this.index = index;
+      focusCalls.push(0);
+      vditorCalls.push({ host, options, instance: this });
       const ir = document.createElement('div');
       ir.className = 'vditor-ir';
       const pre = document.createElement('pre');
@@ -65,6 +73,11 @@ vi.mock('vditor', () => {
       ir.appendChild(pre);
       host.appendChild(ir);
       this.vditor = { ir: { element: pre } };
+    }
+
+    // ISS-94：记录 focus 调用次数，让测试断言 auto-focus 行为
+    public focus(): void {
+      focusCalls[this.index] += 1;
     }
 
     public getValue(): string {
@@ -143,6 +156,7 @@ describe('WysiwygEditorPane 内联 SVG 显示 + sanitize (ISS-168 编辑器部�
   beforeEach(() => {
     vditorCalls.length = 0;
     setValueCalls.length = 0;
+    focusCalls.length = 0;
     host = document.createElement('div');
     document.body.append(host);
   });
@@ -1034,6 +1048,157 @@ describe('WysiwygEditorPane 内联 SVG 显示 + sanitize (ISS-168 编辑器部�
       await act(async () => {
         root?.unmount();
       });
+    });
+  });
+});
+
+describe('WysiwygEditorPane 自动聚焦 (ISS-94)', () => {
+  let host: HTMLDivElement;
+
+  beforeEach(() => {
+    vditorCalls.length = 0;
+    setValueCalls.length = 0;
+    focusCalls.length = 0;
+    host = document.createElement('div');
+    document.body.append(host);
+  });
+
+  afterEach(() => {
+    host.remove();
+    vi.clearAllMocks();
+  });
+
+  it('空内容（新建空白文件）after() 后调用 editor.focus()', async () => {
+    let root: Root | null = null;
+
+    await act(async () => {
+      root = createRoot(host);
+      root.render(
+        renderWithProvider(
+          React.createElement(WysiwygEditorPane, {
+            source: '',
+            onChange: () => undefined,
+          }),
+        ),
+      );
+      await flushMicrotasks();
+    });
+
+    expect(vditorCalls).toHaveLength(1);
+    const call = vditorCalls[0];
+
+    await act(async () => {
+      call.options.after?.();
+      await flushMicrotasks();
+      await flushFrames();
+    });
+
+    // ISS-94：空内容时应 auto-focus 一次
+    expect(focusCalls[0]).toBe(1);
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+
+  it('仅含空白的 source 也视为空内容，after() 后调用 editor.focus()', async () => {
+    let root: Root | null = null;
+
+    await act(async () => {
+      root = createRoot(host);
+      root.render(
+        renderWithProvider(
+          React.createElement(WysiwygEditorPane, {
+            source: '   \n  \t ',
+            onChange: () => undefined,
+          }),
+        ),
+      );
+      await flushMicrotasks();
+    });
+
+    const call = vditorCalls[0];
+    await act(async () => {
+      call.options.after?.();
+      await flushMicrotasks();
+      await flushFrames();
+    });
+
+    // trim 后为空 → 视为新建空白文件
+    expect(focusCalls[0]).toBe(1);
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+
+  it('非空内容 after() 后不调用 editor.focus()（不抢焦点）', async () => {
+    let root: Root | null = null;
+
+    await act(async () => {
+      root = createRoot(host);
+      root.render(
+        renderWithProvider(
+          React.createElement(WysiwygEditorPane, {
+            source: '# 已有标题\n\n正文内容',
+            onChange: () => undefined,
+          }),
+        ),
+      );
+      await flushMicrotasks();
+    });
+
+    const call = vditorCalls[0];
+    await act(async () => {
+      call.options.after?.();
+      await flushMicrotasks();
+      await flushFrames();
+    });
+
+    // ISS-94：打开已有文档不应抢焦点
+    expect(focusCalls[0]).toBe(0);
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+
+  it('focusedOnceRef guard：after() 重入不重复 focus', async () => {
+    let root: Root | null = null;
+
+    await act(async () => {
+      root = createRoot(host);
+      root.render(
+        renderWithProvider(
+          React.createElement(WysiwygEditorPane, {
+            source: '',
+            onChange: () => undefined,
+          }),
+        ),
+      );
+      await flushMicrotasks();
+    });
+
+    const call = vditorCalls[0];
+
+    // 第一次 after() → focus
+    await act(async () => {
+      call.options.after?.();
+      await flushMicrotasks();
+      await flushFrames();
+    });
+    expect(focusCalls[0]).toBe(1);
+
+    // 再次触发 after()（模拟重入 / 重渲染）→ guard 拦截，不重复 focus
+    await act(async () => {
+      call.options.after?.();
+      await flushMicrotasks();
+      await flushFrames();
+    });
+    expect(focusCalls[0]).toBe(1);
+
+    await act(async () => {
+      root?.unmount();
     });
   });
 });

--- a/src/components/WysiwygEditorPane.tsx
+++ b/src/components/WysiwygEditorPane.tsx
@@ -554,6 +554,10 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
   const sanitizingRef = useRef(false);
   const initializingRef = useRef(false);
   const userInteractedRef = useRef(false);
+  // ISS-94：新建空白文件时编辑器初始化完成后自动 focus 一次。
+  // ref 标记「已 focus 过一次」，避免 after() 重入或组件重渲染时反复抢焦点。
+  // Vditor 按 filePath 变化销毁重建（init effect cleanup），cleanup 中重置为 false。
+  const focusedOnceRef = useRef(false);
   const [phase, setPhase] = useState<EditorPhase>('loading');
   const [imageDiagnostics, setImageDiagnostics] = useState<RenderDiagnostic[]>([]);
   // retryKey 递增时强制重新初始化 Vditor
@@ -909,6 +913,21 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
               });
             }
           }
+
+          // ISS-94：新建空白文件时自动聚焦编辑器，光标直接进入可键盘输入。
+          // 仅当内容为空（去除空白后）时触发——打开已有文档不抢焦点，让用户
+          // 先浏览内容。用 focusedOnceRef 标记已 focus 过一次，防止 after()
+          // 重入或后续重渲染反复抢焦点。注意：此时 cancelled 仍未翻转（本回调
+          // 在 cancelled 检查之后进入），editor 已就绪，focus 是安全同步调用。
+          if (!focusedOnceRef.current && latestSource.current.trim() === '') {
+            focusedOnceRef.current = true;
+            try {
+              editor.focus();
+            } catch (error) {
+              // focus 失败不应阻塞编辑器正常工作，静默降级
+              console.error('[Folia] after() editor.focus 失败:', error);
+            }
+          }
         },
         input(value) {
           if (initializingRef.current || applyingExternalValue.current || sanitizingRef.current) return;
@@ -1075,6 +1094,8 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
       pendingSourceRef.current = null;
       initializingRef.current = false;
       userInteractedRef.current = false;
+      // ISS-94：Vditor 按 filePath 变化销毁重建，重置 focus 标记让新空白文件可再次 auto-focus
+      focusedOnceRef.current = false;
     };
   }, [filePath, lockComplexTables, emitEditorValueIfChanged, onChange, retryKey, handleImageFiles, handleTextPaste]);
 


### PR DESCRIPTION
Closes #94

## 根因
wysiwyg 模式 Vditor `after()` 初始化回调未调 `editor.focus()`；source 模式 CodeMirror `onCreateEditor` 未调 `view.focus()`。新建空白文件后光标不进编辑器，需手动点击。

## 改动
- 两种模式初始化完成后自动 focus，**仅当文档内容为空（新建空白文件）**时触发；打开已有文档不抢焦点。
- `focusedOnceRef` guard 防重入；wysiwyg 在 init effect cleanup 重置（切 tab 后新空白文件可再次 focus）。
- try/catch 降级，focus 失败不阻塞编辑器。

## 验证
typecheck / lint / test 全过（EditorPane + WysiwygEditorPane 新增测试）。真机确认待做（新建空白文件光标闪烁）。

## 执行
Wave-1 Worker C（claude glm-5.2）。