### PR TITLE
feat(editor): 代码块悬停复制按钮（主 IR + HTML 预览，无 MutationObserver）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes of this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- **代码块复制按钮（ISS-190）**：主编辑器（即时渲染 IR）与 HTML 预览面板的代码块（`<pre><code>`）在鼠标悬停时，右上角淡入「复制」按钮，点击把代码纯文本写入剪贴板，并在 ~1.5s 内显示「已复制」反馈后复位。复制走 `clipboardService.writeText`（`navigator.clipboard.writeText` 优先，失败降级 `document.execCommand('copy')`）。**挂载方式铁律**：新增 `codeBlockCopyService` **绝不使用 MutationObserver**——仅用 `mouseover/mouseout` 事件委托 + `scroll`（capture）+ `ResizeObserver` 按 `getBoundingClientRect` 做几何跟随定位；按钮挂在独立的 overlay 层（与编辑器 host / 预览 article-shell 同级），**绝不进入 Vditor IR DOM**，避免被 `editor.getValue()` 经 Lute 反序列化写回 markdown 污染文档、或被 sanitize 重写。富媒体（mermaid/echarts/math 等异步渲染语言）重渲染把当前代码块替换掉时，下一次几何重算发现 `pre.isConnected === false` 自动隐藏按钮，不残留、不抖动；mermaid 等图表块本身不出复制按钮（避免复制出 SVG 标记）。Word 纸张预览面不含按钮（仅文本面）。新增 `codeBlockCopyService` 14 项单测（hover 出现 / 点击复制 / 反馈复位 / 富媒体重渲染不残留 / 静态断言无 `new MutationObserver`）+ `WysiwygEditorPane` 2 项集成测试。验收门：typecheck / lint / 613 单测 / build 全绿。**真机验证（NOT_VERIFIED）**：WKWebView 内 hover 淡入与几何跟随的真实观感、真实剪贴板写入须在 `tauri dev` 下由真机确认；jsdom 下 `getBoundingClientRect` 全零，单测通过 mock 固定矩形覆盖定位逻辑。
 
 ## [0.6.7] - 2026-08-12
 

--- a/src/components/WechatPreviewPane.tsx
+++ b/src/components/WechatPreviewPane.tsx
@@ -19,6 +19,7 @@ import type { HtmlExportPresetId } from '../services/htmlExportPresets';
 import { resolveLocalImages } from '../services/localImageResolver';
 import { prepareMarkdownForVditorPreview } from '../services/markdownSvgPreviewService';
 import { createRenderCoordinator, type RenderDiagnostic } from '../services/renderCoordinator';
+import { attachCodeBlockCopy, type CodeCopyLabels } from '../services/codeBlockCopyService';
 import { MediaPlaceholder } from './MediaPlaceholder';
 
 type WechatPreviewPaneProps = {
@@ -39,6 +40,11 @@ export function WechatPreviewPane({ source, fileName = 'document.md', onClose, f
   const t = (key: Parameters<typeof translate>[1]) => translate(settings.locale, key);
   const deferredSource = useDeferredValue(source);
   const renderRef = useRef<HTMLDivElement>(null);
+  // ISS-190：代码块复制按钮。scrollRef 为事件委托 + scroll 跟随根；
+  // codeCopyOverlayRef 是与 article-shell 同级的 overlay 层（按钮 append 入此，
+  // 不进入 article-shell 的 dangerouslySetInnerHTML，避免被重渲染清掉）。
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const codeCopyOverlayRef = useRef<HTMLDivElement>(null);
   const renderIdRef = useRef(0);
   const [previewResult, setPreviewResult] = useState<WechatPreviewResult | null>(null);
   const [actionStatus, setActionStatus] = useState<ActionStatus | null>(null);
@@ -153,6 +159,29 @@ export function WechatPreviewPane({ source, fileName = 'document.md', onClose, f
       abortController.abort();
     };
   }, [deferredSource, fileName, filePath, htmlExportPreset, markdownPreviewInput, renderFeatures.hasHighlightableCode, sourceIsEmpty]);
+
+  /* ISS-190：代码块复制按钮（HTML 预览面）。
+   * 挂载方式铁律：attachCodeBlockCopy 绝不使用 MutationObserver（详见 service 顶部），
+   * 仅 mouseover/mouseout 委托 + scroll(capture) + ResizeObserver 几何跟随。Word 纸张
+   * 预览面不含按钮（仅文本面）。root 为滚动容器，overlay 为与 article-shell 同级的层，
+   * 按钮 append 到 overlay，不进入 article-shell 的 dangerouslySetInnerHTML（重渲染会清空）。*/
+  const codeCopyLabels = useMemo<CodeCopyLabels>(
+    // 直接用 translate + settings.locale 作为依赖，避免依赖本组件内每次渲染都新建的 t 函数
+    // （否则 attach effect 会在每次渲染重跑，反复解绑 / 重绑按钮）。
+    () => ({
+      buttonTitle: translate(settings.locale, 'codeBlockCopyLabel'),
+      defaultText: translate(settings.locale, 'codeBlockCopyDefault'),
+      copiedText: translate(settings.locale, 'codeBlockCopied'),
+      failedText: translate(settings.locale, 'codeBlockCopyFailed'),
+    }),
+    [settings.locale],
+  );
+  useEffect(() => {
+    const root = scrollRef.current;
+    const overlay = codeCopyOverlayRef.current;
+    if (!root || !overlay) return undefined;
+    return attachCodeBlockCopy(root, overlay, codeCopyLabels);
+  }, [codeCopyLabels]);
 
   const effectiveStatus = sourceIsEmpty ? 'empty' : status;
   const effectiveActionStatus = sourceIsEmpty ? null : actionStatus;
@@ -271,7 +300,7 @@ export function WechatPreviewPane({ source, fileName = 'document.md', onClose, f
           </ul>
         </div>
       )}
-      <div className="wechat-preview-scroll">
+      <div ref={scrollRef} className="wechat-preview-scroll">
         {effectiveStatus === 'empty' ? (
           <div className="wechat-preview-empty">{t('wechatPreviewEmpty')}</div>
         ) : effectiveStatus === 'loading' && !previewResult ? (
@@ -302,6 +331,9 @@ export function WechatPreviewPane({ source, fileName = 'document.md', onClose, f
         )}
       </div>
       <div ref={renderRef} className="wechat-preview-render-source" aria-hidden="true" />
+      {/* ISS-190：代码块复制按钮 overlay（pointer-events:none，按钮自身 auto）。
+          不进入 article-shell，避免被 dangerouslySetInnerHTML 重渲染清空。 */}
+      <div ref={codeCopyOverlayRef} className="folia-code-copy-overlay" aria-hidden="true" />
     </aside>
   );
 }

--- a/src/components/WysiwygEditorPane.test.tsx
+++ b/src/components/WysiwygEditorPane.test.tsx
@@ -1463,3 +1463,115 @@ describe('WysiwygEditorPane 标题光标漂移 + 复制残留 marker (ISS-106 / 
     });
   });
 });
