### PR TITLE
fix(update): ISS-99 重试后下载进度交错回退(per-attempt 令牌隔离)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **修复自动更新下载超时后点击「重试」时进度交错回退（如 `1% → 22% → 2% → 23%`）的问题**（ISS-99）：根因是 Tauri updater 的 `update.download(onEvent)` **没有取消参数**，超时/重试后旧下载尝试的 `onProgress` 回调仍挂在跑着的 Rust 下载流上，继续往同一个 `downloading` state 写进度；而 ISS-72 引入的三道守卫（abort 信号 / phase / version）在同版本重试时**全部失效**——旧尝试的 `AbortController` 在 `.finally` 里被置 null 后重试无法 abort、重试把 phase 重置回 `downloading`、version 守卫无法区分同版本（如 0.6.5）的两次尝试。现引入**单调递增的 per-attempt 令牌**（`updateAttemptRef`），新尝试（含重试）`++` 使旧令牌失效，旧尝试的 `onProgress` / `.then` / `.catch` 见到令牌不再匹配即丢弃事件，UI 只展示当前有效尝试的单调进度。新增 1 项 AppLayout 集成回归测试：mock 两次 `downloadAppUpdate`（attempt#1 发 10% 后挂起、attempt#2 发 1%/2%），超时 → 重试后故意触发 attempt#1 的陈旧 22% 事件，断言界面仍为「下载中 2%」且不出现「下载中 22%」（修复前该断言失败）。**已知残留**：Tauri 插件 API 不支持中途取消 `update.download()`，且重试复用同一 `Update` 对象（`close()` 会连带废掉重试），故旧 Rust 下载流会静默跑到自然结束、有短暂额外带宽，但不影响 UI 正确性；彻底取消需重试时重新 `check()` + close 旧 Update，属更大改动，本期不做。真机精确复现需可控的下载中途超时 + 待下载更新源（当前已处于目标版本），无法稳定触发，行为以集成测试为准（见 `project-folia-realapp-verify`：Folia WKWebView 交互无法用 orca click 驱动，web 交互走真实组件单测）。
+
 ## [0.6.5] - 2026-08-04
 
 ### Added

