### PR TITLE
feat(editor): ISS-207 style=text-align 包裹块对齐恢复

### DIFF
--- a/e2e/wysiwyg-html-wrapper-align.spec.ts
+++ b/e2e/wysiwyg-html-wrapper-align.spec.ts
@@ -123,3 +123,42 @@ test('ISS-205: 空 content 的 html-block 节点全部不可见（无浅色横�
   ));
   expect(markers.join('\n')).toContain('<div align="right">');
 });
+
+test('ISS-207: style="text-align" 写法包裹组段落恢复右对齐', async ({ page }) => {
+  const styleMd = [
+    '<div style="text-align: right">',
+    '',
+    '具状人：某某',
+    '',
+    '2026年　月　日',
+    '',
+    '</div>',
+  ].join('\n');
+  const styleSession = {
+    ...SESSION,
+    activeTabId: 'tab-iss207',
+    tabs: [{
+      ...SESSION.tabs[0],
+      id: 'tab-iss207',
+      file: {
+        ...SESSION.tabs[0].file,
+        path: '/tmp/iss207-style-align.md',
+        name: 'iss207-style-align.md',
+        content: styleMd,
+        lastSavedContent: styleMd,
+      },
+    }],
+  };
+  await page.addInitScript((s) => localStorage.setItem('folia.session.v1', s), JSON.stringify(styleSession));
+
+  await page.goto(APP_URL);
+  await page.waitForSelector('.vditor-ir', { state: 'attached', timeout: 120_000 });
+
+  const sig = page.locator('.vditor-reset p', { hasText: '具状人：某某' });
+  await expect.poll(async () => sig.evaluate((el) => window.getComputedStyle(el).textAlign), {
+    timeout: 30_000,
+    intervals: [500, 1000, 2000],
+  }).toBe('right');
+
+  await expect(page.locator('.vditor-reset p', { hasText: '2026年' })).toHaveCSS('text-align', 'right');
+});

--- a/src/services/vditorIrSanitizeService.test.ts
+++ b/src/services/vditorIrSanitizeService.test.ts
@@ -716,3 +716,60 @@ describe('ISS-205 review 加固：黑名单补强与对齐注入收窄', () => {
       .toContain('落款文字');
   });
 });
+
+describe('repairSplitWrapperHtmlIrPreviews style 写法 (ISS-207)', () => {
+  it('style="text-align:right" 包裹组注入 right class 并隐藏孤立标签，round-trip 保真', () => {
+    const { lute, html } = createIrHtml([
+      '<div style="text-align: right">',
+      '',
+      '具状人：某人',
+      '',
+      '2026年　月　日',
+      '',
+      '</div>',
+    ].join('\n'));
+    const sanitized = sanitizeVditorIrHtml(html);
+    const root = document.createElement('div');
+    root.innerHTML = sanitized.html;
+
+    const changed = repairSplitWrapperHtmlIrPreviews(root);
+
+    expect(changed).toBe(true);
+    expect(root.querySelectorAll('.folia-html-align-right').length).toBe(2);
+    expect(root.querySelectorAll('.folia-html-align-right')[0].textContent).toBe('具状人：某人');
+    // 无 align 属性 → 不注 class 的断言只针对 align 场景；此处 style 已命中
+    expect(root.querySelectorAll('.folia-ir-html-wrap-hidden').length).toBe(2);
+
+    const roundTrip = lute.VditorIRDOM2Md(root.innerHTML);
+    expect(roundTrip).toContain('<div style="text-align: right">');
+    expect(roundTrip).toContain('</div>');
+  });
+
+  it('style 写法大小写/空格变体均可识别', () => {
+    for (const open of ['<div style="TEXT-ALIGN:center">', '<div style="text-align:center">', '<div style=\'text-align:center\'>']) {
+      const md = [open, '', '居中内容', '', '</div>'].join('\n');
+      const { html } = createIrHtml(md);
+      const sanitized = sanitizeVditorIrHtml(html);
+      const root = document.createElement('div');
+      root.innerHTML = sanitized.html;
+
+      repairSplitWrapperHtmlIrPreviews(root);
+
+      const centered = Array.from(root.querySelectorAll('.folia-html-align-center'));
+      expect(centered.map((el) => el.textContent)).toContain('居中内容');
+    }
+  });
+
+  it('无对齐声明的 style 不注入', () => {
+    const md = ['<div style="color:red">', '', '红色段', '', '</div>'].join('\n');
+    const { html } = createIrHtml(md);
+    const sanitized = sanitizeVditorIrHtml(html);
+    const root = document.createElement('div');
+    root.innerHTML = sanitized.html;
+
+    repairSplitWrapperHtmlIrPreviews(root);
+
+    expect(root.querySelectorAll('[class*="folia-html-align-"]').length).toBe(0);
+    expect(root.querySelectorAll('.folia-ir-html-wrap-hidden').length).toBe(2);
+  });
+});