+
+describe('WysiwygEditorPane 代码块复制按钮 (ISS-190)', () => {
+  let host: HTMLDivElement;
+
+  beforeEach(() => {
+    vditorCalls.length = 0;
+    setValueCalls.length = 0;
+    focusCalls.length = 0;
+    host = document.createElement('div');
+    document.body.append(host);
+  });
+
+  afterEach(() => {
+    host.remove();
+    vi.clearAllMocks();
+  });
+
+  /** jsdom 的 getBoundingClientRect 全零返回，会让 service 的「滚出可视区」判定误隐藏按钮。
+   *  这里给指定元素挂一个落在可视区内的固定矩形。 */
+  function mockRect(el: Element, rect: { top: number; bottom: number; left: number; right: number }): void {
+    el.getBoundingClientRect = () => ({
+      top: rect.top, bottom: rect.bottom, left: rect.left, right: rect.right,
+      width: rect.right - rect.left, height: rect.bottom - rect.top,
+      x: rect.left, y: rect.top, toJSON: () => {},
+    });
+  }
+
+  it('hover 主 IR 内代码块 → overlay 出现 is-visible 复制按钮，按钮不进入 IR DOM', async () => {
+    let root: Root | null = null;
+    await act(async () => {
+      root = createRoot(host);
+      root.render(
+        renderWithProvider(
+          React.createElement(WysiwygEditorPane, { source: '', onChange: () => undefined }),
+        ),
+      );
+      await flushMicrotasks();
+      await flushFrames();
+    });
+
+    const call = vditorCalls[0];
+    // overlay 是 host 的同级元素（.wysiwyg-editor-pane 的子节点），按钮会 append 到此
+    const pane = call.host.parentElement as HTMLElement;
+    const overlay = pane.querySelector<HTMLElement>('.folia-code-copy-overlay');
+    expect(overlay).not.toBeNull();
+    mockRect(overlay!, { top: 0, left: 0, right: 800, bottom: 600 });
+
+    // 在 IR DOM 注入一个普通代码块
+    const ir = call.host.querySelector<HTMLElement>('.vditor-ir pre')!;
+    const codePre = document.createElement('pre');
+    codePre.innerHTML = '<code class="language-js">const z = 3;</code>';
+    ir.appendChild(codePre);
+    mockRect(codePre, { top: 100, left: 40, right: 760, bottom: 220 });
+
+    await act(async () => {
+      codePre.querySelector('code')!.dispatchEvent(
+        new MouseEvent('mouseover', { bubbles: true }),
+      );
+      await flushMicrotasks();
+    });
+
+    const button = overlay!.querySelector<HTMLButtonElement>('.folia-code-copy-trigger');
+    expect(button).not.toBeNull();
+    expect(button!.classList.contains('is-visible')).toBe(true);
+    // 铁律：按钮在 overlay 内，绝不残留在 IR DOM（不污染 getValue / sanitize）
+    expect(ir.querySelector('.folia-code-copy-trigger')).toBeNull();
+    expect(call.host.querySelector('.folia-code-copy-trigger')).toBeNull();
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+
+  it('hover mermaid 块 → 按钮不显示（异步渲染语言被排除）', async () => {
+    let root: Root | null = null;
+    await act(async () => {
+      root = createRoot(host);
+      root.render(
+        renderWithProvider(
+          React.createElement(WysiwygEditorPane, { source: '', onChange: () => undefined }),
+        ),
+      );
+      await flushMicrotasks();
+      await flushFrames();
+    });
+
+    const call = vditorCalls[0];
+    const pane = call.host.parentElement as HTMLElement;
+    const overlay = pane.querySelector<HTMLElement>('.folia-code-copy-overlay')!;
+    mockRect(overlay, { top: 0, left: 0, right: 800, bottom: 600 });
+
+    const ir = call.host.querySelector<HTMLElement>('.vditor-ir pre')!;
+    const codePre = document.createElement('pre');
+    codePre.innerHTML = '<code class="language-mermaid">graph TD\nA-->B</code>';
+    ir.appendChild(codePre);
+    mockRect(codePre, { top: 100, left: 40, right: 760, bottom: 220 });
+
+    await act(async () => {
+      codePre.querySelector('code')!.dispatchEvent(
+        new MouseEvent('mouseover', { bubbles: true }),
+      );
+      await flushMicrotasks();
+    });
+
+    const button = overlay.querySelector<HTMLButtonElement>('.folia-code-copy-trigger');
+    expect(button?.classList.contains('is-visible')).toBe(false);
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+});

--- a/src/components/WysiwygEditorPane.tsx
+++ b/src/components/WysiwygEditorPane.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MediaPlaceholder } from './MediaPlaceholder';
+import { attachCodeBlockCopy, type CodeCopyLabels } from '../services/codeBlockCopyService';
 import type { RenderDiagnostic } from '../services/renderCoordinator';
 import { VDITOR_PREVIEW_I18N } from '../services/vditorPreviewConfig';
 import {
@@ -633,6 +634,10 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
   );
   const imageAssetStore = useImageAssetStore();
   const hostRef = useRef<HTMLDivElement>(null);
+  // ISS-190：代码块复制按钮 overlay 层（与 host 同级，在 pane 内）。
+  // 按钮由 codeBlockCopyService append 到此 div，**绝不进入 Vditor IR DOM**，
+  // 避免 editor.getValue() 经 Lute 反序列化把按钮写回 markdown 污染文档。
+  const codeCopyOverlayRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<import('vditor').default | null>(null);
   const applyingExternalValue = useRef(false);
   const latestSource = useRef(source);
@@ -1387,6 +1392,32 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
     };
   }, [onViewComplexTable, source, t]);
 