--- a/src/app/AppLayout.test.tsx
+++ b/src/app/AppLayout.test.tsx
@@ -3,7 +3,7 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppLayout } from './AppLayout';
-import type { UpdateCheckResult } from '../services/updateService';
+import type { UpdateCheckResult, UpdateProgress } from '../services/updateService';
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -262,6 +262,95 @@ describe('AppLayout update flow', () => {
     expect(host.textContent).toContain('重试下载');
     // 防止 leak
     resolveDownload();
+  });
+
+  // ISS-99：超时后点重试,旧下载尝试的 onProgress 仍挂在跑着的 Rust 下载流上
+  // (Tauri updater 的 update.download 无法中途取消),会继续往同一个 downloading
+  // state 写进度。版本守卫无法区分同版本的两次尝试,导致进度交错回退(1%→22%→2%→23%)。
+  // per-attempt token 守卫后,旧尝试的陈旧进度事件必须被忽略。
+  it('ignores stale progress from the previous attempt after a timeout retry', async () => {
+    let attempt1OnProgress: (p: UpdateProgress) => void = () => {};
+    let attempt2OnProgress: (p: UpdateProgress) => void = () => {};
+    let resolveAttempt1: () => void = () => {};
+    let resolveAttempt2: () => void = () => {};
+    let downloadCallCount = 0;
+    const availableUpdate = {
+      status: 'available',
+      version: '0.6.5',
+      update: {},
+    } as Extract<UpdateCheckResult, { status: 'available' }>;
+    updateServiceMock.checkForAppUpdate.mockResolvedValue(availableUpdate);
+    updateServiceMock.downloadAppUpdate.mockImplementation(async (_update, onProgress) => {
+      downloadCallCount += 1;
+      if (downloadCallCount === 1) {
+        attempt1OnProgress = onProgress!;
+        onProgress?.({ status: 'downloading', downloadedBytes: 10, totalBytes: 100, percent: 10 });
+        await new Promise<void>((resolve) => { resolveAttempt1 = resolve; });
+        return;
+      }
+      attempt2OnProgress = onProgress!;
+      onProgress?.({ status: 'downloading', downloadedBytes: 1, totalBytes: 100, percent: 1 });
+      await new Promise<void>((resolve) => { resolveAttempt2 = resolve; });
+    });
+
+    await act(async () => {
+      root.render(<AppLayout />);
+      await flushPromises();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2600);
+      await flushPromises();
+    });
+
+    // attempt#1 已发 10%
+    expect(updateServiceMock.downloadAppUpdate).toHaveBeenCalledTimes(1);
+    expect(host.textContent).toContain('下载中 10%');
+
+    // 5 分钟超时 → error 态 + 「重试下载」按钮
+    await act(async () => {
+      vi.advanceTimersByTime(5 * 60 * 1000);
+      await flushPromises();
+    });
+    expect(host.textContent).toContain('重试下载');
+
+    // 点重试 → attempt#2 启动,发 1%
+    const retryButton = host.querySelector<HTMLButtonElement>('button.toolbar-update-button.error');
+    expect(retryButton).toBeTruthy();
+    await act(async () => {
+      retryButton!.click();
+      await flushPromises();
+    });
+    expect(updateServiceMock.downloadAppUpdate).toHaveBeenCalledTimes(2);
+    expect(host.textContent).toContain('下载中 1%');
+
+    // attempt#2 正常单调推进到 2%
+    await act(async () => {
+      attempt2OnProgress({ status: 'downloading', downloadedBytes: 2, totalBytes: 100, percent: 2 });
+      await flushPromises();
+    });
+    expect(host.textContent).toContain('下载中 2%');
+
+    // BUG 条件:attempt#1 那条仍跑着的 Rust 下载流发来陈旧进度(22%)—— 必须被忽略,不回退
+    await act(async () => {
+      attempt1OnProgress({ status: 'downloading', downloadedBytes: 22, totalBytes: 100, percent: 22 });
+      await flushPromises();
+    });
+    expect(host.textContent).toContain('下载中 2%');
+    expect(host.textContent).not.toContain('下载中 22%');
+
+    // 旧流最终 Finished 时,downloadAppUpdate 内部会发 status:'ready'(percent:100)。
+    // 这同样是陈旧事件,必须被 attempt 令牌拦截——不能把界面翻成「下载中 100%」。
+    await act(async () => {
+      attempt1OnProgress({ status: 'ready', downloadedBytes: 100, totalBytes: 100, percent: 100 });
+      await flushPromises();
+    });
+    expect(host.textContent).toContain('下载中 2%');
+    expect(host.textContent).not.toContain('下载中 100%');
+
+    // 防 leak:放行两个挂起的下载 promise
+    resolveAttempt1();
+    resolveAttempt2();
   });
 
   // ISS-72：Rust 端抛网络错误应显示本地化文案（而非英文原文）。

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -171,6 +171,11 @@ export function AppLayout() {
   // ref 在 effect 依赖里不会触发重渲染，开关切回 on 时 useEffect 不会重跑。
   const [autoUpdateCheckStarted, setAutoUpdateCheckStarted] = useState(false);
   const updateDownloadVersionRef = useRef<string | null>(null);
+  // ISS-99：per-attempt 单调令牌。Tauri updater 的 update.download 无法中途取消,
+  // 超时/重试后旧尝试的 onProgress 仍挂在跑着的 Rust 下载流上,会继续发 Progress。
+  // version 守卫无法区分同版本的两次尝试,故用 attempt 令牌标识「当前有效尝试」,
+  // 新尝试开始后旧尝试的回调一律忽略事件,避免进度交错回退(1%→22%→2%→23%)。
+  const updateAttemptRef = useRef(0);
   // ISS-72：当前下载的取消句柄（虽然 Tauri JS SDK 不支持 abort，仅用于防御性
   // 重入 + 在 finally 中清理 ref，避免 stale controller 残留）。
   const downloadAbortRef = useRef<AbortController | null>(null);
@@ -482,6 +487,9 @@ export function AppLayout() {
     downloadAbortRef.current?.abort();
     const abort = new AbortController();
     downloadAbortRef.current = abort;
+    // ISS-99：本次尝试的令牌。新尝试(含重试)会 ++ 使旧令牌失效,
+    // 旧尝试的 onProgress/then/catch 见到 attemptId 不再匹配即丢弃事件。
+    const attemptId = ++updateAttemptRef.current;
     updateDownloadVersionRef.current = update.version;
     setUpdateState({ phase: 'downloading', source, update, percent: 0 });
 
@@ -493,7 +501,9 @@ export function AppLayout() {
     Promise.race([
       downloadAppUpdate(update.update, (p) => {
         if (abort.signal.aborted) return;
+        if (updateAttemptRef.current !== attemptId) return;
         setUpdateState((current) => {
+          if (updateAttemptRef.current !== attemptId) return current;
           if (current.phase !== 'downloading') return current;
           if (current.update.version !== update.version) return current;
           return { phase: 'downloading', source, update, percent: p.percent ?? current.percent ?? 0 };
@@ -503,7 +513,9 @@ export function AppLayout() {
     ])
       .then(() => {
         if (abort.signal.aborted) return;
+        if (updateAttemptRef.current !== attemptId) return;
         setUpdateState((current) => {
+          if (updateAttemptRef.current !== attemptId) return current;
           if (current.phase !== 'downloading') return current;
           if (current.update.version !== update.version) return current;
           return { phase: 'ready', source, update };
@@ -511,6 +523,9 @@ export function AppLayout() {
       })
       .catch((error) => {
         if (abort.signal.aborted) return;
+        // ISS-99：旧尝试的迟到错误不得覆盖新尝试的状态；此 return 必须早于下面
+        // updateDownloadVersionRef.current = null，否则会清掉当前有效尝试的去重守卫。
+        if (updateAttemptRef.current !== attemptId) return;
         updateDownloadVersionRef.current = null;
         setUpdateState({
           phase: 'error',


### PR DESCRIPTION
## 问题

Closes #99

自动更新下载超时后点击「重试」,进度出现非单调回退和交错(如 \`1% → 22% → 2% → 23%\`)。发生在 #72(下载卡死兜底 + 重试入口)之后。

## 根因

Tauri updater \`@tauri-apps/plugin-updater@2.10.1\` 的 \`update.download(onEvent)\` **没有取消参数**(已核对 \`dist-js/index.d.ts\`):一旦发起,Rust 侧下载会持续通过 Channel 向其 \`onEvent\` 回调发 \`Progress\` 事件,直到自然结束/出错。\`Promise.race\` 只赛跑 JS 侧 promise 的结算,不会停掉 Rust 侧下载。

超时 → 重试时,旧尝试#1 的 \`onEvent\` 回调仍挂在那条仍在跑的 Rust 下载流上,继续往同一个 \`downloading\` state 写进度。ISS-72 引入的三道守卫**在同版本重试时全部失效**:

| 守卫 | 失效原因 |
|---|---|
| \`abort.signal.aborted\` | 旧 \`AbortController\` 从未被 abort —— \`.finally\` 在 race 结算(含超时)时把 \`downloadAbortRef.current\` 置 null,重试时 \`downloadAbortRef.current?.abort()\` 是空操作 |
| \`current.phase !== 'downloading'\` | 重试已把 phase 重置回 \`downloading\` |
| \`current.update.version !== update.version\` | 重试目标版本相同(0.6.5),**无法区分同版本的两次尝试** ← 设计缺陷 |

于是尝试#1(~22%、23%)与尝试#2(1%、2%)交替写同一个 state → 交错回退,与 issue 描述完全吻合。

## 修复

引入**单调递增的 per-attempt 令牌** \`updateAttemptRef\`(即 issue 期望的「独立的任务标识」)。\`startBackgroundUpdateDownload\` 每次执行 \`++updateAttemptRef.current\` 并在闭包里捕获 \`attemptId\`;新尝试(含重试、自动检查、手动检查三条路径)开始后旧令牌失效,旧尝试的 \`onProgress\` / \`.then\` / \`.catch\` 见到 \`attemptId\` 不匹配即丢弃事件。保留原有 version/phase/abort 守卫作为 defense in depth。

产品代码改动仅 \`src/app/AppLayout.tsx\` 14 行(ref + attemptId + 6 处 stale 守卫)。

## 已知残留(本期不修)

Tauri 插件 API 不支持中途取消 \`update.download()\`,且重试复用同一 \`Update\` 对象(\`close()\` 会连带废掉重试),故旧 Rust 下载流会静默跑到自然结束,有短暂额外带宽,但**不影响 UI 正确性**。彻底取消需重试时重新 \`check()\` + close 旧 Update,属更大改动,本期不做(用户已确认最小修复范围)。

## 验证

- ✅ **集成回归测试**(权威行为验证):\`src/app/AppLayout.test.tsx\` 新增用例,挂载真实 \`AppLayout\` + mock 两次 \`downloadAppUpdate\`(attempt#1 发 10% 后挂起、attempt#2 发 1%/2%),超时 → 重试后**故意触发 attempt#1 的陈旧 22% 事件**,断言界面仍为「下载中 2%」且不出现「下载中 22%」。**修复前该断言失败**(state 被覆盖为 22%),修复后通过。
- ✅ typecheck 干净;\`eslint\` 干净。
- ✅ 全量单测 592/592 通过(含新用例,且 ISS-72 既有 4 个 update 用例不回归)。
- ✅ \`npm run build\` 生产构建通过。
- ⚠️ **真机精确复现:NOT_VERIFIED(不可行)**。受限于:(1) 当前 app 已处于目标版本 0.6.5,无待下载更新源;(2) race 需要可控的下载中途网络超时,无法按需制造;(3) 按 \`project-folia-realapp-verify\`,orca click 无法驱动 Folia WKWebView 交互、playwright e2e 以 \`isTauri=false\` 运行使更新流不激活。该代码库 web 交互的既定验证路径是真实组件单测,本 PR 的集成测试即挂载真实 \`AppLayout\` 并驱动精确 bug 条件,对这类非确定性 race 是比手动点击更强的证据。