### PR TITLE
test(e2e): 补 #92 右键菜单 a11y 聚焦 e2e 覆盖

### DIFF
--- a/e2e/iss-92-contextmenu-a11y.spec.ts
+++ b/e2e/iss-92-contextmenu-a11y.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * E2E: ISS-92 — 右键文件标签菜单打开后应自动聚焦首项（键盘 a11y）
+ *
+ * 背景：ContextMenu 原先打开后不 focus 首项，键盘用户需先按 ↓ 才进入导航。
+ * ISS-92 在 useEffect 挂载时 firstItem.focus()。此测试验该行为——这是 orca
+ * computer 驱动不了的 web 交互（WKWebView 不响应 macOS-level click），
+ * 所以用 playwright 浏览器驱动来覆盖。
+ */
+import { test, expect } from '@playwright/test';
+
+async function coldStartOnRecentPage(page: import('@playwright/test').Page): Promise<void> {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload({ waitUntil: 'load' });
+  await expect(page.locator('.recent-page')).toBeVisible({ timeout: 30000 });
+}
+
+test.describe('ISS-92: 右键菜单 a11y 自动聚焦首项', () => {
+  test('右键文件标签 → 菜单首项 menuitem 聚焦，且 ↓ 能循环导航到第二项', async ({ page }) => {
+    test.setTimeout(60000); // vite dev 首次冷启动 reload 偶发偏慢，放宽单测超时
+    await coldStartOnRecentPage(page);
+    // 欢迎页「新建」进入编辑器，产生可右键的文件标签
+    await page.locator('.recent-page-secondary').click();
+    await expect(page.locator('.wysiwyg-editor-pane')).toBeVisible({ timeout: 10000 });
+
+    // 右键首个文件标签触发 contextmenu
+    await page.locator('.tabbar-tab').first().click({ button: 'right' });
+
+    const menu = page.locator('.tab-context-menu');
+    await expect(menu).toBeVisible();
+
+    const items = menu.locator('[role="menuitem"]');
+    const count = await items.count();
+    expect(count).toBeGreaterThan(0);
+
+    // 核心断言：菜单打开应自动聚焦首个 menuitem（ISS-92 修复）
+    await expect(items.first()).toBeFocused();
+
+    // 按 ↓ 应移到第二项（依赖首项已聚焦）
+    await page.keyboard.press('ArrowDown');
+    await expect(items.nth(1 % count)).toBeFocused();
+  });
+});


### PR DESCRIPTION
为 #92 的 a11y focus（菜单打开自动聚焦首项）补 e2e 回归测试。

ISS-92 这项交互 orca computer 驱动不了（WKWebView 不响应 macOS-level click），改用 playwright e2e（Chromium）覆盖：右键文件标签 → 断言首个 `[role=menuitem]` `toBeFocused` + 按 ↓ 移到第二项。测试已 pass（54.4s），确认 a11y focus 在浏览器真机有效。

纯测试补充，#92 已在 #98 合入；这是回归覆盖。