+  /* ISS-190：代码块复制按钮（主 IR）。
+   *
+   * 挂载方式铁律：本 effect 调用的 attachCodeBlockCopy **绝不使用 MutationObserver**，
+   * 仅用 mouseover/mouseout 委托 + scroll(capture) + ResizeObserver 做几何跟随（详见
+   * codeBlockCopyService 顶部说明）。按钮挂在与 host 同级的 overlay 层，不进入 Vditor
+   * IR DOM，避免污染 editor.getValue() 的 Lute 反序列化结果。
+   *
+   * labels 随 locale 变化时重新挂载（cleanup 移除旧按钮 / 监听）。host 与 overlay 均
+   * 由 ref 持有，挂载后稳定；首次 render 后即可 attach——Vditor 未就绪时无 pre>code，
+   * 按钮 simply 永不显示，待 Vditor 渲染出代码块后 mouseover 自动命中。 */
+  const codeCopyLabels = useMemo<CodeCopyLabels>(
+    () => ({
+      buttonTitle: t('codeBlockCopyLabel'),
+      defaultText: t('codeBlockCopyDefault'),
+      copiedText: t('codeBlockCopied'),
+      failedText: t('codeBlockCopyFailed'),
+    }),
+    [t],
+  );
+  useEffect(() => {
+    const host = hostRef.current;
+    const overlay = codeCopyOverlayRef.current;
+    if (!host || !overlay) return undefined;
+    return attachCodeBlockCopy(host, overlay, codeCopyLabels);
+  }, [codeCopyLabels]);
+
   // 错误状态：显示可见的错误信息和重试按钮
   if (phase === 'error') {
     return (
@@ -1422,6 +1453,9 @@ export function WysiwygEditorPane({ source, onChange, onViewComplexTable, filePa
         </div>
       )}
       <div ref={hostRef} className="wysiwyg-editor-host" />
+      {/* ISS-190：代码块复制按钮 overlay。pointer-events:none 让鼠标穿透到 IR DOM；
+          按钮自身 pointer-events:auto 由 CSS 控制。绝不进入 host 内的 IR DOM。 */}
+      <div ref={codeCopyOverlayRef} className="folia-code-copy-overlay" aria-hidden="true" />
     </div>
   );
 }