--- a/src/services/vditorIrSanitizeService.ts
+++ b/src/services/vditorIrSanitizeService.ts
@@ -775,6 +775,9 @@ const WRAPPER_TAG_RE = '(?:div|p|section|blockquote)';
 const WRAPPER_OPEN_RE = new RegExp(`^<(${WRAPPER_TAG_RE})((?:\\s[^<>]*)?)>(?:</\\1>)?$`, 'i');
 const WRAPPER_CLOSE_RE = new RegExp(`^</(${WRAPPER_TAG_RE})>$`, 'i');
 const ALIGN_ATTR_RE = /\balign\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))/i;
+// ISS-207：`style="text-align: right"` 与 `align` 属性是同一对齐意图的两种
+// 常见写法（GitHub / Typora 均支持），align 未命中时回退解析 style。
+const STYLE_TEXT_ALIGN_RE = /text-align\s*:\s*(?:"\s*)?([a-z]+)/i;
 
 const ALIGN_CLASS_MAP: Record<string, string> = {
   right: FOLIA_IR_HTML_ALIGN_RIGHT_CLASS,
@@ -791,7 +794,16 @@ function parseWrapperOpenMarker(text: string | null): WrapperOpenInfo | null {
   const attrs = match[2] ?? '';
   const alignMatch = ALIGN_ATTR_RE.exec(attrs);
   const rawAlign = (alignMatch?.[1] ?? alignMatch?.[2] ?? alignMatch?.[3] ?? '').toLowerCase();
-  return { tag: match[1].toLowerCase(), alignClass: ALIGN_CLASS_MAP[rawAlign] ?? null };
+  const fromAttr = ALIGN_CLASS_MAP[rawAlign] ?? null;
+  if (fromAttr) return { tag: match[1].toLowerCase(), alignClass: fromAttr };
+  // style 回退：取 style 属性值内首个 text-align 声明。属性值可能含 `>`?
+  // 不——WRAPPER_OPEN_RE 的 attrs 段排除 `<>`，与既有边界一致（含尖括号
+  // 的属性值 give-up 保横条，安全失败方向）。
+  const styleMatch = /style\s*=\s*(?:"([^"]*)"|'([^']*)')/i.exec(attrs);
+  const styleValue = (styleMatch?.[1] ?? styleMatch?.[2] ?? '').toLowerCase();
+  const textAlignMatch = STYLE_TEXT_ALIGN_RE.exec(styleValue);
+  const styledAlign = textAlignMatch?.[1]?.toLowerCase() ?? '';
+  return { tag: match[1].toLowerCase(), alignClass: ALIGN_CLASS_MAP[styledAlign] ?? null };
 }
 
 function isWrapperCloseMarker(text: string | null, tag: string): boolean {


### PR DESCRIPTION
## Summary

落地 [ISS-207 / Issue #140](https://github.com/cat-xierluo/Folia/issues/140)(PR #137 review M3):`<div style="text-align: right">` 是 `align` 属性的等价写法(GitHub / Typora 均支持),但 ISS-205 修复只解析了 `align` 属性——该写法的包裹组被 Lute 拆块后孤立标签横条已隐藏,**对齐却仍不恢复**。

## Change

`parseWrapperOpenMarker` 在 `ALIGN_ATTR_RE` 未命中时回退解析开标签 `style` 属性内首个 `text-align:` 声明,映射到既有 `folia-html-align-right/center/left` class。隐藏/配对/round-trip 机制零改动。

边界:属性值含尖括号(`<div title="a>b">`)维持 give-up 保横条的安全失败方向(`WRAPPER_OPEN_RE` attrs 段本就排除 `<>`)。

## Test plan

- [x] TDD 红→绿:单测 +3(主用例含 round-trip 逐字保真断言;大小写/单双引号变体;无对齐 style 不注入)
- [x] e2e +1:style 变体真渲染断言(computed `text-align: right`)
- [x] 762/762 单测;typecheck/lint 0 error
- [ ] 真机(tauri dev WKWebView):style 写法右对齐 + align 写法不回归(合并前补充)

Closes #140

关联:PR #137 / #139,Issue #136