### PR TITLE
fix: #94 review B1 source 切 tab focus + #92 review R1 微信面板窄视口豁免

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -966,6 +966,7 @@ export function AppLayout() {
     <Suspense fallback={<div className="editor-pane lazy-pane"><span>源码编辑器加载中</span></div>}>
       <EditorPane
         source={file.content}
+        autoFocusKey={activeTabId}
         onChange={handleContentChange}
         headingScrollRequest={sourceHeadingScrollRequest}
       />

--- a/src/components/EditorPane.tsx
+++ b/src/components/EditorPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { markdown } from '@codemirror/lang-markdown';
 import { EditorState } from '@codemirror/state';
@@ -15,16 +15,20 @@ type EditorPaneProps = {
   source: string;
   onChange: (value: string) => void;
   headingScrollRequest?: SourceHeadingScrollRequest;
+  /** ISS-94 review B1：tab 标识，变化（切 tab）时允许重新触发 auto-focus。 */
+  autoFocusKey?: string;
 };
 
-export function EditorPane({ source, onChange, headingScrollRequest }: EditorPaneProps) {
+export function EditorPane({ source, onChange, headingScrollRequest, autoFocusKey }: EditorPaneProps) {
   const settings = useSettings();
   const [editorView, setEditorView] = useState<EditorView | null>(null);
   const handledHeadingScrollRequestRef = useRef<number | null>(null);
   // ISS-94：新建空白文件时编辑器初始化完成后自动 focus 一次。
-  // ref 标记「已 focus 过一次」，避免组件重渲染 / onCreateEditor 重入时反复抢焦点。
-  // EditorPane 随标签切换 unmount/remount，新组件实例 ref 默认 false，新空白文件可再次 auto-focus。
+  // autoFocusKey 变化（切 tab）时重置标记，允许新空白文件再 focus。
+  // 不用 key={tabId} remount（会导致 CodeMirror 重建 + AppLayout 集成测试 timeout），
+  // 改用 autoFocusKey prop + useEffect 响应，区分「切 tab」（key 变）vs「清空文档」（source 变）。
   const focusedOnceRef = useRef(false);
+  const prevAutoFocusKeyRef = useRef(autoFocusKey);
   const editorFontFamily = settings.editorFontFamily === 'System Default'
     ? 'var(--font-mono)'
     : `'${settings.editorFontFamily}', var(--font-mono)`;
@@ -72,21 +76,24 @@ export function EditorPane({ source, onChange, headingScrollRequest }: EditorPan
     });
   }, [editorView, headingScrollRequest, source]);
 
-  // ISS-94：CodeMirror 编辑器创建后，若文件内容为空（新建空白文件）则自动 focus，
-  // 让用户挂载后即可键盘输入。仅 focus 一次（focusedOnceRef guard），打开已有文档
-  // 不抢焦点。onCreateEditor 仅在组件挂载时触发一次，此处闭包捕获的 source 即初始 source。
-  const handleCreateEditor = useCallback((view: EditorView) => {
-    setEditorView(view);
-    if (!focusedOnceRef.current && source.trim() === '') {
+  // ISS-94：editorView 就绪后，若 source 为空且未 focus 过，则 focus 一次。
+  // autoFocusKey 变（切 tab）时重置 focusedOnceRef，让新空白文件能再次 auto-focus；
+  // 清空已有文档（autoFocusKey 不变）不会重新 focus，避免编辑中途抢焦点。
+  useEffect(() => {
+    if (autoFocusKey !== prevAutoFocusKeyRef.current) {
+      focusedOnceRef.current = false;
+      prevAutoFocusKeyRef.current = autoFocusKey;
+    }
+    if (editorView && source.trim() === '' && !focusedOnceRef.current) {
       focusedOnceRef.current = true;
       try {
-        view.focus();
+        editorView.focus();
       } catch (error) {
         // focus 失败不应阻塞编辑器正常工作，静默降级
-        console.error('[Folia] onCreateEditor view.focus 失败:', error);
+        console.error('[Folia] EditorPane auto-focus 失败:', error);
       }
     }
-  }, [source]);
+  }, [editorView, source, autoFocusKey]);
 
   return (
     <div className="editor-pane">
@@ -95,7 +102,7 @@ export function EditorPane({ source, onChange, headingScrollRequest }: EditorPan
         height="100%"
         extensions={extensions}
         onChange={onChange}
-        onCreateEditor={handleCreateEditor}
+        onCreateEditor={setEditorView}
         spellCheck={settings.editorSpellCheck}
         theme="light"
         basicSetup={{

--- a/src/components/WechatPreviewPane.test.tsx
+++ b/src/components/WechatPreviewPane.test.tsx
@@ -427,7 +427,7 @@ describe('WechatPreviewPane', () => {
     await expect(exportedBlobs[0].text()).resolves.toContain('rgb(12, 88, 44)');
   });
 
-  it('auto-closes when the viewport is narrower than MIN_VIEWPORT (850px)', async () => {
+  it('does NOT auto-close on mount at narrow viewport (ISS-92 review R1：用户主动打开豁免当次)', async () => {
     const originalWidth = window.innerWidth;
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
@@ -441,7 +441,8 @@ describe('WechatPreviewPane', () => {
       await flushPromises();
     });
 
-    expect(onClose).toHaveBeenCalledTimes(1);
+    // 窄屏 mount 不立即关——用户主动打开应允许当次使用（原先 mount 即秒关，窄屏永远打不开）
+    expect(onClose).not.toHaveBeenCalled();
 
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,

--- a/src/components/WechatPreviewPane.tsx
+++ b/src/components/WechatPreviewPane.tsx
@@ -78,7 +78,8 @@ export function WechatPreviewPane({ source, fileName = 'document.md', onClose, f
         onClose();
       }
     };
-    handleResize();
+    // ISS-92 review R1：mount 时不立即检查——用户在窄视口主动打开时应允许当次使用
+    //（否则点开即秒关，窄屏永远用不了这个面板）。仅在后续 resize（窗口继续缩窄）时才自动收起。
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, [onClose]);


### PR DESCRIPTION
code review（53bafc7..main）抓出的两个应修项：

## B1（#94 review，真实 bug）
EditorPane（CodeMirror）原用 `onCreateEditor`（mount-only）focus，AppLayout 无 key → 切 tab 不 remount → 新空白 source 文件**不 auto-focus**（worker C 注释还撒谎说会 remount）。

修：加 `autoFocusKey` prop（=activeTabId）+ useEffect 响应：切 tab（autoFocusKey 变）重置 `focusedOnceRef` + source 空 → focus；清空已有文档（autoFocusKey 不变）不 focus。**不用 key remount**（会重建 CodeMirror + AppLayoutSourceEditor/SystemOpenSource 集成测试 timeout，已验证）。

## R1（#92 review，UX）
WechatPreviewPane 窄视口（<850）mount 即 `onClose` → 用户主动打开秒关、窄屏永远打不开。改 mount 不立即检查（只监听 resize），窄视口打开豁免当次，仅后续 resize 更窄才收起。

## 验证
typecheck/lint/591 tests 全过。WechatPreviewPane mount 豁免用例已改。

未修（review 可选项，留 follow-up）：R2 StatusBar 复制反馈 tab 来回切假复发、R3 pathInvalid 仍可选折叠路径、C1-C3 cleanup。