--- a/src/services/codeBlockCopyService.test.ts
+++ b/src/services/codeBlockCopyService.test.ts
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  attachCodeBlockCopy,
+  findCopyableCodeBlock,
+  isAsyncRenderCodeBlock,
+  CODE_COPY_TRIGGER_CLASS,
+  CODE_COPY_TRIGGER_VISIBLE_CLASS,
+  CODE_COPY_TRIGGER_COPIED_CLASS,
+  type CodeCopyLabels,
+} from './codeBlockCopyService';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+vi.mock('./clipboardService', () => ({
+  // 默认解析为 'native'，表示 navigator.clipboard.writeText 成功
+  writeText: vi.fn().mockResolvedValue('native'),
+}));
+
+// 测试期间把 rAF 设为同步执行，避免 jsdom / fake timer 下 rAF 不触发的 flake。
+let rafCount = 0;
+
+const LABELS: CodeCopyLabels = {
+  buttonTitle: '复制代码',
+  defaultText: '复制',
+  copiedText: '已复制',
+  failedText: '复制失败',
+};
+
+/** 给元素挂一个固定的 getBoundingClientRect，绕过 jsdom 全零返回。 */
+function mockRect(el: Element, rect: {
+  top: number; bottom: number; left: number; right: number;
+}): void {
+  el.getBoundingClientRect = () => ({
+    top: rect.top, bottom: rect.bottom, left: rect.left, right: rect.right,
+    width: rect.right - rect.left, height: rect.bottom - rect.top,
+    x: rect.left, y: rect.top, toJSON: () => {},
+  });
+}
+
+function setup(): { root: HTMLElement; overlay: HTMLElement; detach: () => void } {
+  const root = document.createElement('div');
+  const overlay = document.createElement('div');
+  // overlay 默认覆盖 800x600 视区
+  mockRect(overlay, { top: 0, left: 0, right: 800, bottom: 600 });
+  document.body.append(root, overlay);
+  const detach = attachCodeBlockCopy(root, overlay, LABELS);
+  return { root, overlay, detach };
+}
+
+function makeCodeBlock(opts: { lang?: string; text?: string; irMarker?: boolean } = {}): {
+  pre: HTMLPreElement; code: HTMLElement;
+} {
+  const pre = document.createElement('pre');
+  if (opts.irMarker) pre.className = 'vditor-ir__marker vditor-ir__marker--pre';
+  const code = document.createElement('code');
+  if (opts.lang) code.className = `language-${opts.lang}`;
+  code.textContent = opts.text ?? 'const x = 1;';
+  pre.appendChild(code);
+  // 给 pre 一个落在 overlay 可视区内的几何
+  mockRect(pre, { top: 100, left: 40, right: 760, bottom: 220 });
+  return { pre, code };
+}
+
+function fireMouseOver(target: Element, relatedTarget: EventTarget | null = null): void {
+  target.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, relatedTarget }));
+}
+function fireMouseOut(target: Element, relatedTarget: EventTarget | null): void {
+  target.dispatchEvent(new MouseEvent('mouseout', { bubbles: true, relatedTarget }));
+}
+
+describe('codeBlockCopyService · findCopyableCodeBlock', () => {
+  it('普通代码块命中：返回 pre/code/text', () => {
+    const root = document.createElement('div');
+    const { pre, code } = makeCodeBlock({ text: 'console.log("hi")' });
+    root.appendChild(pre);
+    expect(findCopyableCodeBlock(code)).toEqual({
+      pre, code, text: 'console.log("hi")',
+    });
+  });
+
+  it('异步渲染语言（mermaid/echarts/...）不命中', () => {
+    const root = document.createElement('div');
+    const { pre, code } = makeCodeBlock({ lang: 'mermaid', text: 'graph TD' });
+    root.appendChild(pre);
+    expect(findCopyableCodeBlock(code)).toBeNull();
+    expect(isAsyncRenderCodeBlock(code)).toBe(true);
+  });
+
+  it('空代码块不命中', () => {
+    const root = document.createElement('div');
+    const { pre, code } = makeCodeBlock({ text: '   ' });
+    root.appendChild(pre);
+    expect(findCopyableCodeBlock(code)).toBeNull();
+  });
+
+  it('Vditor IR 源码 marker pre 不命中', () => {
+    const root = document.createElement('div');
+    const { pre, code } = makeCodeBlock({ irMarker: true, text: 'x' });
+    root.appendChild(pre);
+    expect(findCopyableCodeBlock(code)).toBeNull();
+  });
+
+  it('target 不在 pre 内 → null', () => {
+    const root = document.createElement('div');
+    const p = document.createElement('p');
+    p.textContent = '正文';
+    root.appendChild(p);
+    expect(findCopyableCodeBlock(p)).toBeNull();
+  });
+});
+
+describe('codeBlockCopyService · attachCodeBlockCopy', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    rafCount = 0;
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return ++rafCount;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('hover 代码块 → overlay 内出现带 is-visible 的按钮（按钮不进入 root 文档树）', () => {
+    const { root, overlay } = setup();
+    const { pre, code } = makeCodeBlock();
+    root.appendChild(pre);
+
+    fireMouseOver(code);
+
+    const button = overlay.querySelector<HTMLButtonElement>(`.${CODE_COPY_TRIGGER_CLASS}`);
+    expect(button).not.toBeNull();
+    expect(button!.classList.contains(CODE_COPY_TRIGGER_VISIBLE_CLASS)).toBe(true);
+    // 关键：按钮在 overlay 内，不残留在 root 的内容树（IR DOM）里
+    expect(root.querySelector(`.${CODE_COPY_TRIGGER_CLASS}`)).toBeNull();
+  });
+
+  it('鼠标移出代码块 → 按钮隐藏（失去 is-visible）', () => {
+    const { root, overlay } = setup();
+    const { pre, code } = makeCodeBlock();
+    root.appendChild(pre);
+    fireMouseOver(code);
+    const button = overlay.querySelector<HTMLButtonElement>(`.${CODE_COPY_TRIGGER_CLASS}`)!;
+    expect(button.classList.contains(CODE_COPY_TRIGGER_VISIBLE_CLASS)).toBe(true);
+
+    const outside = document.createElement('div');
+    document.body.append(outside);
+    fireMouseOut(code, outside);
+    expect(button.classList.contains(CODE_COPY_TRIGGER_VISIBLE_CLASS)).toBe(false);
+  });
+
+  it('点击按钮调用 writeText 传入代码文本，按钮进入 is-copied 反馈态', async () => {
+    const { writeText } = await import('./clipboardService');
+    const { root, overlay } = setup();
+    const { pre, code } = makeCodeBlock({ text: 'let y = 2;' });
+    root.appendChild(pre);
+    fireMouseOver(code);
+    const button = overlay.querySelector<HTMLButtonElement>(`.${CODE_COPY_TRIGGER_CLASS}`)!;
+
+    // writeText 调用 + is-copied 置位都是同步发生；只 flush 微任务让 promise 落定，
+    // 不推进 1500ms 反馈复位定时器（否则会被复位成 idle）。
+    button.click();
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledWith('let y = 2;');
+    expect(button.classList.contains(CODE_COPY_TRIGGER_COPIED_CLASS)).toBe(true);
+    expect(button.querySelector('.folia-code-copy-trigger__text')?.textContent).toBe('已复制');
+  });
+
+  it('~1.5s 后反馈复位回默认态（鼠标仍在 pre 上）', async () => {
+    const { root, overlay } = setup();
+    const { pre, code } = makeCodeBlock();
+    root.appendChild(pre);
+    fireMouseOver(code);
+    const button = overlay.querySelector<HTMLButtonElement>(`.${CODE_COPY_TRIGGER_CLASS}`)!;
+    button.click();
+    await Promise.resolve();
+    expect(button.classList.contains(CODE_COPY_TRIGGER_COPIED_CLASS)).toBe(true);
+
+    // 推进 1600ms → 反馈复位定时器触发，回默认态（currentBlock 仍在，故只复位文案不隐藏）
+    vi.advanceTimersByTime(1600);
+    expect(button.classList.contains(CODE_COPY_TRIGGER_COPIED_CLASS)).toBe(false);
+    expect(button.querySelector('.folia-code-copy-trigger__text')?.textContent).toBe('复制');
+  });
+
+  it('hover mermaid 块 → 按钮不显示', () => {
+    const { root, overlay } = setup();
+    const { pre, code } = makeCodeBlock({ lang: 'mermaid', text: 'graph TD' });
+    root.appendChild(pre);
+    fireMouseOver(code);
+    const button = overlay.querySelector<HTMLButtonElement>(`.${CODE_COPY_TRIGGER_CLASS}`);
+    // 按钮节点存在但不应进入可见态
+    expect(button?.classList.contains(CODE_COPY_TRIGGER_VISIBLE_CLASS)).toBe(false);
+  });
+
+  it('富媒体重渲染：原 pre 被替换为新 pre 后，按钮能干净重定位到新块（不残留、不抖动）', () => {
+    const { root, overlay } = setup();
+    const block1 = makeCodeBlock({ text: 'old code' });
+    root.appendChild(block1.pre);
+    fireMouseOver(block1.code);
+    const button = overlay.querySelector<HTMLButtonElement>(`.${CODE_COPY_TRIGGER_CLASS}`)!;
+    expect(button.classList.contains(CODE_COPY_TRIGGER_VISIBLE_CLASS)).toBe(true);
+
+    // 模拟 mermaid/重渲染把原 pre 整体替换掉
+    const oldPre = block1.pre;
+    oldPre.remove();
+    const block2 = makeCodeBlock({ text: 'new code' });
+    root.appendChild(block2.pre);
+
+    // 按钮仍只在 overlay 内，不会残留在已被移除的 oldPre 中
+    expect(root.querySelector(`.${CODE_COPY_TRIGGER_CLASS}`)).toBeNull();
+
+    // 鼠标移到新块 → 按钮重定位到新块文本，可见态恢复
+    fireMouseOver(block2.code);
+    expect(button.classList.contains(CODE_COPY_TRIGGER_VISIBLE_CLASS)).toBe(true);
+  });
+
+  it('原 pre 被移除后触发滚动重定位 → 按钮自动隐藏（不悬空在空白处）', () => {
+    const { root, overlay } = setup();
+    const block1 = makeCodeBlock({ text: 'x' });
+    root.appendChild(block1.pre);
+    fireMouseOver(block1.code);
+    const button = overlay.querySelector<HTMLButtonElement>(`.${CODE_COPY_TRIGGER_CLASS}`)!;
+    expect(button.classList.contains(CODE_COPY_TRIGGER_VISIBLE_CLASS)).toBe(true);
+
+    block1.pre.remove();
+    // 触发滚动事件 → service 在 rAF 内重算，发现 pre 已 disconnected → 隐藏
+    root.dispatchEvent(new Event('scroll', { bubbles: false }));
+    expect(button.classList.contains(CODE_COPY_TRIGGER_VISIBLE_CLASS)).toBe(false);
+  });
+
+  it('detach 后移除按钮、解绑监听，后续 mouseover 不再创建按钮', () => {
+    const { root, overlay, detach } = setup();
+    detach();
+    const { pre, code } = makeCodeBlock();
+    root.appendChild(pre);
+    fireMouseOver(code);
+    expect(overlay.querySelector(`.${CODE_COPY_TRIGGER_CLASS}`)).toBeNull();
+  });
+});
+
+describe('codeBlockCopyService · 挂载方式铁律：禁止新增 MutationObserver', () => {
+  it('源码中不存在 new MutationObserver（防止与 renderCoordinator 的 MO 叠加成 CPU 死循环）', () => {
+    const src = fs.readFileSync(
+      path.resolve(__dirname, 'codeBlockCopyService.ts'),
+      'utf8',
+    );
+    expect(src).not.toContain('new MutationObserver');
+    // 同时确认本文件没有引入 MutationObserver 类型
+    expect(src).not.toMatch(/MutationObserver\s*\(/);
+  });
+});

--- a/src/services/codeBlockCopyService.ts
+++ b/src/services/codeBlockCopyService.ts
@@ -1,0 +1,322 @@
+// ISS-190：代码块复制按钮（主 IR + HTML 预览）。
+//
+// 挂载方式铁律（违反必拒）：
+// 本服务**绝对禁止使用 MutationObserver**。富媒体（Mermaid / echarts / KaTeX 等）
+// 重渲染时，renderCoordinator 已有 MutationObserver 在监听 DOM 变化；若再叠加一个
+// 监听编辑器/预览 DOM 的 MO，写按钮 / 清理按钮的 DOM 操作会触发 MO 回调，MO 回调
+// 又触发新的 DOM 操作，形成自递归，已知导致 100% CPU 死循环（见 ISS-119/179）。
+//
+// 因此按钮定位只靠几何：
+// 1. mouseover/mouseout（事件委托到容器根）→ 决定「当前悬停在哪个 <pre> 代码块」。
+// 2. scroll（capture 阶段，捕获后代任意滚动容器）+ ResizeObserver → 滚动 / 尺寸
+//    变化时按 getBoundingClientRect 重新计算按钮坐标。
+// 不监听 DOM 结构变化；富媒体重渲染若把当前 pre 替换掉，下一次几何重算时
+// `currentPre.isConnected === false` 会自动隐藏按钮（不残留、不抖动）。
+//
+// 按钮挂在 overlay 层（由调用方提供的、position:absolute/inset:0/pointer-events:none
+// 的 div），**绝不进入 Vditor IR DOM**——避免被 editor.getValue() 经 Lute 反序列化
+// 写回 markdown 污染文档，也避免被 sanitize 重写。overlay 是 React 渲染的同级 div，
+// 调用方负责其生命周期；本服务只把按钮 append 到 overlay 内并在 detach 时移除。
+//
+// 可见性：按钮用 `is-visible` class 控制（opacity 0↔1 + pointer-events 切换），
+// 不用 display:none 切换——这样 hover 淡入的 opacity transition 才能稳定触发
+// （display:none → block 的首帧 transition 在 WKWebView 不稳定）。
+//
+// 复制：复用 clipboardService.writeText（navigator.clipboard.writeText 优先，
+// 失败降级 document.execCommand('copy')），纯文本。
+import { writeText } from './clipboardService';
+
+export interface CodeCopyLabels {
+  /** 按钮 title / aria-label（完整动作描述） */
+  buttonTitle: string;
+  /** 默认态按钮文字（短） */
+  defaultText: string;
+  /** 复制成功反馈文字 */
+  copiedText: string;
+  /** 复制失败反馈文字 */
+  failedText: string;
+}
+
+/**
+ * 富媒体异步渲染语言：这些 code 块会被 Vditor 替换为 SVG / canvas / KaTeX，
+ * 不属于「可复制源码代码块」，且重渲染时 DOM 会被替换。按钮不应出现在它们上面，
+ * 既能避免复制出一坨 SVG 标记，也能避免按钮定位跟随重渲染抖动。
+ */
+const ASYNC_RENDER_LANGS = new Set([
+  'mermaid', 'flowchart', 'sequence', 'echarts', 'math',
+  'plantuml', 'graphviz', 'markmap', 'mindmap', 'abc', 'smiles',
+]);
+
+/** 按钮在 overlay 内的 class（CSS 控制外观 / hover 淡入） */
+export const CODE_COPY_TRIGGER_CLASS = 'folia-code-copy-trigger';
+/** 可见态 class（CSS 控制 opacity:1 + pointer-events:auto，实现淡入） */
+export const CODE_COPY_TRIGGER_VISIBLE_CLASS = 'is-visible';
+/** 复制成功反馈态 class（CSS 控制颜色） */
+export const CODE_COPY_TRIGGER_COPIED_CLASS = 'is-copied';
+/** 复制失败反馈态 class */
+export const CODE_COPY_TRIGGER_FAILED_CLASS = 'is-failed';
+
+/** 「已复制」反馈复位时长（与任务规格 ~1.5s 对齐） */
+const COPY_FEEDBACK_RESET_MS = 1500;
+
+/** 按钮相对 pre 右上角的内边距（px） */
+const BUTTON_INSET_PX = 6;
+
+export interface CopyableCodeBlock {
+  pre: HTMLPreElement;
+  code: HTMLElement;
+  text: string;
+}
+
+/**
+ * 从事件 target 反查「可复制代码块」对应的 <pre>。
+ *
+ * 命中条件（全部满足）：
+ * - target 位于某个 <pre> 内；
+ * - 该 <pre> 直接包含一个 <code> 子元素；
+ * - <code> 文本非空；
+ * - <code> 不带任何异步渲染语言 class（mermaid 等——会被替换成 SVG）；
+ * - 该 <pre> 不是 Vditor IR 源码 marker（`vditor-ir__marker`，那是源码展示态，
+ *   非渲染结果，且编辑它没有意义）。
+ *
+ * 返回 null 表示鼠标当前位置没有可复制的代码块。
+ */
+export function findCopyableCodeBlock(target: Element): CopyableCodeBlock | null {
+  const pre = target.closest('pre');
+  if (!pre) return null;
+  // 排除 Vditor IR 源码 marker pre（class 同时含 vditor-ir__marker / vditor-ir__marker--pre）
+  if (pre.classList.contains('vditor-ir__marker')) return null;
+  const code = pre.querySelector('code');
+  if (!code) return null;
+  // 排除异步渲染语言（mermaid / echarts / math / ...）
+  if (isAsyncRenderCodeBlock(code)) return null;
+  const text = (code.textContent ?? '').trim();
+  if (text.length === 0) return null;
+  return {
+    pre: pre as HTMLPreElement,
+    code: code as HTMLElement,
+    text,
+  };
+}
+
+/**
+ * 判断一个元素是否为（或属于）异步渲染语言的 code 块。导出给单测用。
+ */
+export function isAsyncRenderCodeBlock(code: Element): boolean {
+  for (const lang of ASYNC_RENDER_LANGS) {
+    if (code.classList.contains(`language-${lang}`)) return true;
+  }
+  return false;
+}
+
+function buildButtonContent(state: 'idle' | 'copied' | 'failed', text: string): string {
+  const icon =
+    state === 'copied'
+      ? '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>'
+      : state === 'failed'
+        ? '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg>'
+        : '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>';
+  return `${icon}<span class="folia-code-copy-trigger__text">${text}</span>`;
+}
+
+/**
+ * 把「代码块复制按钮」挂到指定容器。
+ *
+ * @param root  事件委托 + scroll(capture) + ResizeObserver 的目标；pre>code 位于其内。
+ * @param overlay 按钮 append 到此节点。必须是由调用方控制的、视觉上覆盖 root 可见区
+ *                的定位节点（position:absolute; inset:0; pointer-events:none）。
+ *                不能是 Vditor IR DOM 的子节点（会污染 getValue）。
+ * @param labels 文案。
+ * @returns cleanup 函数：移除按钮、解绑所有监听、断开 observer、清定时器。
+ */
+export function attachCodeBlockCopy(
+  root: HTMLElement,
+  overlay: HTMLElement,
+  labels: CodeCopyLabels,
+): () => void {
+  // ---- 按钮节点 ----
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = CODE_COPY_TRIGGER_CLASS;
+  button.title = labels.buttonTitle;
+  button.setAttribute('aria-label', labels.buttonTitle);
+  button.innerHTML = buildButtonContent('idle', labels.defaultText);
+  overlay.appendChild(button);
+
+  // ---- 运行期状态 ----
+  let currentBlock: CopyableCodeBlock | null = null;
+  let feedbackTimer: number | null = null;
+  let rafId: number | null = null;
+
+  function clearFeedbackTimer(): void {
+    if (feedbackTimer !== null) {
+      window.clearTimeout(feedbackTimer);
+      feedbackTimer = null;
+    }
+  }
+
+  function setButtonLabel(state: 'idle' | 'copied' | 'failed', text: string): void {
+    button.classList.toggle(CODE_COPY_TRIGGER_COPIED_CLASS, state === 'copied');
+    button.classList.toggle(CODE_COPY_TRIGGER_FAILED_CLASS, state === 'failed');
+    button.innerHTML = buildButtonContent(state, text);
+  }
+
+  function setVisible(visible: boolean): void {
+    button.classList.toggle(CODE_COPY_TRIGGER_VISIBLE_CLASS, visible);
+  }
+
+  function hideButton(): void {
+    setVisible(false);
+    currentBlock = null;
+    clearFeedbackTimer();
+    setButtonLabel('idle', labels.defaultText);
+  }
+
+  /**
+   * 按 currentBlock.pre 的当前视口几何，把按钮定位到其右上角并显示。
+   * 返回 true 表示已定位显示；false 表示应隐藏（pre 被替换 / 滚出可视区）。
+   */
+  function positionAndShow(): boolean {
+    const block = currentBlock;
+    if (!block || !block.pre.isConnected) {
+      return false;
+    }
+    const preRect = block.pre.getBoundingClientRect();
+    const overlayRect = overlay.getBoundingClientRect();
+    // 完全滚出可视区（垂直）→ 不显示，避免按钮悬在空白处
+    if (preRect.bottom <= overlayRect.top + BUTTON_INSET_PX
+      || preRect.top >= overlayRect.bottom - BUTTON_INSET_PX) {
+      return false;
+    }
+    // top：贴 pre 顶部，但当 pre 顶部已滚到 overlay 上方时，吸附在 overlay 顶部留 inset。
+    const top = Math.max(
+      BUTTON_INSET_PX,
+      preRect.top - overlayRect.top + BUTTON_INSET_PX,
+    );
+    // right：贴 pre 右侧；pre 横向超出 overlay 时吸附 overlay 右侧。
+    const rightFromOverlayRight = overlayRect.right - preRect.right + BUTTON_INSET_PX;
+    const right = Math.max(BUTTON_INSET_PX, rightFromOverlayRight);
+    button.style.top = `${top}px`;
+    button.style.right = `${right}px`;
+    button.style.left = '';
+    setVisible(true);
+    return true;
+  }
+
+  /** 滚动 / resize 时的重定位（按钮已显示才需要） */
+  function scheduleReposition(): void {
+    if (rafId !== null) return;
+    rafId = window.requestAnimationFrame(() => {
+      rafId = null;
+      if (!currentBlock) return;
+      if (!positionAndShow()) {
+        hideButton();
+      }
+    });
+  }
+
+  // ---- 事件委托：mouseover / mouseout ----
+  const onMouseOver = (event: MouseEvent): void => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    // hover 到按钮自身不切换目标
+    if (target === button || button.contains(target)) return;
+    const found = findCopyableCodeBlock(target);
+    if (!found) return;
+    // 同一个 pre，不重复重置（避免覆盖进行中的「已复制」反馈）
+    if (currentBlock && currentBlock.pre === found.pre) return;
+    currentBlock = found;
+    clearFeedbackTimer();
+    setButtonLabel('idle', labels.defaultText);
+    if (!positionAndShow()) {
+      hideButton();
+    }
+  };
+
+  const onMouseOut = (event: MouseEvent): void => {
+    if (!currentBlock) return;
+    const next = event.relatedTarget;
+    // 鼠标仍在 pre 内，或移到了按钮上 → 保持显示
+    if (next instanceof Node) {
+      if (currentBlock.pre.contains(next)) return;
+      if (next === button || button.contains(next)) return;
+    }
+    hideButton();
+  };
+
+  // ---- 滚动跟随（capture：捕获后代任意滚动容器的 scroll，scroll 不冒泡）----
+  const onScroll = (): void => {
+    if (!currentBlock) return;
+    scheduleReposition();
+  };
+
+  // ---- 尺寸跟随（容器或内容 resize 时重定位）----
+  const resizeObserver = typeof ResizeObserver !== 'undefined'
+    ? new ResizeObserver(() => {
+        if (!currentBlock) return;
+        scheduleReposition();
+      })
+    : null;
+  resizeObserver?.observe(root);
+
+  // ---- 点击复制 ----
+  const onClick = (event: MouseEvent): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    const text = currentBlock?.text ?? button.dataset.codeText ?? '';
+    button.dataset.codeText = text;
+    if (text.length === 0) return;
+    clearFeedbackTimer();
+    setButtonLabel('copied', labels.copiedText);
+    void writeText(text)
+      .then(() => {
+        scheduleResetFeedback();
+      })
+      .catch((error) => {
+        console.warn('[Folia] 代码块复制失败:', error);
+        setButtonLabel('failed', labels.failedText);
+        scheduleResetFeedback();
+      });
+  };
+
+  function scheduleResetFeedback(): void {
+    clearFeedbackTimer();
+    feedbackTimer = window.setTimeout(() => {
+      feedbackTimer = null;
+      // 反馈复位时若鼠标已离开（currentBlock 被清），直接隐藏；否则回默认态
+      if (!currentBlock || !currentBlock.pre.isConnected) {
+        hideButton();
+      } else {
+        setButtonLabel('idle', labels.defaultText);
+      }
+    }, COPY_FEEDBACK_RESET_MS);
+  }
+
+  // mousedown 阻止默认，避免点击按钮时把焦点 / 选区抢到按钮，干扰编辑器
+  const onMouseDown = (event: MouseEvent): void => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  button.addEventListener('mousedown', onMouseDown);
+  button.addEventListener('click', onClick);
+  root.addEventListener('mouseover', onMouseOver);
+  root.addEventListener('mouseout', onMouseOut);
+  root.addEventListener('scroll', onScroll, true);
+
+  // ---- cleanup ----
+  return () => {
+    if (rafId !== null) {
+      window.cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    clearFeedbackTimer();
+    button.removeEventListener('mousedown', onMouseDown);
+    button.removeEventListener('click', onClick);
+    root.removeEventListener('mouseover', onMouseOver);
+    root.removeEventListener('mouseout', onMouseOut);
+    root.removeEventListener('scroll', onScroll, true);
+    resizeObserver?.disconnect();
+    button.remove();
+  };
+}

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -169,6 +169,11 @@ const zhCN = {
   confirmCloseSave: '保存',
   confirmCloseDiscard: '不保存',
   confirmCloseCancel: '取消',
+  // ISS-190：代码块复制按钮（主 IR + HTML 预览，Word 纸张预览不含）
+  codeBlockCopyLabel: '复制代码',
+  codeBlockCopyDefault: '复制',
+  codeBlockCopied: '已复制',
+  codeBlockCopyFailed: '复制失败',
 };
 
 type I18nKey = keyof typeof zhCN;
