### PR TITLE
refactor: review R2/R3/C3 清理

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -1107,6 +1107,7 @@ export function AppLayout() {
         {rightPanel}
       </div>
       <StatusBar
+        key={activeTabId}
         filePath={file.path}
         dirty={file.dirty}
         draftPersisted={session.activeTab?.draftPersisted}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -90,7 +90,7 @@ export function StatusBar({ filePath, dirty, draftPersisted, pathInvalid, reload
         // 显示可能是折叠后的短形式，title 始终给出完整路径。
         title={hasPath ? (canCopy ? `${filePath}\n${t('statusBarCopyHint')}` : filePath) : undefined}
         style={
-          hasPath ? { cursor: 'text', userSelect: 'text' } : undefined
+          hasPath ? { cursor: canCopy ? 'text' : 'default', userSelect: canCopy ? 'text' : 'none' } : undefined
         }
       >
         {hasPath ? formatDisplayPath(filePath) : t('statusBarNoFile')}

--- a/src/components/statusPathFormat.ts
+++ b/src/components/statusPathFormat.ts
@@ -6,6 +6,11 @@ const PATH_TAIL_SEGMENTS = 2;
 const PATH_HEAD_SEGMENTS = 2;
 const PATH_ELLIPSIS = '…';
 
+/** 尾部省略：保留 path 前 (maxLength - 省略号宽) 个字符 + …。Math.max 防 maxLength 过小的边界。 */
+function truncateTail(path: string, maxLength: number): string {
+  return `${path.slice(0, Math.max(0, maxLength - PATH_ELLIPSIS.length))}${PATH_ELLIPSIS}`;
+}
+
 /**
  * ISS-90：把过长的绝对路径折叠成 `/Users/maoking/…/notes/2026-08-04.md` 形式。
  * 路径首尾识别价值最高（根目录 / 用户名 + 文件名），因此折叠中段而非尾部。
@@ -20,12 +25,12 @@ export function formatDisplayPath(path: string, maxLength = PATH_DISPLAY_MAX_LEN
   const headCount = segments[0] === '' ? PATH_HEAD_SEGMENTS + 1 : PATH_HEAD_SEGMENTS;
   // 头尾片段之间至少要有一段可折叠，否则没有中段可省，退化为尾部省略。
   if (segments.length <= headCount + PATH_TAIL_SEGMENTS) {
-    return `${path.slice(0, maxLength - 1)}${PATH_ELLIPSIS}`;
+    return truncateTail(path, maxLength);
   }
 
   const tail = segments.slice(-PATH_TAIL_SEGMENTS).join(separator);
   const head = segments.slice(0, headCount).join(separator);
   const folded = `${head}${separator}${PATH_ELLIPSIS}${separator}${tail}`;
   // 折叠后仍超长（例如文件名本身极长）时，退化为尾部省略保证不撑破布局。
-  return folded.length <= maxLength ? folded : `${path.slice(0, maxLength - 1)}${PATH_ELLIPSIS}`;
+  return folded.length <= maxLength ? folded : truncateTail(path, maxLength);
 }


### PR DESCRIPTION
code review 可选清理项（B1/R1 已在 #101 修）：

- **R2**：StatusBar 复制反馈 tab 来回切「假复发」→ AppLayout 给 StatusBar `key={activeTabId}`，切 tab remount 清 copyMarker（原 effect setState 方案触发 react lint，key remount 更干净）。
- **R3**：pathInvalid 时仍 `userSelect:'text'` 可选到折叠假路径 → 改 `canCopy ? text : none`。
- **C3**：formatDisplayPath 两处 `slice+ELLIPSIS` 重复 → 抽 `truncateTail` helper + `Math.max` 修 maxLength 过小边界。

跳过：C1（StrictMode 双调，focus 幂等 + dev-only）、C2（title \n 换行，自定义 tooltip overkill）——review 评为可接受。

591 tests pass。