### PR TITLE
fix(preview): 表格列宽改 auto + overflow-wrap:break-word，修长内容列挤塌短列 (DEC-131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **修复 Markdown 表格列宽被强制等分、长内容列把短内容列挤成逐字竖排导致行高过高的问题**：根因是编辑器（`src/styles/app.css`）与阅读预览（`src/styles/preview.css`）的表格规则同时设了 `table-layout: fixed`，而单元格用 `overflow-wrap: anywhere`——`fixed` 把所有列强制等宽（无视内容），`anywhere` 又把单元格最小宽度降到 1 字符。在「某一列内容远多于其它」的表格上（典型：`legal-skills/README.md` 的「最近更新的 Skill」表，5 列里「更新要点」内容极长），布局协商时长内容列吞掉几乎所有宽度，把短内容列（如 Skill 列的 `multica-skill-update`）挤成逐字竖排（`m/u/l/t/i/c/a...`），行高极高。改为 `table-layout: auto`（列宽按内容自适应，长内容列获得更多宽度）+ 单元格 `overflow-wrap: break-word`、`word-break: normal`（最小宽度回到「最长词」，不再塌缩到 1 字宽；CJK 由 `normal` 在任意两字间断行，超长 token 真放不下时仍会断行）。真机验证（`tauri dev` + orca computer-use 驱动 WKWebView，详见 [DEC-131](docs/DECISIONS.md)）：同一张「最近更新的 Skill」表，Skill 列链接由逐字竖排恢复为横向一行显示，「更新要点」列合理最宽（约 40-50%），行高正常。Word 纸张预览（`.word-paper-content table`，ISS-182 保真面）与微信预览（`wechatPreviewService` 注入 CSS）存在同根因，但属不同保真面、各有保真测试，本期未改，留作后续。同一次排查的另外两个问题（`<details>` 折叠失效、二维码不渲染）结论见 [DEC-131](docs/DECISIONS.md)：前者为 Vditor IR 已知限制（记为限制不强行修），后者在当前 main 已正常渲染（用户报告大概率来自早于 v0.6.3 的旧发布版）。
+
 ## [0.6.6] - 2026-08-05
 
 ### Added

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1255,7 +1255,11 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 .wysiwyg-editor-pane .vditor-wysiwyg .vditor-wysiwyg__preview table {
   width: 100%;
   max-width: 100%;
-  table-layout: fixed;
+  /* table-layout: auto：让列宽按内容自适应（内容密集列获得更多宽度，短列收窄），
+     避免 fixed 把所有列强制等宽、长内容列被挤到极窄导致行高过高。
+     溢出防护仍在单元格的 word-break / overflow-wrap（见下方 th/td 规则），
+     CJK 与超长 token 会换行，表格不会横向超出 100%。 */
+  table-layout: auto;
   border-collapse: collapse;
 }
 
@@ -1266,8 +1270,14 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 .wysiwyg-editor-pane .vditor-wysiwyg .vditor-wysiwyg__preview th,
 .wysiwyg-editor-pane .vditor-wysiwyg .vditor-wysiwyg__preview td {
   white-space: normal;
-  word-break: break-word;
-  overflow-wrap: anywhere;
+  /* word-break: normal + overflow-wrap: break-word（而非 anywhere）：
+     anywhere 会把单元格 min-content 降到 1 字符，table-layout:auto 协商时
+     让长内容兄弟列吞掉几乎所有宽度、把本列挤成逐字竖排（legal-skills README
+     的 Skill 列 `multica-skill-update` 曾因此变成 m/u/l/t/i/c/a...）。
+     break-word 保持 min-content = 最长词宽度，列不会被挤到 1 字宽；
+     超长 token 在真的放不下时仍会断行。CJK 由 normal 在任意两字间断行。 */
+  word-break: normal;
+  overflow-wrap: break-word;
 }
 
 .wysiwyg-editor-pane .folia-ir-svg-fragment-hidden {

--- a/src/styles/preview.css
+++ b/src/styles/preview.css
@@ -180,14 +180,17 @@
   color: var(--fg);
 }
 
-/* Tables - compact legal-document layout, overriding Vditor nowrap defaults */
+/* Tables - legal-document layout, overriding Vditor nowrap defaults.
+   table-layout: auto 让列宽按内容自适应（内容密集列获得更多宽度），避免 fixed
+   把所有列强制等宽、长内容列被挤到极窄导致行高过高。溢出仍由下方 th/td 的
+   word-break / overflow-wrap 兜底（超长 token 放不下时断行），表格不会横向超出 100%。 */
 .preview-content.vditor-reset table,
 .preview-content table {
   width: 100% !important;
   max-width: 100% !important;
   min-width: 0 !important;
   border-collapse: collapse;
-  table-layout: fixed !important;
+  table-layout: auto !important;
   margin: 16px 0;
   font-size: 14px;
   word-break: normal !important;
@@ -201,16 +204,17 @@
   padding: 8px 12px;
   vertical-align: top;
   white-space: normal !important;
-  word-break: break-word !important;
-  overflow-wrap: anywhere !important;
-  min-width: 0 !important;
+  /* break-word（非 anywhere）保持 min-content=最长词宽度，避免 auto 布局下
+     长内容列吞光宽度、把本列挤成逐字竖排。CJK 由 normal 在任意两字间断行。 */
+  word-break: normal !important;
+  overflow-wrap: break-word !important;
   max-width: 100%;
 }
 
 .preview-content.vditor-reset td *,
 .preview-content.vditor-reset th * {
   white-space: normal !important;
-  overflow-wrap: anywhere !important;
+  overflow-wrap: break-word !important;
 }
 
 .preview-content th {


### PR DESCRIPTION
## 背景

用户报告用 Folia 打开 \`legal-skills/README.md\` 有三个渲染问题。本 PR 修复其中**表格列宽**一项；另两项（\`<details>\` 折叠、二维码）的结论一并记录在 DEC-131（本地决策日志），见下。

## 改动（本 PR）

\`table-layout: fixed\` + 单元格 \`overflow-wrap: anywhere\` → \`table-layout: auto\` + \`overflow-wrap: break-word\`（+ \`word-break: normal\`），覆盖：

- \`src/styles/app.css\`：IR / WYSIWYG 编辑器（用户实际看到的渲染面）。
- \`src/styles/preview.css\`：阅读预览（\`PreviewPane\`，虽已无生产调用方，但同模式且仍有测试，一并修）。

**根因**：\`fixed\` 把所有列强制等宽（无视内容），\`anywhere\` 又把单元格最小宽度降到 1 字符。在「某一列内容远多于其它」的表格上（如本表的「更新要点」极长），布局协商时长内容列吞掉几乎所有宽度，把短内容列（Skill 列的 \`multica-skill-update\`）挤成逐字竖排 \`m/u/l/t/i/c/a...\`，行高极高。\`auto\` 让列宽按内容自适应；\`break-word\` 保持最小宽度 = 最长词（不再塌缩到 1 字宽），CJK 由 \`normal\` 在任意两字间断行，超长 token 真放不下时仍断行。

## 不在本 PR

- **Word 纸张预览**（\`.word-paper-content table\`，ISS-182 保真面）与**微信预览**（\`wechatPreviewService\` 注入 CSS）存在同根因，但属不同保真面、各有保真测试，本期未改，留作后续。
- **\`<details>\` 折叠失效**：Vditor IR 对「跨块 HTML 元素」的架构限制（\`<details>\` 开标签 / 内部 markdown 表格 / \`</details>\` 是 3 个独立 CommonMark 块，IR 各自隔离渲染 → 浏览器就地闭合孤立开标签 → 折叠体空壳、内容外露成兄弟）。无简单 CSS 修法，按用户决定记为已知限制。详见 DEC-131。
- **二维码不渲染**：当前 main（v0.6.6 dev）真机最小复现探针里 QR 完整渲染，README 的 a11y 也显示 \`<img>\` 在 DOM 且无错误 banner；相对路径图片解析在 main 早已修复（ISS-156 → ISS-187/DEC-129，含 v0.6.3）。用户报告大概率来自早于 v0.6.3 的旧发布版，升级即可，main 无需改动。

## 验证

- typecheck 干净；592/592 单测绿。
- 真机（\`tauri dev\` + orca computer-use 驱动 WKWebView）：同一张「最近更新的 Skill」表，Skill 列链接由逐字竖排恢复为横向一行，更新要点列合理最宽（~40-50%），行高正常。