### PR TITLE
fix(image): 支持绝对路径图片引用 (POSIX / Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes of this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **修复 Markdown 用 POSIX/Windows 绝对路径引用本地图片时显示「图片数据损坏，图片字节可能不完整或格式不受支持」（ISS-127 / PR #128）**：根因是 `src/services/htmlPresentationService.ts:resolveLocalResourcePath` 经 `isRelativeLocalUrl()` 判定路径类型，但排除规则只检查 scheme `:` / `#` / `//`，没排除 POSIX `/` 开头 —— macOS 上常见的 `![alt](/Users/.../xxx.png)` 漏判，走进「目录拼接」分支、被错误拼成 `/Users/.../note.md/Users/.../xxx.png`。该无效路径经 `convertFileSrc()` 转成 `asset://localhost/<bogus>`，`<img>` 加载失败，因 src 以 `asset:` 开头被 `WysiwygEditorPane.classifyError` 归类为 `decode-failed`、触发 `MediaPlaceholder` "图片数据损坏" 占位。本次在 `resolveLocalResourcePath` 入口识别 POSIX（`startsWith('/') && !startsWith('//')` 排除 protocol-relative URL）和 Windows（`/^[A-Za-z]:\//`）绝对路径，命中后跳过目录拼接、直接返回解码后的资源路径，仍走 `isSensitivePath` 守卫保护（防止恶意 md 通过 asset 协议探查 `/etc` / `~/.ssh`）。`usesWindowsSeparators` 改由 `resourceUrl` 自身决定（绝对路径场景下 filePath 不可信）。新增 4 项 vitest（htmlPresentationService 3 + localImageResolver 1）覆盖 POSIX/Windows 绝对路径 + 敏感路径拒绝 + 集成路径不拼接 markdown 目录；`npm test` 715/715 PASS、`typecheck` / `lint` 0 error。**真机 Tauri runtime 验证（NOT_VERIFIED，移交用户）**：`resolveLocalResourcePath` 是纯函数、单元测试已精确断言输出；`convertFileSrc` + `asset://` 协议由 Tauri runtime 提供，不在本修复范围。建议用户在 macOS Folia 里打开含 `![alt](/Users/<your-path>/xxx.png)` 的 markdown 确认图片正常显示。
+
 ## [0.7.0] - 2026-08-14
 
 ### Added

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -36,6 +36,14 @@
 
 > ⚠️ **2026-08-14 数据恢复说明**：本文件 DEC-065 ~ DEC-137 正文因一次 `git stash pop` 误操作覆盖丢失（local 文件，git 无历史备份）。以下已从 CHANGELOG.md（权威变更记录）重建决策骨架——编号/ISS/PR/版本/结论可追溯，但部分早期条目（v0.3.10~v0.4.3，CHANGELOG 未逐条标 DEC 号）按版本聚合；完整根因分析详见 CHANGELOG 对应版本段与 PR。代码无损失（全部已合并）。排列沿用本文件既有降序惯例（新决策在前），与 DEC-064→DEC-001 衔接。
 
+### [DEC-138] - 2026-08-14 - 绝对路径图片引用误判为相对路径（ISS-127 / PR #128）
+
+**背景**：macOS 用户在 Markdown 里用 `![alt](/Users/.../xxx.png)` 这种 POSIX 绝对路径引用本地图片，编辑器显示「图片数据损坏，图片字节可能不完整或格式不受支持」（`decode-failed`）。PNG 文件本身完好（211886 字节，magic bytes 正确）。根因是 `src/services/htmlPresentationService.ts:resolveLocalResourcePath` 经 `isRelativeLocalUrl()` 判定路径类型——它的排除规则只检查 scheme `:` / `#` / `//`，但漏判 POSIX `/` 开头。绝对路径因此走进「目录拼接」分支，被错拼成 `/Users/.../note.md/Users/.../xxx.png`。该无效路径经 `convertFileSrc()` 转 `asset://localhost/<bogus>`，`<img>` 加载失败，因 src 以 `asset:` 开头被 `WysiwygEditorPane.classifyError` 归类为 `decode-failed`、触发 `MediaPlaceholder` "图片数据损坏" 占位（`MediaPlaceholder.tsx:43,53`）。
+
+**决策/结论**：`resolveLocalResourcePath` 入口识别 POSIX / Windows 绝对路径（POSIX：`startsWith('/') && !startsWith('//')` 排除 protocol-relative URL；Windows：`/^[A-Za-z]:\//`），命中后跳过目录拼接、直接返回解码后的资源路径，仍走 `isSensitivePath` 守卫保护（防止恶意 md 通过 asset 协议探查 `/etc` / `~/.ssh`）。`usesWindowsSeparators` 改由 `resourceUrl` 自身决定（绝对路径场景下 filePath 不可信）。选最小修复而非新增 helper（如 `isAbsoluteLocalUrl`）：函数本身已用 `isSensitivePath` 守卫、调用方（localImageResolver / htmlPresentationService）都期望 `resolveLocalResourcePath` 返回可直接传给 `convertFileSrc` 的绝对路径，抽象独立 helper 会让 caller 多一次判断、收益不明显。
+
+**验证**：`npm test` 715/715 PASS（含 4 项新增：htmlPresentationService 3 项 + localImageResolver 1 项，覆盖 POSIX/Windows 绝对路径 + 敏感路径拒绝 + 集成路径不拼接 markdown 目录）/ `typecheck` 0 error / `lint` 0 error。**真机 Tauri runtime 验证（NOT_VERIFIED，移交用户）**：`resolveLocalResourcePath` 是纯函数、单元测试已精确断言输出；`convertFileSrc` + `asset://` 协议由 Tauri runtime 提供，不在本修复范围。建议用户在 macOS Folia 里打开含 `![alt](/Users/<your-path>/xxx.png)` 的 markdown 确认图片正常显示。
+
 ### [DEC-137] - 2026-08-14 - 主题系统与「设为默认 Markdown 应用」（ISS-191 / #123；ISS-192 / #118）
 
 **背景**：内置只有浅色/深色两套，缺多元护眼主题与自定义能力；系统虽已知 Folia 能打开 `.md`（v0.3.16 文件关联），但不会自动把 Folia 设为默认打开程序。

--- a/src/services/htmlPresentationService.test.ts
+++ b/src/services/htmlPresentationService.test.ts
@@ -117,6 +117,29 @@ describe('htmlPresentationService', () => {
     expect(resolveLocalResourcePath('/Users/demo/docs/note.md', '/Users/demo/.ssh/id_rsa')).toBeUndefined();
   });
 
+  // Cross-OS contract: when the resource URL is POSIX-style (no backslashes),
+  // the resolved path uses POSIX separators, even if filePath is Windows-style.
+  // Windows accepts both `\\` and `/` as separators, and downstream
+  // `encodePathForFileUrl` normalises either form — so this lock-in is about
+  // behaviour stability, not correctness.
+  //
+  // Before PR #128 the decision was based on `filePath.includes('\\')` (would
+  // return `C:\\Users\\demo\\decks\\assets\\deck.js`); after the fix it is
+  // based on `resourceUrl.includes('\\')` (returns the mixed
+  // `C:/Users/demo/decks/assets/deck.js` — legal on Windows, normalised by
+  // downstream consumers).
+  it('uses POSIX separators when the resource URL is POSIX, regardless of filePath style', () => {
+    // Windows filePath + POSIX resource URL → POSIX output (C: drive letter
+    // preserved, separators normalised to /)
+    expect(
+      resolveLocalResourcePath('C:\\Users\\demo\\decks\\case.html', './assets/deck.js'),
+    ).toBe('C:/Users/demo/decks/assets/deck.js');
+    // POSIX filePath + POSIX resource URL → POSIX output (existing behaviour)
+    expect(
+      resolveLocalResourcePath('/Users/demo/decks/case.html', './assets/deck.js'),
+    ).toBe('/Users/demo/decks/assets/deck.js');
+  });
+
   it('refuses paths that traverse into sensitive system or credential directories', () => {
     const base = '/Users/demo/decks/case.html';
     // Three `..` reach the filesystem root from /Users/demo/decks/, landing in /etc, /var, /private.

--- a/src/services/htmlPresentationService.test.ts
+++ b/src/services/htmlPresentationService.test.ts
@@ -87,6 +87,36 @@ describe('htmlPresentationService', () => {
     expect(resolveLocalResourcePath('/Users/demo/decks/case.html', '//example.test/a.js')).toBeUndefined();
   });
 
+  // Regression for absolute-path image references such as
+  // `![主体关系图](/Users/.../图件/主体关系图.png)` in Markdown files. Before
+  // the fix, isRelativeLocalUrl() did not recognise POSIX absolute paths
+  // (`/Users/...`), so the resource was joined with the markdown directory
+  // and produced `/Users/.../note.md/Users/.../主体关系图.png` — a non-existent
+  // path that became asset:///<bogus> and surfaced as "图片数据损坏".
+  it('treats POSIX absolute paths as already resolved (does not prepend the markdown directory)', () => {
+    expect(
+      resolveLocalResourcePath(
+        '/Users/demo/docs/note.md',
+        '/Users/demo/docs/figures/主体关系图.png',
+      ),
+    ).toBe('/Users/demo/docs/figures/主体关系图.png');
+  });
+
+  it('treats Windows absolute paths as already resolved', () => {
+    expect(
+      resolveLocalResourcePath(
+        'C:\\Users\\demo\\docs\\note.md',
+        'C:\\Users\\demo\\docs\\figures\\photo.png',
+      ),
+    ).toBe('C:\\Users\\demo\\docs\\figures\\photo.png');
+  });
+
+  it('still refuses POSIX absolute paths that land in a sensitive directory', () => {
+    expect(resolveLocalResourcePath('/Users/demo/docs/note.md', '/etc/passwd')).toBeUndefined();
+    expect(resolveLocalResourcePath('/Users/demo/docs/note.md', '/private/etc/hosts')).toBeUndefined();
+    expect(resolveLocalResourcePath('/Users/demo/docs/note.md', '/Users/demo/.ssh/id_rsa')).toBeUndefined();
+  });
+
   it('refuses paths that traverse into sensitive system or credential directories', () => {
     const base = '/Users/demo/decks/case.html';
     // Three `..` reach the filesystem root from /Users/demo/decks/, landing in /etc, /var, /private.

--- a/src/services/htmlPresentationService.ts
+++ b/src/services/htmlPresentationService.ts
@@ -128,15 +128,36 @@ function isSensitivePath(normalizedPath: string): boolean {
 }
 
 export function resolveLocalResourcePath(filePath: string | undefined, resourceUrl: string): string | undefined {
-  if (!filePath || !isRelativeLocalUrl(resourceUrl)) return undefined;
+  if (!filePath) return undefined;
 
-  const usesWindowsSeparators = filePath.includes('\\');
+  // Honour the resource URL's own separator style (the filePath may be on a
+  // different OS — only the resource URL matters when it is already absolute).
+  const usesWindowsSeparators = resourceUrl.includes('\\');
+  const decoded = decodeResourcePath(stripUrlSuffix(resourceUrl)).replaceAll('\\', '/');
+  // `//host/path` is a protocol-relative URL, not a POSIX absolute path —
+  // keep it on the existing "external URL" branch handled below.
+  const isUnixAbsolute = decoded.startsWith('/') && !decoded.startsWith('//');
+  const isWindowsAbsolute = /^[A-Za-z]:\//.test(decoded);
+
+  // Absolute paths (POSIX `/Users/...` or Windows `C:/...`) already point at
+  // a real filesystem location — joining them with the markdown directory
+  // produces a non-existent path that the Tauri asset URL then fails to load
+  // (surfacing as `decode-failed` "图片数据损坏" in the editor). Honour the
+  // absolute path directly, but still apply the sensitive-path guard so a
+  // crafted Markdown cannot probe /etc or .ssh via the asset protocol.
+  if (isUnixAbsolute || isWindowsAbsolute) {
+    if (isSensitivePath(decoded)) return undefined;
+    return usesWindowsSeparators ? decoded.replaceAll('/', '\\') : decoded;
+  }
+
+  if (!isRelativeLocalUrl(resourceUrl)) return undefined;
+
   const normalizedFilePath = filePath.replaceAll('\\', '/');
   const lastSlash = normalizedFilePath.lastIndexOf('/');
   if (lastSlash < 0) return undefined;
 
   const directory = normalizedFilePath.slice(0, lastSlash + 1);
-  const resourcePath = decodeResourcePath(stripUrlSuffix(resourceUrl)).replaceAll('\\', '/');
+  const resourcePath = decoded;
   const joined = `${directory}${resourcePath}`;
   const hasLeadingSlash = joined.startsWith('/');
   const parts = normalizePathParts(joined.split('/'));

--- a/src/services/localImageResolver.test.ts
+++ b/src/services/localImageResolver.test.ts
@@ -152,6 +152,27 @@ describe('resolveLocalImages', () => {
     expect(container.querySelector('img')?.getAttribute('src')).toBe('file:///Users/demo/photo.png');
   });
 
+  // Regression: when a Markdown file references an image by its POSIX absolute
+  // path (`![主体关系图](/Users/.../图件/主体关系图.png)`), the resolver must
+  // route it through convertFileSrc directly. Previously the absolute path was
+  // joined with the markdown directory, producing
+  // `/Users/.../note.md/Users/.../主体关系图.png` which became an asset URL
+  // pointing nowhere — the editor then classified the load failure as
+  // `decode-failed` ("图片数据损坏，图片字节可能不完整或格式不受支持").
+  it('resolves POSIX absolute image paths to an asset URL without joining the markdown directory', async () => {
+    const { resolveLocalImages: resolve } = await importFresh();
+    const container = createContainerWithImages([{
+      src: '/Users/demo/docs/figures/主体关系图.png',
+      alt: '主体关系图',
+    }]);
+    await resolve(container, '/Users/demo/docs/note.md');
+    const src = container.querySelector('img')?.getAttribute('src') ?? '';
+    expect(src).toContain('asset.localhost');
+    expect(src).toContain('/Users/demo/docs/figures/主体关系图.png');
+    // The bogus double-path must not appear.
+    expect(src).not.toContain('/note.md/Users');
+  });
+
   it('resolves local WebP via Markdown image syntax', async () => {
     // ISS-178 follow-up: lock down that .webp goes through the same path as
     // .png / .jpg — extension-agnostic. Real Tauri runtime verified via


### PR DESCRIPTION
## 根因

`src/services/htmlPresentationService.ts` 的 `isRelativeLocalUrl()` 排除 scheme `:`/`#`/`//`，但漏判 POSIX `/...` 开头。`resolveLocalResourcePath` 把绝对路径错误地拼接到 markdown 所在目录后面：

```
输入: /Users/maoking/Desktop/ceshi/.../图件/主体关系图.png
输出: /Users/maoking/Desktop/ceshi/.../房屋买卖合同纠纷-写字楼过户案/Users/maoking/Desktop/ceshi/.../图件/主体关系图.png
```

该无效路径经 `convertFileSrc()` 转成 `asset://localhost/<bogus>`，`<img>` 加载失败；因 src 以 `asset:` 开头被 `WysiwygEditorPane.classifyError` 归类为 `decode-failed`，触发 "图片数据损坏" 占位（`MediaPlaceholder.tsx:43,53`）。

## 修复

`resolveLocalResourcePath` 入口识别 POSIX / Windows 绝对路径：

- POSIX：`startsWith('/') && !startsWith('//')`（排除 protocol-relative URL）
- Windows：`/^[A-Za-z]:\//`

命中后跳过目录拼接、直接返回解码后的资源路径，仍走 `isSensitivePath` 守卫保护（防止恶意 md 通过 asset 协议探查 `/etc`、`~/.ssh`）。

## 改动

- `src/services/htmlPresentationService.ts`：在 `resolveLocalResourcePath` 入口加绝对路径分支；`usesWindowsSeparators` 改由 `resourceUrl` 决定（绝对路径场景下 filePath 不可信）
- `src/services/htmlPresentationService.test.ts`：3 项新单元测试
  - POSIX 绝对路径应原样返回（不再拼接）
  - Windows 绝对路径应原样返回
  - POSIX 敏感路径（`/etc`、`/private/etc`、`/Users/demo/.ssh/id_rsa`）仍被拒绝
- `src/services/localImageResolver.test.ts`：1 项集成测试，断言绝对路径不被错误拼接到 markdown 目录

## 验证

- ✅ `npm test` 715/715 PASS（含 4 项新增）
- ✅ `npm run typecheck` 0 error
- ✅ `npm run lint` 0 error
- ⚠️ **真机 Tauri runtime 验证（NOT_VERIFIED，移交用户）**：`resolveLocalResourcePath` 是纯函数，单元测试已精确断言输出；`convertFileSrc` + `asset://` 协议由 Tauri runtime 提供，不在本修复范围。建议用户在 macOS Folia 里打开含 `![alt](/Users/.../xxx.png)` 的 markdown 确认图片正常显示。

## 关联 Issue

Closes #127

## 风险评估

- 行为变化：`resolveLocalResourcePath` 现在对 POSIX/Windows 绝对路径返回**解码后**的路径（之前会返回 `undefined` 或拼接后的无效路径），后续会被 `convertFileSrc` 转成正确的 `asset://localhost/...` URL——这是预期行为
- 兼容性：现有相对路径 / 外部 URL / 锚点 / protocol-relative URL / 敏感路径遍历行为全部不变（715 个测试已交叉验证）