@@ -336,6 +341,10 @@ const enUS: Record<I18nKey, string> = {
   confirmCloseSave: 'Save',
   confirmCloseDiscard: 'Don’t Save',
   confirmCloseCancel: 'Cancel',
+  codeBlockCopyLabel: 'Copy code',
+  codeBlockCopyDefault: 'Copy',
+  codeBlockCopied: 'Copied',
+  codeBlockCopyFailed: 'Copy failed',
 };
 
 const jaJP: Record<I18nKey, string> = {
@@ -501,6 +510,10 @@ const jaJP: Record<I18nKey, string> = {
   confirmCloseSave: '保存',
   confirmCloseDiscard: '保存しない',
   confirmCloseCancel: 'キャンセル',
+  codeBlockCopyLabel: 'コードをコピー',
+  codeBlockCopyDefault: 'コピー',
+  codeBlockCopied: 'コピー済み',
+  codeBlockCopyFailed: 'コピー失敗',
 };
 
 const dictionaries: Record<AppLocale, Record<I18nKey, string>> = {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1134,6 +1134,7 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 }
 
 .wysiwyg-editor-pane {
+  position: relative;
   height: 100%;
   min-width: 0;
 }
@@ -1527,6 +1528,86 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
+
+/* ===== ISS-190 代码块复制按钮（主 IR + HTML 预览，Word 纸张预览不含） ===== */
+/* overlay 层：定位锚点 + 鼠标穿透。按钮几何跟随靠 getBoundingClientRect 在
+   JS 里算（mouseover/mouseout + scroll + ResizeObserver），不靠 MutationObserver。*/
+.folia-code-copy-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 6;
+}
+
+.folia-code-copy-trigger {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  font-size: 12px;
+  line-height: 1.4;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  /* 默认隐藏：opacity:0 + visibility:hidden + pointer-events:none，
+     不用 display:none —— 这样 hover 淡入的 opacity transition 才能稳定触发。*/
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  box-shadow: 0 1px 4px var(--shadow-soft);
+  transform: translateY(-2px);
+  transition: opacity 0.15s ease, transform 0.15s ease, background-color 0.15s ease,
+    color 0.15s ease, border-color 0.15s ease, visibility 0s linear 0.15s;
+  user-select: none;
+  white-space: nowrap;
+}
+
+/* service 命中可复制代码块后加 is-visible，触发 opacity 0→1 淡入（0.15s） */
+.folia-code-copy-trigger.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition: opacity 0.15s ease, transform 0.15s ease, background-color 0.15s ease,
+    color 0.15s ease, border-color 0.15s ease, visibility 0s;
+}
+
+.folia-code-copy-trigger.is-visible:hover {
+  background: var(--accent);
+  color: var(--accent-fg, #fff);
+  border-color: var(--accent);
+}
+
+.folia-code-copy-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.folia-code-copy-trigger.is-copied {
+  background: color-mix(in oklch, var(--accent) 16%, var(--surface));
+  color: var(--accent);
+  border-color: color-mix(in oklch, var(--accent) 40%, var(--border));
+}
+
+.folia-code-copy-trigger.is-failed {
+  background: color-mix(in oklch, #e5484d 16%, var(--surface));
+  color: #e5484d;
+  border-color: color-mix(in oklch, #e5484d 40%, var(--border));
+}
+
+.folia-code-copy-trigger svg {
+  flex: 0 0 auto;
+}
+
+.folia-code-copy-trigger__text {
+  font-weight: 500;
+}
+
 
 /* ===== On-demand Word Paper Preview ===== */
 
@@ -2086,6 +2167,7 @@ html[data-runtime='tauri'][data-platform='macos'] .app-toolbar {
 /* ===== On-demand HTML Article Preview ===== */
 
 .wechat-preview-panel {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-width: 0;


### PR DESCRIPTION
Closes #120

## 改动

ISS-190 代码块复制按钮。鼠标悬停主编辑器（即时渲染 IR）与 HTML 预览面板的 `<pre><code>` 代码块时，右上角淡入「复制」按钮，点击写入代码纯文本到剪贴板，~1.5s 内显示「已复制」反馈后复位。

- **新增** `src/services/codeBlockCopyService.ts`：overlay 几何跟随定位（`mouseover/mouseout` 事件委托 + `scroll`(capture) + `ResizeObserver` 按 `getBoundingClientRect`），复用 `clipboardService.writeText`（`navigator.clipboard.writeText` 优先，失败降级 `document.execCommand('copy')`）。
- **接入** `WysiwygEditorPane`（主 IR）与 `WechatPreviewPane`（HTML 预览）：各加一个 React 渲染的 overlay div（`pointer-events:none`），按钮 append 到 overlay。
- **i18n** 三语言新增 `codeBlockCopyLabel/Default/Copied/Failed`。
- **CSS** `app.css`：overlay + 按钮样式，`is-visible` class 控制 opacity 0↔1 淡入（0.15s），`is-copied/is-failed` 反馈态。
- **CHANGELOG** 加 Unreleased / Added 条目。

## 挂载方式铁律（关键）

- **绝对禁止新增 `MutationObserver`**。富媒体（Mermaid 等）重渲染时，新增 MO 会与 `renderCoordinator` 已有 MO 叠加形成自递归，已知导致 100% CPU 死循环（ISS-119/179）。按钮定位只靠几何。
- 按钮**绝不进入 Vditor IR DOM**——否则会被 `editor.getValue()` 经 Lute 反序列化写回 markdown 污染文档、或被 sanitize 重写。按钮在与 host / article-shell 同级的 overlay 层。
- 富媒体（mermaid / echarts / math 等异步渲染语言）块不出按钮（会被替换成 SVG，复制无意义且重渲染会抖动）；富媒体重渲染把当前代码块替换掉时，下一次几何重算发现 `pre.isConnected === false` 自动隐藏按钮，不残留、不抖动。
- Word 纸张预览（仅文本保真面）不含按钮。

## 改动文件

- `src/services/codeBlockCopyService.ts`（新）
- `src/services/codeBlockCopyService.test.ts`（新，14 项）
- `src/components/WysiwygEditorPane.tsx` / `.test.tsx`（接入 + 2 项集成测试）
- `src/components/WechatPreviewPane.tsx`（接入）
- `src/services/i18n.ts`（三语言）
- `src/styles/app.css`（样式）
- `CHANGELOG.md`

## 验证

- `npm run typecheck` ✅ 干净
- `npm run lint` ✅ 干净
- `npm test` ✅ 613 / 613（新增 16 项：service 14 + WysiwygEditorPane 集成 2）
- `npm run build` ✅ 成功
- 无 Rust 改动，未跑 cargo check。
- 静态断言：service 源码 `grep 'new MutationObserver'` 为空，并有单测 `codeBlockCopyService 源码中不存在 new MutationObserver` 守卫。

## 需真机验证（NOT_VERIFIED）

WKWebView 内 hover 淡入与几何跟随的真实观感、真实剪贴板写入须在 `tauri dev` 下由真机确认；jsdom 下 `getBoundingClientRect` 全零，单测通过 mock 固定矩形覆盖定位逻辑。