### PR TITLE
fix(editor): 修复文档切换后滚动位置重置顶部 (#112)

### DIFF
--- a/e2e/scroll-restore.spec.ts
+++ b/e2e/scroll-restore.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * E2E: ISS-112 — 文档切换后滚动位置应按文档独立保存/恢复
+ *
+ * 背景：长文档滚到中间后，切到其他文档/标签再切回，scrollTop 重置到顶部。
+ * 根因：编辑器组件在 tab 切换时更新 source（CodeMirror）或销毁重建（Vditor），
+ * 滚动容器的 scrollTop 未按文档 ID 独立保存与恢复。
+ */
+import { expect, type Page, test } from '@playwright/test';
+
+/** 生成足够长的 markdown，确保编辑器出现可滚动区域。 */
+function makeLongDoc(lineCount: number): string {
+  const lines: string[] = [];
+  for (let i = 1; i <= lineCount; i++) {
+    lines.push(`## 标题 ${i}`, `这是第 ${i} 段的内容，${'测试内容'.repeat(20)}`, '');
+  }
+  return lines.join('\n');
+}
+
+async function coldStart(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await expect(page.locator('.recent-page')).toBeVisible({ timeout: 10_000 });
+}
+
+async function enterBlankEditor(page: Page): Promise<void> {
+  await page.locator('.recent-page-secondary').click();
+  await expect(page.locator('.wysiwyg-editor-pane')).toBeVisible({ timeout: 10_000 });
+}
+
+async function switchToSourceMode(page: Page): Promise<void> {
+  await page.getByRole('button', { name: '源码模式' }).click();
+  await expect(page.locator('.cm-editor')).toBeVisible({ timeout: 5_000 });
+}
+
+test.describe('ISS-112: 滚动位置按文档独立保存与恢复', () => {
+  test('源码模式：滚到中间 → 切新标签 → 切回，scrollTop 不重置为 0', async ({ page }) => {
+    await coldStart(page);
+    await enterBlankEditor(page);
+    await switchToSourceMode(page);
+
+    // 插入长文档使编辑器可滚动
+    await page.locator('.cm-content').click();
+    await page.keyboard.insertText(makeLongDoc(80));
+    await expect(page.locator('.cm-content')).toContainText('标题 80');
+
+    // 等待 CodeMirror 渲染完成（确保 scrollHeight 足够）
+    await page.waitForTimeout(100);
+
+    // 滚动到已知位置
+    const targetScroll = 500;
+    await page.locator('.cm-scroller').evaluate((el, top) => {
+      el.scrollTop = top;
+      el.dispatchEvent(new Event('scroll', { bubbles: true }));
+    }, targetScroll);
+
+    const scrolled = await page.locator('.cm-scroller').evaluate((el) => el.scrollTop);
+    expect(scrolled).toBeGreaterThan(200);
+
+    // 切到新标签（TabBar「+」→ 欢迎页占位标签）
+    await page.locator('.tabbar-new').click();
+    await expect(page.locator('.recent-page')).toBeVisible();
+
+    // 切回第一个标签
+    await page.locator('.tabbar-tab').first().click();
+    await expect(page.locator('.cm-editor')).toBeVisible({ timeout: 5_000 });
+    // 等待编辑器内容渲染 + 滚动恢复逻辑
+    await page.waitForTimeout(300);
+
+    const restored = await page.locator('.cm-scroller').evaluate((el) => el.scrollTop);
+    // 核心断言：恢复后的 scrollTop 不应是 0，且接近原滚动位置
+    expect(restored).toBeGreaterThan(200);
+  });
+
+  test('所见即所得模式：滚到中间 → 切新标签 → 切回，scrollTop 不重置为 0', async ({ page }) => {
+    // Vditor IR 模式下的实际滚动容器是 .vditor-ir > .vditor-reset（<pre> 元素，
+    // height:100% + overflow:auto）。其他 .vditor-reset（SV 模式 / preview 面板）
+    // 不是编辑器主滚动区。
+    const irScroller = page.locator('.wysiwyg-editor-pane .vditor-ir > .vditor-reset').first();
+
+    await coldStart(page);
+    await enterBlankEditor(page);
+
+    // 等 Vditor IR 初始化
+    await expect(page.locator('.wysiwyg-editor-pane .vditor-ir')).toBeVisible({ timeout: 10_000 });
+    await expect(irScroller).toBeVisible({ timeout: 5_000 });
+
+    // 插入长文档
+    await irScroller.click();
+    await page.keyboard.insertText(makeLongDoc(60));
+    await expect(irScroller).toContainText('标题 60');
+    await page.waitForTimeout(200);
+
+    // 滚动到已知位置
+    const targetScroll = 400;
+    await irScroller.evaluate((el, top) => {
+      el.scrollTop = top;
+      el.dispatchEvent(new Event('scroll', { bubbles: true }));
+    }, targetScroll);
+
+    const scrolled = await irScroller.evaluate((el) => el.scrollTop);
+    expect(scrolled).toBeGreaterThan(100);
+
+    // 切到新标签
+    await page.locator('.tabbar-new').click();
+    await expect(page.locator('.recent-page')).toBeVisible();
+
+    // 切回
+    await page.locator('.tabbar-tab').first().click();
+    await expect(page.locator('.wysiwyg-editor-pane')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.wysiwyg-editor-pane .vditor-ir')).toBeVisible({ timeout: 10_000 });
+    await expect(irScroller).toBeVisible({ timeout: 5_000 });
+    // Vditor 初始化是异步的，给足恢复时间
+    await page.waitForTimeout(600);
+
+    const restored = await irScroller.evaluate((el) => el.scrollTop);
+    expect(restored).toBeGreaterThan(100);
+  });
+
+  test('两篇不同文档各自保持独立滚动位置', async ({ page }) => {
+    await coldStart(page);
+    await enterBlankEditor(page);
+    await switchToSourceMode(page);
+
+    // 文档 A
+    await page.locator('.cm-content').click();
+    await page.keyboard.insertText(makeLongDoc(100));
+    await page.waitForTimeout(100);
+    await page.locator('.cm-scroller').evaluate((el) => {
+      el.scrollTop = 600;
+      el.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+    const scrollA = await page.locator('.cm-scroller').evaluate((el) => el.scrollTop);
+    expect(scrollA).toBeGreaterThan(300);
+
+    // 新建第二个标签 → 第二篇文档
+    await page.locator('.tabbar-new').click();
+    await expect(page.locator('.recent-page')).toBeVisible();
+    await page.locator('.recent-page-secondary').click();
+    await expect(page.locator('.wysiwyg-editor-pane')).toBeVisible({ timeout: 10_000 });
+    await switchToSourceMode(page);
+
+    await page.locator('.cm-content').click();
+    await page.keyboard.insertText(makeLongDoc(120));
+    await page.waitForTimeout(100);
+    await page.locator('.cm-scroller').evaluate((el) => {
+      el.scrollTop = 900;
+      el.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+    const scrollB = await page.locator('.cm-scroller').evaluate((el) => el.scrollTop);
+    expect(scrollB).toBeGreaterThan(500);
+
+    // 切回第一个标签 → 应恢复 A 的位置（约 600），而非 B 的（约 900）
+    await page.locator('.tabbar-tab').first().click();
+    await expect(page.locator('.cm-editor')).toBeVisible({ timeout: 5_000 });
+    await page.waitForTimeout(300);
+
+    const restoredA = await page.locator('.cm-scroller').evaluate((el) => el.scrollTop);
+    expect(restoredA).toBeGreaterThan(300);
+    // A 和 B 的恢复位置不应相同（独立保存）
+    expect(Math.abs(restoredA - scrollB)).toBeGreaterThan(100);
+  });
+});

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { createEmptyFile, type TocItem } from '../types/document';
@@ -131,6 +131,34 @@ const UPDATE_DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
 // 故把 TOC 刷新防抖到输入停顿后执行（ISS-159）。文件内容本身仍每键同步落盘/保存。
 const TOC_REFRESH_DEBOUNCE_MS = 150;
 
+// ISS-112：切回文档时恢复滚动位置的重试次数。编辑器（CodeMirror / Vditor）在
+// tab 切换或从欢迎页切回时会重建滚动容器，内容渲染到 scrollHeight 足以容纳目标
+// scrollTop 可能需要数帧（Vditor 异步初始化 + 动态 import）。20 帧 ≈ 330ms @60fps
+// 覆盖典型初始化耗时；超出后放弃恢复，避免无限重试。
+const SCROLL_RESTORE_MAX_ATTEMPTS = 20;
+// 恢复精度容差（px）：当 |scrollTop - target| <= 此值时视为恢复成功。浏览器可能
+// 将 scrollTop 量化到设备像素边界，精确比较会误判失败。
+const SCROLL_RESTORE_TOLERANCE_PX = 4;
+
+/**
+ * ISS-112：查找主内容区当前编辑器的实际滚动容器。
+ *
+ * - 源码模式：CodeMirror 6 的 `.cm-scroller`（唯一、稳定）。
+ * - 所见即所得模式：Vditor IR 模式 `.vditor-ir > .vditor-reset`（`<pre>` 元素，
+ *   Vditor 自带 CSS 给它 `height:100%; overflow:auto`）。不用泛化的
+ *   `.vditor-reset`——Vditor 内部还有 SV 模式 / preview 面板的 `.vditor-reset`，
+ *   会匹配到错误元素。
+ *
+ * 返回 null 表示编辑器尚未挂载（如正在加载 lazy chunk 或停在欢迎页）。
+ */
+function findEditorScroller(root: HTMLElement): HTMLElement | null {
+  const cmScroller = root.querySelector<HTMLElement>('.cm-scroller');
+  if (cmScroller) return cmScroller;
+  const irScroller = root.querySelector<HTMLElement>('.vditor-ir > .vditor-reset');
+  if (irScroller) return irScroller;
+  return null;
+}
+
 // ISS-72 / ISS-84：把 Rust 端原始错误分类映射到本地化文案。fallback 仍展示原文便于排查。
 // 归类逻辑与检查更新路径共用 updateService.categorizeUpdateError（#84 要求三条路径共用一套）。
 function toUpdateErrorMessage(
@@ -182,6 +210,15 @@ export function AppLayout() {
   const mainContentRef = useRef<HTMLDivElement>(null);
   // 防抖挂起的 TOC 刷新定时器；卸载时清掉，避免 stale setToc（ISS-159）。
   const tocRefreshTimerRef = useRef<number | null>(null);
+  // ISS-112：per-tab scrollTop 缓存（tabId → scrollTop）。不持久化——仅运行期
+  // 在当前窗口内有效，重启 / 跨窗口 tear-off 不传递（跨窗口 scroll 恢复属后续增强）。
+  const scrollPositionsRef = useRef<Map<string, number>>(new Map());
+  // 当前正在跟踪滚动位置的 tabId（通常 = activeTabId，但放在 ref 中让 scroll
+  // 监听器——只绑定一次——始终读到最新值，无需随 tab 切换重新 add/remove listener）。
+  const trackedTabIdRef = useRef<string>('');
+  // 恢复期间抑制 scroll 事件写回缓存。编辑器在 tab 切换时会通过 setValue / 重建
+  // 触发 scrollTop 归零的 scroll 事件，若不抑制会把目标 tab 的缓存覆盖为 0。
+  const suppressScrollSaveRef = useRef(false);
   // 取消挂起的 TOC 防抖刷新：打开新文件 / 卸载时调用，避免上一个文件的过期 setToc 覆盖新文件大纲（ISS-159）。
   const cancelPendingTocRefresh = useCallback(() => {
     if (tocRefreshTimerRef.current !== null) {
@@ -295,6 +332,111 @@ export function AppLayout() {
   useEffect(() => {
     cancelPendingTocRefresh();
   }, [activeTabId, cancelPendingTocRefresh]);
+
+  // ISS-112：在 useLayoutEffect（早于任何 useEffect）中同步更新 trackedTabIdRef
+  // 并抑制 scroll 写回。关键时序：子组件（EditorPane / WysiwygEditorPane）的
+  // [source] / [filePath] useEffect 会调用 setValue / 重建 Vditor，使 scrollTop
+  // 归零。useLayoutEffect 在所有 useEffect 之前跑（React 保证 layout effect 先于
+  // passive effect），故 suppress 会在 setValue 的 scroll-to-0 事件之前生效。
+  useLayoutEffect(() => {
+    if (!activeTabId) return;
+    const isInitial = trackedTabIdRef.current === '';
+    trackedTabIdRef.current = activeTabId;
+    // 首次挂载无 scroll 位置可恢复，不需要抑制；只在 tab 切换时抑制。
+    if (!isInitial) {
+      suppressScrollSaveRef.current = true;
+    }
+  }, [activeTabId]);
+
+  // ISS-112：编辑器滚动位置的 per-tab 持续跟踪。
+  // 在 mainContentRef 上以 capture 阶段监听 scroll 事件（scroll 事件不冒泡，但 capture
+  // 阶段可以在祖先上捕获后代 scroller 的事件）。监听器只绑定一次（空依赖），通过 ref
+  // 读取最新的 trackedTabId，避免随 tab 切换反复 add/remove listener。
+  useEffect(() => {
+    const root = mainContentRef.current;
+    if (!root) return;
+
+    const handleScroll = () => {
+      if (suppressScrollSaveRef.current) return;
+      const scroller = findEditorScroller(root);
+      if (!scroller) return;
+      scrollPositionsRef.current.set(trackedTabIdRef.current, scroller.scrollTop);
+    };
+
+    root.addEventListener('scroll', handleScroll, { capture: true, passive: true });
+    return () => root.removeEventListener('scroll', handleScroll, { capture: true as const });
+  }, []);
+
+  // ISS-112：tab 切换时恢复目标 tab 的滚动位置。
+  // 时序要点：
+  //   1. render 阶段（上方 if 分支）已把 trackedTabIdRef 更新为新 activeTabId 并把
+  //      suppressScrollSaveRef 设为 true——这一步早于任何 useEffect，确保子组件
+  //      [source] / [filePath] effect 中 setValue 触发的 scroll-to-0 事件不会污染缓存。
+  //   2. 本 effect deps=[activeTabId]，在子组件 effect 之后跑（React 保证子 effect
+  //      先于父 effect），此时编辑器已对新内容执行 setValue / 重建，scrollTop 已归零。
+  //   3. 滚动容器可能尚未就绪（编辑器从欢迎页切回时是重新挂载，lazy chunk 需要几帧
+  //      加载），故用 rAF 重试直到 scrollTop 生效或超出 SCROLL_RESTORE_MAX_ATTEMPTS。
+  useEffect(() => {
+    const targetTop = scrollPositionsRef.current.get(activeTabId) ?? 0;
+
+    // 无缓存（首次打开该 tab）或目标本就是顶部 → 无需恢复，直接放行 scroll 监听。
+    if (targetTop === 0) {
+      suppressScrollSaveRef.current = false;
+      return;
+    }
+
+    let cancelled = false;
+    let rafId = 0;
+    let attempts = 0;
+
+    const tryRestore = () => {
+      if (cancelled) return;
+      const root = mainContentRef.current;
+      if (!root) {
+        if (++attempts < SCROLL_RESTORE_MAX_ATTEMPTS) {
+          rafId = window.requestAnimationFrame(tryRestore);
+        } else {
+          suppressScrollSaveRef.current = false;
+        }
+        return;
+      }
+      const scroller = findEditorScroller(root);
+      if (!scroller) {
+        // 编辑器尚未挂载（lazy chunk 加载中 / 欢迎页占位）。重试。
+        if (++attempts < SCROLL_RESTORE_MAX_ATTEMPTS) {
+          rafId = window.requestAnimationFrame(tryRestore);
+        } else {
+          suppressScrollSaveRef.current = false;
+        }
+        return;
+      }
+      scroller.scrollTop = targetTop;
+      // 检查是否生效。内容尚未渲染到足够 scrollHeight 时 scrollTop 会被钳制在
+      // maxScroll 以下，需重试直到内容渲染完成。
+      if (Math.abs(scroller.scrollTop - targetTop) <= SCROLL_RESTORE_TOLERANCE_PX) {
+        suppressScrollSaveRef.current = false;
+        return;
+      }
+      if (++attempts >= SCROLL_RESTORE_MAX_ATTEMPTS) {
+        suppressScrollSaveRef.current = false;
+        return;
+      }
+      rafId = window.requestAnimationFrame(tryRestore);
+    };
+
+    rafId = window.requestAnimationFrame(tryRestore);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+      // 注意：此处不释放 suppressScrollSaveRef。若 tab 快速连切（A→B→C），A 的
+      // effect cleanup 取消 A 的 rAF 后，render 阶段已把 suppress 设为 true（B 的
+      // render 先于本 cleanup）。若 cleanup 释放了 suppress，A→B 之间的 setValue
+      // scroll 事件可能在 B 的 effect body 跑之前被监听器捕获。保持 suppress=true
+      // 直到新 effect body 覆盖它更安全。组件卸载时监听器也一并拆除，suppress
+      // 残留无副作用。
+    };
+  }, [activeTabId]);
 
   useEffect(() => {
     /* ISS-180 闭合：SettingsPage 外壳已静态导入。挂载时仅预热 7 个非默认


### PR DESCRIPTION
## 摘要

**根因**：tab 切换时编辑器组件（CodeMirror / Vditor）会对新内容执行 `setValue`（源码模式）或整体销毁重建（所见即所得模式，`[filePath]` dep 触发 Vditor re-init），滚动容器（`.cm-scroller` / `.vditor-reset`）的 `scrollTop` 被重置为 0，且未按文档 / tab ID 独立保存恢复。

**Fix 方案**：在 `AppLayout` 中加入 per-tab `scrollTop` 缓存（`Map<tabId, number>`，内存态、不持久化）：

1. **持续跟踪**：在 `mainContentRef` 上以 capture 阶段监听 `scroll` 事件（scroll 事件不冒泡，但 capture 阶段可在祖先上捕获），每次 scroll 把 `scrollTop` 归属到当前 `activeTabId`（trackedTabIdRef）。
2. **切换抑制**：`useLayoutEffect` 在 tab 切换时（早于子组件 `useEffect`）立即把 `suppressScrollSaveRef` 设为 `true`，防止子组件 `setValue` / Vditor 重建触发的 `scroll-to-0` 事件把目标 tab 的缓存覆盖为 0。
3. **rAF 重试恢复**：`useEffect`（在子组件 `setValue` 完成后）从缓存读取目标 `scrollTop`，用 `requestAnimationFrame` 重试设置（最多 20 帧 ≈ 330ms），覆盖以下时序窗口：
   - 编辑器从欢迎页切回时重新挂载，lazy chunk 需要数帧加载；
   - CodeMirror / Vditor 内容异步渲染，`scrollHeight` 逐步增长到足以容纳目标 `scrollTop`。
4. **滚动容器识别**：
   - 源码模式：`.cm-scroller`（CodeMirror 6 scroller）；
   - 所见即所得：`.vditor-ir > .vditor-reset`（Vditor IR `<pre>` 元素，Vditor CSS 给 `height:100%; overflow:auto`），不用泛化的 `.vditor-reset`（会误匹配 SV 模式 / preview 面板）。

## 测试计划

### 自动化（全部通过）

| 命令 | 结果 |
|------|------|
| `npm run typecheck` | ✅ pass |
| `npm run lint` | ✅ pass |
| `npm run test`（vitest 单元） | ✅ 597 passed (60 files) |
| `npm run build` | ✅ built in 536ms |
| `npm run test:e2e -- scroll-restore` | ✅ 3 passed（源码模式 / 所见即所得 / 两文档独立） |

### 回归 e2e（确认不退化）

| Spec | 结果 |
|------|------|
| `mermaid-ir-renders.spec.ts` | ✅ 1 passed |
| `rich-media-cross-surface.spec.ts` | ✅ included in below |
| `rich-media-fixture-matrix.spec.ts` | ✅ 9 passed |

### e2e 用例文件

`e2e/scroll-restore.spec.ts`：3 个测试
1. 源码模式：滚到中间 → 切新标签 → 切回，`scrollTop` 不重置为 0；
2. 所见即所得模式：同上；
3. 两篇不同文档各自保持独立滚动位置（切 A→B→A，恢复值 ≈ A 的原始滚动位置且 ≠ B 的）。

## Agent 归属

PM Wave-1 W1 / claude-code / glm-5.2

## 关联

Closes #112
Refs DEC-135

## 风险

- **滚动性能**：capture 阶段 scroll 监听器在每个 scroll 帧执行一次 `Map.set`（O(1)，passive listener 不阻塞渲染）；与既有的 TOC active-heading scroll 监听（`AppLayout.tsx` 已有同款模式）叠加，每帧两次轻量操作，可忽略。
- **内存占用**：`Map<tabId, number>` 每项 ≈ 50 bytes，典型 10 个 tab ≈ 500 bytes；关闭 tab 后不主动清理（key 残留），但上限为历史 tab 总数，可忽略。
- **Tab 切换时序**：`useLayoutEffect` 设 suppress 早于子组件 `useEffect` 中的 `setValue`；`useEffect` 恢复在子组件 `setValue` 之后（React 保证子 effect 先于父 effect）。快速连切（A→B→C）时 A 的 rAF 被 cleanup 取消，B 的 render 阶段已重设 suppress=true，不会出现 suppress 真空窗口。跨窗口 tear-off 不传递 scroll 缓存（`scrollPositionsRef` 为 per-AppLayout 实例），属后续增强。