### PR TITLE
fix: 补全 PR #142 丢失的 ISS-206 前端代码 + ISS-207 review 小修

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2.6.1", features = [] }
 [dependencies]
 log = "0.4"
 notify = "6"
+base64 = "0.22"
 serde_json = "1.0"
 tauri = { version = "2.11.1", features = ["protocol-asset"] }
 tauri-plugin-log = "2"

--- a/src/services/localImageResolver.test.ts
+++ b/src/services/localImageResolver.test.ts
@@ -239,14 +239,13 @@ describe('resolveLocalImages (ISS-206 data URL 通路)', () => {
   });
 
   it('keeps the original src when the media command fails (oversize / missing)', async () => {
-    const { resolveLocalImages: resolve } = await importFresh();
     vi.resetModules();
     vi.doMock('@tauri-apps/api/core', () => ({
       invoke: vi.fn(async () => {
         throw new Error('media file exceeds the 20971520-byte limit');
       }),
     }));
-    const mod = await import('./localImageResolver');
+    const { resolveLocalImages: resolve } = await import('./localImageResolver');
     const container = createContainerWithImages([{ src: './huge.png' }]);
     await mod.resolveLocalImages(container, '/Users/demo/docs/note.md');
     // 命令失败 → 原样保留（编辑器走占位显示），不得写半截 data URL。

--- a/src/services/localImageResolver.test.ts
+++ b/src/services/localImageResolver.test.ts
@@ -247,7 +247,7 @@ describe('resolveLocalImages (ISS-206 data URL 通路)', () => {
     }));
     const { resolveLocalImages: resolve } = await import('./localImageResolver');
     const container = createContainerWithImages([{ src: './huge.png' }]);
-    await mod.resolveLocalImages(container, '/Users/demo/docs/note.md');
+    await resolve(container, '/Users/demo/docs/note.md');
     // 命令失败 → 原样保留（编辑器走占位显示），不得写半截 data URL。
     expect(container.querySelector('img')?.getAttribute('src')).toBe('./huge.png');
   });

--- a/src/services/localImageResolver.test.ts
+++ b/src/services/localImageResolver.test.ts
@@ -1,20 +1,41 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
-// The function checks for __TAURI_INTERNALS__ in window before loading
-// convertFileSrc. We need to mock both the global and the dynamic import.
+// ISS-206：本地媒体不再走 convertFileSrc → asset 协议（scope 仅 $HOME，
+// 非 HOME 目录文档的图片全部加载失败），改由受控 Rust 命令
+// `read_media_as_data_url` 读字节转 data URL。测试 mock 的是
+// @tauri-apps/api/core 的 `invoke`，并记录每次收到的路径供断言。
 
-const mockConvertFileSrc = (filePath: string) => `https://asset.localhost${filePath}`;
+const invokedPaths: string[] = [];
 
-describe('resolveLocalImages', () => {
+const SUPPORTED_MEDIA_EXT = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico', 'svg', 'avif']);
+
+function mockReadMediaAsDataUrl(path: string): string {
+  invokedPaths.push(path);
+  const ext = path.split('.').pop()?.toLowerCase() ?? '';
+  // 与 Rust media_mime_type 白名单对齐：不支持的扩展名抛错（前端保留原 src）。
+  if (!SUPPORTED_MEDIA_EXT.has(ext)) {
+    throw new Error(`unsupported media extension: ${path}`);
+  }
+  const mime = ext === 'jpg' || ext === 'jpeg'
+    ? 'image/jpeg'
+    : ext === 'svg'
+      ? 'image/svg+xml'
+      : ext === 'webp'
+        ? 'image/webp'
+        : ext === 'gif'
+          ? 'image/gif'
+          : 'image/png';
+  // base64('fake') —— 内容无关紧要，断言只看 data URL 前缀与 invoke 路径。
+  return `data:${mime};base64,ZmFrZQ==`;
+}
+
+describe('resolveLocalImages (ISS-206 data URL 通路)', () => {
   let originalInternals: unknown;
 
   beforeEach(() => {
+    invokedPaths.length = 0;
     originalInternals = (window as Record<string, unknown>).__TAURI_INTERNALS__;
-    (window as Record<string, unknown>).__TAURI_INTERNALS__ = {
-      convertFileSrc: mockConvertFileSrc,
-    };
-    // Reset the cached function so it re-initializes each test
-    // We re-import the module to reset the module-level cache
+    (window as Record<string, unknown>).__TAURI_INTERNALS__ = {};
   });
 
   afterEach(() => {
@@ -25,7 +46,10 @@ describe('resolveLocalImages', () => {
   async function importFresh(): Promise<typeof import('./localImageResolver')> {
     vi.resetModules();
     vi.doMock('@tauri-apps/api/core', () => ({
-      convertFileSrc: mockConvertFileSrc,
+      invoke: vi.fn(async (cmd: string, args: { path: string }) => {
+        expect(cmd).toBe('read_media_as_data_url');
+        return mockReadMediaAsDataUrl(args.path);
+      }),
     }));
     return import('./localImageResolver');
   }
@@ -49,31 +73,30 @@ describe('resolveLocalImages', () => {
     expect(container.querySelector('img')?.getAttribute('src')).toBe('./photo.webp');
   });
 
-  it('resolves relative image paths to asset URLs', async () => {
+  it('resolves relative image paths via the media data-url command', async () => {
     const { resolveLocalImages: resolve } = await importFresh();
     const container = createContainerWithImages([{ src: './photo.webp' }]);
     await resolve(container, '/Users/demo/docs/note.md');
     const img = container.querySelector('img');
     expect(img).toBeTruthy();
-    const src = img!.getAttribute('src');
-    expect(src).toContain('asset.localhost');
-    expect(src).toContain('/Users/demo/docs/photo.webp');
+    expect(invokedPaths).toContain('/Users/demo/docs/photo.webp');
+    expect(img!.getAttribute('src')).toBe('data:image/webp;base64,ZmFrZQ==');
   });
 
   it('resolves images in subdirectories', async () => {
     const { resolveLocalImages: resolve } = await importFresh();
     const container = createContainerWithImages([{ src: 'assets/images/logo.png' }]);
     await resolve(container, '/Users/demo/projects/readme.md');
-    const src = container.querySelector('img')?.getAttribute('src');
-    expect(src).toContain('/Users/demo/projects/assets/images/logo.png');
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('data:image/png;base64,ZmFrZQ==');
+    expect(invokedPaths).toContain('/Users/demo/projects/assets/images/logo.png');
   });
 
   it('resolves parent directory references', async () => {
     const { resolveLocalImages: resolve } = await importFresh();
     const container = createContainerWithImages([{ src: '../images/photo.jpg' }]);
     await resolve(container, '/Users/demo/docs/sub/notes.md');
-    const src = container.querySelector('img')?.getAttribute('src');
-    expect(src).toContain('/Users/demo/docs/images/photo.jpg');
+    expect(invokedPaths).toContain('/Users/demo/docs/images/photo.jpg');
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('data:image/jpeg;base64,ZmFrZQ==');
   });
 
   it('restores a sanitized Vditor IR image src from its relative Markdown marker', async () => {
@@ -88,9 +111,9 @@ describe('resolveLocalImages', () => {
 
     await resolve(container, '/Users/demo/project/manuscript/04-实战篇/ch10.md');
 
+    expect(invokedPaths).toContain('/Users/demo/project/figures/screenshots/ch10/示例图片.png');
     const src = container.querySelector('img')?.getAttribute('src') ?? '';
-    expect(src).toContain('asset.localhost');
-    expect(src).toContain('/Users/demo/project/figures/screenshots/ch10/示例图片.png');
+    expect(src).toMatch(/^data:image\/png;base64,/);
   });
 
   it('does not restore a sanitized Vditor IR image marker that resolves into a sensitive path', async () => {
@@ -106,6 +129,7 @@ describe('resolveLocalImages', () => {
     await resolve(container, '/Users/demo/decks/case.md');
 
     expect(container.querySelector('img')?.hasAttribute('src')).toBe(false);
+    expect(invokedPaths).toHaveLength(0);
   });
 
   it('resolves two-level parent references with Chinese file names (ISS-187)', async () => {
@@ -117,11 +141,10 @@ describe('resolveLocalImages', () => {
       container,
       '/Users/demo/法律 skill 书籍项目/manuscript/04-实战篇/ch10-鉴定式案例分析.md',
     );
-    const src = container.querySelector('img')?.getAttribute('src');
-    expect(src).toContain('asset.localhost');
-    expect(src).toContain(
+    expect(invokedPaths).toContain(
       '/Users/demo/法律 skill 书籍项目/figures/screenshots/ch10/fig-ch10-s3-05-W2a请求权预选.png',
     );
+    expect(container.querySelector('img')?.getAttribute('src')).toMatch(/^data:image\/png;base64,/);
   });
 
   it('skips data: URIs', async () => {
@@ -129,6 +152,7 @@ describe('resolveLocalImages', () => {
     const container = createContainerWithImages([{ src: 'data:image/png;base64,abc123' }]);
     await resolve(container, '/Users/demo/docs/note.md');
     expect(container.querySelector('img')?.getAttribute('src')).toBe('data:image/png;base64,abc123');
+    expect(invokedPaths).toHaveLength(0);
   });
 
   it('skips https:// URLs', async () => {
@@ -136,6 +160,7 @@ describe('resolveLocalImages', () => {
     const container = createContainerWithImages([{ src: 'https://example.com/photo.png' }]);
     await resolve(container, '/Users/demo/docs/note.md');
     expect(container.querySelector('img')?.getAttribute('src')).toBe('https://example.com/photo.png');
+    expect(invokedPaths).toHaveLength(0);
   });
 
   it('skips http:// URLs', async () => {
@@ -143,6 +168,7 @@ describe('resolveLocalImages', () => {
     const container = createContainerWithImages([{ src: 'http://example.com/photo.png' }]);
     await resolve(container, '/Users/demo/docs/note.md');
     expect(container.querySelector('img')?.getAttribute('src')).toBe('http://example.com/photo.png');
+    expect(invokedPaths).toHaveLength(0);
   });
 
   it('skips file:// URLs', async () => {
@@ -150,39 +176,35 @@ describe('resolveLocalImages', () => {
     const container = createContainerWithImages([{ src: 'file:///Users/demo/photo.png' }]);
     await resolve(container, '/Users/demo/docs/note.md');
     expect(container.querySelector('img')?.getAttribute('src')).toBe('file:///Users/demo/photo.png');
+    expect(invokedPaths).toHaveLength(0);
   });
 
   // Regression: when a Markdown file references an image by its POSIX absolute
   // path (`![主体关系图](/Users/.../图件/主体关系图.png)`), the resolver must
-  // route it through convertFileSrc directly. Previously the absolute path was
+  // hand that exact path to the media command. Previously the absolute path was
   // joined with the markdown directory, producing
-  // `/Users/.../note.md/Users/.../主体关系图.png` which became an asset URL
-  // pointing nowhere — the editor then classified the load failure as
-  // `decode-failed` ("图片数据损坏，图片字节可能不完整或格式不受支持").
-  it('resolves POSIX absolute image paths to an asset URL without joining the markdown directory', async () => {
+  // `/Users/.../note.md/Users/.../主体关系图.png` which pointed nowhere — the
+  // editor classified the load failure as `decode-failed`.
+  it('resolves POSIX absolute image paths without joining the markdown directory', async () => {
     const { resolveLocalImages: resolve } = await importFresh();
     const container = createContainerWithImages([{
       src: '/Users/demo/docs/figures/主体关系图.png',
       alt: '主体关系图',
     }]);
     await resolve(container, '/Users/demo/docs/note.md');
+    expect(invokedPaths).toContain('/Users/demo/docs/figures/主体关系图.png');
     const src = container.querySelector('img')?.getAttribute('src') ?? '';
-    expect(src).toContain('asset.localhost');
-    expect(src).toContain('/Users/demo/docs/figures/主体关系图.png');
-    // The bogus double-path must not appear.
-    expect(src).not.toContain('/note.md/Users');
+    expect(src).toMatch(/^data:image\/png;base64,/);
   });
 
-  it('resolves local WebP via Markdown image syntax', async () => {
+  it('resolves local WebP via Markdown image syntax (extension-agnostic)', async () => {
     // ISS-178 follow-up: lock down that .webp goes through the same path as
-    // .png / .jpg — extension-agnostic. Real Tauri runtime verified via
-    // `folia-fresh-1.png` (test.md with `![](./sample.webp)`).
+    // .png / .jpg — extension-agnostic.
     const { resolveLocalImages: resolve } = await importFresh();
     const container = createContainerWithImages([{ src: './sample.webp' }]);
     await resolve(container, '/tmp/folia-webp-test/test.md');
-    const src = container.querySelector('img')?.getAttribute('src');
-    expect(src).toContain('asset.localhost');
-    expect(src).toContain('/tmp/folia-webp-test/sample.webp');
+    expect(invokedPaths).toContain('/tmp/folia-webp-test/sample.webp');
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('data:image/webp;base64,ZmFrZQ==');
   });
 
   it('resolves local WebP via inline HTML <img src> tag', async () => {
@@ -194,8 +216,8 @@ describe('resolveLocalImages', () => {
     img.setAttribute('src', './sample.webp');
     container.appendChild(img);
     await resolve(container, '/tmp/folia-webp-test/test.md');
-    expect(img.getAttribute('src')).toContain('asset.localhost');
-    expect(img.getAttribute('src')).toContain('/tmp/folia-webp-test/sample.webp');
+    expect(invokedPaths).toContain('/tmp/folia-webp-test/sample.webp');
+    expect(img.getAttribute('src')).toBe('data:image/webp;base64,ZmFrZQ==');
   });
 
   it('handles multiple images in one container', async () => {
@@ -208,14 +230,30 @@ describe('resolveLocalImages', () => {
     ]);
     await resolve(container, '/Users/demo/docs/sub/note.md');
     const imgs = container.querySelectorAll('img');
-    expect(imgs[0].getAttribute('src')).toContain('asset.localhost');
-    expect(imgs[0].getAttribute('src')).toContain('/Users/demo/docs/sub/local.webp');
+    expect(imgs[0].getAttribute('src')).toBe('data:image/webp;base64,ZmFrZQ==');
     expect(imgs[1].getAttribute('src')).toBe('https://remote.com/img.png');
-    expect(imgs[2].getAttribute('src')).toContain('/Users/demo/docs/parent.gif');
+    expect(imgs[2].getAttribute('src')).toBe('data:image/gif;base64,ZmFrZQ==');
     expect(imgs[3].getAttribute('src')).toBe('data:image/svg+xml,<svg></svg>');
+    expect(invokedPaths).toContain('/Users/demo/docs/sub/local.webp');
+    expect(invokedPaths).toContain('/Users/demo/docs/parent.gif');
   });
 
-  it('resolves <source src> relative paths', async () => {
+  it('keeps the original src when the media command fails (oversize / missing)', async () => {
+    const { resolveLocalImages: resolve } = await importFresh();
+    vi.resetModules();
+    vi.doMock('@tauri-apps/api/core', () => ({
+      invoke: vi.fn(async () => {
+        throw new Error('media file exceeds the 20971520-byte limit');
+      }),
+    }));
+    const mod = await import('./localImageResolver');
+    const container = createContainerWithImages([{ src: './huge.png' }]);
+    await mod.resolveLocalImages(container, '/Users/demo/docs/note.md');
+    // 命令失败 → 原样保留（编辑器走占位显示），不得写半截 data URL。
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('./huge.png');
+  });
+
+  it('keeps original src for <source> with unsupported media extension (mp4 不在白名单)', async () => {
     const { resolveLocalImages: resolve } = await importFresh();
     const container = document.createElement('div');
     const video = document.createElement('video');
@@ -224,9 +262,9 @@ describe('resolveLocalImages', () => {
     video.appendChild(source);
     container.appendChild(video);
     await resolve(container, '/Users/demo/docs/note.md');
-    const src = container.querySelector('source')?.getAttribute('src') ?? '';
-    expect(src).toContain('asset.localhost');
-    expect(src).toContain('/Users/demo/docs/clip.mp4');
+    // 命令被调用但白名单拒绝 → 保留原 src（与 Rust 端 Err 行为一致）。
+    expect(invokedPaths).toContain('/Users/demo/docs/clip.mp4');
+    expect(container.querySelector('source')?.getAttribute('src')).toBe('./clip.mp4');
   });
 
   it('resolves <video poster> relative paths', async () => {
@@ -236,9 +274,8 @@ describe('resolveLocalImages', () => {
     video.setAttribute('poster', './cover.jpg');
     container.appendChild(video);
     await resolve(container, '/Users/demo/docs/note.md');
-    const poster = container.querySelector('video')?.getAttribute('poster') ?? '';
-    expect(poster).toContain('asset.localhost');
-    expect(poster).toContain('/Users/demo/docs/cover.jpg');
+    expect(invokedPaths).toContain('/Users/demo/docs/cover.jpg');
+    expect(container.querySelector('video')?.getAttribute('poster')).toMatch(/^data:image\/jpeg;base64,/);
   });
 
   it('resolves <img srcset> candidates while preserving descriptors', async () => {
@@ -249,9 +286,9 @@ describe('resolveLocalImages', () => {
     container.appendChild(img);
     await resolve(container, '/Users/demo/docs/note.md');
     const srcset = container.querySelector('img')?.getAttribute('srcset') ?? '';
-    expect(srcset).toContain('/Users/demo/docs/a.webp');
+    expect(invokedPaths).toContain('/Users/demo/docs/a.webp');
+    expect(invokedPaths).toContain('/Users/demo/docs/b.webp');
     expect(srcset).toContain('1x');
-    expect(srcset).toContain('/Users/demo/docs/b.webp');
     expect(srcset).toContain('2x');
     // External URL inside srcset is left untouched.
     expect(srcset).toContain('https://cdn.example/c.webp');
@@ -265,9 +302,9 @@ describe('resolveLocalImages', () => {
     el.setAttribute('style', "background-image: url('./bg.png'); color: red");
     container.appendChild(el);
     await resolve(container, '/Users/demo/docs/note.md');
+    expect(invokedPaths).toContain('/Users/demo/docs/bg.png');
     const style = container.querySelector('div')?.getAttribute('style') ?? '';
-    expect(style).toContain('asset.localhost');
-    expect(style).toContain('/Users/demo/docs/bg.png');
+    expect(style).toContain('data:image/png;base64,ZmFrZQ==');
     // Unrelated CSS declarations are preserved.
     expect(style).toContain('color: red');
   });
@@ -280,9 +317,9 @@ describe('resolveLocalImages', () => {
       '.hero { background: url("./hero.jpg") center; } .keep { background: url("https://x/y.png"); }';
     container.appendChild(style);
     await resolve(container, '/Users/demo/docs/note.md');
+    expect(invokedPaths).toContain('/Users/demo/docs/hero.jpg');
     const text = container.querySelector('style')?.textContent ?? '';
-    expect(text).toContain('/Users/demo/docs/hero.jpg');
-    expect(text).toContain('asset.localhost');
+    expect(text).toContain('data:image/jpeg;base64,ZmFrZQ==');
     // External URL left untouched.
     expect(text).toContain('https://x/y.png');
   });
@@ -295,6 +332,23 @@ describe('resolveLocalImages', () => {
     // Sensitive traversal refused → original src preserved.
     expect(imgs[0].getAttribute('src')).toBe('../../../etc/passwd');
     // Normal sibling reference resolved.
-    expect(imgs[1].getAttribute('src')).toContain('/Users/demo/decks/ok.png');
+    expect(invokedPaths).toContain('/Users/demo/decks/ok.png');
+    expect(imgs[1].getAttribute('src')).toBe('data:image/png;base64,ZmFrZQ==');
+  });
+
+  it('caches repeated paths — the media command runs once per unique path (input 高频路径)', async () => {
+    const { resolveLocalImages: resolve } = await importFresh();
+    const container = createContainerWithImages([
+      { src: './same.png' },
+      { src: './same.png' },
+    ]);
+    await resolve(container, '/Users/demo/docs/note.md');
+    await resolve(container, '/Users/demo/docs/note.md');
+    const sameCalls = invokedPaths.filter((p) => p === '/Users/demo/docs/same.png');
+    expect(sameCalls).toHaveLength(1);
+    // 两张 img 都拿到 data URL
+    const imgs = container.querySelectorAll('img');
+    expect(imgs[0].getAttribute('src')).toBe('data:image/png;base64,ZmFrZQ==');
+    expect(imgs[1].getAttribute('src')).toBe('data:image/png;base64,ZmFrZQ==');
   });
 });

--- a/src/services/localImageResolver.ts
+++ b/src/services/localImageResolver.ts
@@ -1,33 +1,68 @@
+import { invoke } from '@tauri-apps/api/core';
 import { resolveLocalResourcePath } from './htmlPresentationService';
 
-type ConvertFileSrcFn = (filePath: string, protocol?: string) => string;
+/**
+ * ISS-206 / Issue #138：本地媒体解析通路由「convertFileSrc → asset 协议」
+ * 改为「受控 Rust 命令 read_media_as_data_url 读字节 → data URL」。
+ *
+ * 原通路受 Tauri assetProtocol scope（仅 `$HOME/**`）限制：`$HOME` 之外的
+ * 图片（/tmp、外置卷）一律 `asset protocol not configured to allow the
+ * path` → `<img>` 加载失败 → 「图片数据损坏」占位。data URL 通路天然不受
+ * scope 限制，且与 ISS-201「持久 IO 收敛到自定义命令」同向——命令端有
+ * 绝对路径 / denied-root 黑名单 / 扩展名白名单 / 20MB 上限四层约束。
+ *
+ * 幂等：data:/blob:/http(s):/file:// 等外部 URL 原样跳过（isExternalOrDataUrl）。
+ * 失败语义：命令 Err（超限 / 扩展名不支持 / 文件不存在）→ 返回 null →
+ * 保留原 src，编辑器按既有占位逻辑显示。
+ *
+ * 缓存：data URL 由路径唯一决定且不可变，模块级 Map 缓存 path → dataURL，
+ * 使编辑器高频输入路径（每次 sanitize 触发 resolveLocalImages）对同一
+ * 资源只发生一次 IPC + 读盘。上限 500 条，超出整表清空（简单防泄漏，
+ * media 资源数量级远小于该值）。
+ */
+const dataUrlCache = new Map<string, string>();
+const DATA_URL_CACHE_LIMIT = 500;
+// 并发去重：同一容器内多张相同 src 的 img 会在缓存写入前并发到达，
+// in-flight 表把同路径请求合并为一次 IPC。
+const inflightMedia = new Map<string, Promise<string | null>>();
 
-const NOT_AVAILABLE = Symbol('not-available');
-let convertFileSrcFn: ConvertFileSrcFn | typeof NOT_AVAILABLE | null = null;
+let invokeUnavailable = false;
 
-async function ensureConvertFileSrc(): Promise<ConvertFileSrcFn | null> {
-  if (convertFileSrcFn !== null) {
-    return convertFileSrcFn === NOT_AVAILABLE ? null : convertFileSrcFn;
-  }
+async function readMediaAsDataUrl(absolutePath: string): Promise<string | null> {
+  const cached = dataUrlCache.get(absolutePath);
+  if (cached !== undefined) return cached;
+  const pending = inflightMedia.get(absolutePath);
+  if (pending) return pending;
+  if (invokeUnavailable) return null;
   if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) {
-    convertFileSrcFn = NOT_AVAILABLE;
+    // 纯 Web 环境（vite dev / 测试）没有 Tauri runtime，媒体通路不可用。
+    invokeUnavailable = true;
     return null;
   }
+  const request = (async () => {
+    try {
+      const dataUrl = await invoke<string>('read_media_as_data_url', { path: absolutePath });
+      if (dataUrlCache.size >= DATA_URL_CACHE_LIMIT) dataUrlCache.clear();
+      dataUrlCache.set(absolutePath, dataUrl);
+      return dataUrl;
+    } catch {
+      // 命令 Err（超限 / 不支持扩展名 / 不存在 / denied root）→ 保留原 src。
+      return null;
+    }
+  })();
+  inflightMedia.set(absolutePath, request);
   try {
-    const { convertFileSrc } = await import('@tauri-apps/api/core');
-    convertFileSrcFn = convertFileSrc;
-    return convertFileSrcFn;
-  } catch {
-    convertFileSrcFn = NOT_AVAILABLE;
-    return null;
+    return await request;
+  } finally {
+    inflightMedia.delete(absolutePath);
   }
 }
 
 /**
  * `true` if `rawSrc` is an absolute URL, data URI, blob URI, protocol-relative
  * URL, or hash-only fragment that must be left untouched (not a local relative
- * path). Also recognises already-converted Tauri asset URLs so the pass is
- * idempotent.
+ * path). Also recognises legacy converted Tauri asset URLs so the pass is
+ * idempotent over stale DOM state from before the ISS-206 migration.
  */
 function isExternalOrDataUrl(rawSrc: string): boolean {
   const value = rawSrc.trim();
@@ -46,17 +81,17 @@ function isExternalOrDataUrl(rawSrc: string): boolean {
   );
 }
 
-/** Resolve a single relative URL to a Tauri asset URL, or `null` if it must be left as-is. */
-function resolveSingleUrl(rawSrc: string, filePath: string, convertFn: ConvertFileSrcFn): string | null {
+/** Resolve a single relative URL to a data URL, or `null` if it must be left as-is. */
+async function resolveSingleUrl(rawSrc: string, filePath: string): Promise<string | null> {
   if (isExternalOrDataUrl(rawSrc)) return null;
   const absolutePath = resolveLocalResourcePath(filePath, rawSrc);
   if (!absolutePath) return null;
-  return convertFn(absolutePath);
+  return readMediaAsDataUrl(absolutePath);
 }
 
 /**
  * Vditor IR keeps the original Markdown image destination in a sibling marker.
- * A later DOMPurify pass may remove the already-converted `asset:` src while
+ * A later DOMPurify pass may remove the already-resolved `data:` src while
  * leaving that marker intact. Recover only relative marker values here; the
  * normal sensitive-path guard still runs inside resolveSingleUrl().
  */
@@ -70,10 +105,9 @@ function getVditorIrImageMarkerSource(image: Element): string | null {
 const SRCSET_DESCRIPTOR_PATTERN = /^\d+(\.\d+)?[wx]$/;
 
 /** Resolve every candidate URL inside a `srcset` attribute (`./a.webp 1x, ./b.webp 2x`). */
-function resolveSrcset(raw: string, filePath: string, convertFn: ConvertFileSrcFn): string {
-  return raw
-    .split(',')
-    .map((candidate) => {
+async function resolveSrcset(raw: string, filePath: string): Promise<string> {
+  const candidates = await Promise.all(
+    raw.split(',').map(async (candidate) => {
       const trimmed = candidate.trim();
       if (!trimmed) return '';
       // A srcset entry is `url [descriptor]` where descriptor is `1x` / `100w`.
@@ -86,84 +120,107 @@ function resolveSrcset(raw: string, filePath: string, convertFn: ConvertFileSrcF
         urlPart = trimmed.slice(0, lastSpace);
         descriptor = trimmed.slice(lastSpace + 1);
       }
-      const resolved = resolveSingleUrl(urlPart, filePath, convertFn);
+      const resolved = await resolveSingleUrl(urlPart, filePath);
       if (resolved === null) return trimmed; // external / traversal-protected — keep original
       return descriptor ? `${resolved} ${descriptor}` : resolved;
-    })
-    .filter(Boolean)
-    .join(', ');
+    }),
+  );
+  return candidates.filter(Boolean).join(', ');
 }
 
 /** Resolve relative `url(...)` references inside CSS (inline `style` or `<style>` text). */
-function resolveCssUrls(text: string, filePath: string, convertFn: ConvertFileSrcFn): string {
-  return text.replace(/url\(\s*(['"]?)([^'")]+)\1\s*\)/g, (full, _quote, url) => {
-    const resolved = resolveSingleUrl(url, filePath, convertFn);
-    return resolved === null ? full : `url(${resolved})`;
-  });
+async function resolveCssUrls(text: string, filePath: string): Promise<string> {
+  const replacements = await Promise.all(
+    Array.from(text.matchAll(/url\(\s*(['"]?)([^'")]+)\1\s*\)/g)).map(async (match) => {
+      const resolved = await resolveSingleUrl(match[2], filePath);
+      return resolved === null ? null : { full: match[0], resolved };
+    }),
+  );
+  let result = text;
+  for (const replacement of replacements) {
+    if (!replacement) continue;
+    result = result.replace(replacement.full, `url(${replacement.resolved})`);
+  }
+  return result;
 }
 
 /**
  * Resolve local relative media references inside a container element so they
- * can be loaded by the Tauri WebView.
+ * can be displayed by the WebView (ISS-206: via the controlled media command,
+ * not the asset protocol).
  *
  * Covers `<img src>`, `<source src>`, `<video poster>`, `srcset` candidates
  * (`<img>` / `<source>`), and CSS `background-image: url(...)` (both inline
  * `style` attributes and `<style>` blocks). Each relative path is resolved
- * against the currently-open file's directory, then converted to a Tauri asset
- * URL via `convertFileSrc()`.
+ * against the currently-open file's directory, then loaded through the
+ * `read_media_as_data_url` command.
  *
- * Idempotent: absolute URLs / data URIs / already-converted asset URLs are
- * left untouched. Paths that traverse into sensitive directories (see
- * `isSensitivePath` in `htmlPresentationService`) are refused and the original
- * attribute is preserved.
+ * Idempotent: absolute URLs / data URIs / stale asset URLs are left untouched.
+ * Paths that traverse into sensitive directories (see `isSensitivePath` in
+ * `htmlPresentationService`) are refused and the original attribute is
+ * preserved.
  */
 export async function resolveLocalImages(
   container: HTMLElement,
   filePath: string | undefined,
 ): Promise<void> {
   if (!filePath) return;
-
-  const convertFn = await ensureConvertFileSrc();
-  if (!convertFn) return;
+  if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) return;
 
   // Single-attribute media sources. Query all img nodes because Vditor's
-  // post-render sanitizer may have removed an asset: src; in that case the
-  // original relative destination is recovered from its IR marker.
+  // post-render sanitizer may have removed an already-resolved src; in that
+  // case the original relative destination is recovered from its IR marker.
   const singleAttrSelectors: Array<{ selector: string; attr: string }> = [
     { selector: 'img', attr: 'src' },
     { selector: 'source[src]', attr: 'src' },
     { selector: 'video[poster]', attr: 'poster' },
   ];
+  const singleAttrTasks: Array<Promise<void>> = [];
   for (const { selector, attr } of singleAttrSelectors) {
     container.querySelectorAll(selector).forEach((el) => {
       const raw = el.getAttribute(attr)
         ?? (selector === 'img' ? getVditorIrImageMarkerSource(el) : null);
       if (!raw) return;
-      const resolved = resolveSingleUrl(raw, filePath, convertFn);
-      if (resolved !== null) el.setAttribute(attr, resolved);
+      singleAttrTasks.push(
+        resolveSingleUrl(raw, filePath).then((resolved) => {
+          if (resolved !== null) el.setAttribute(attr, resolved);
+        }),
+      );
     });
   }
 
-  // srcset candidates: img[srcset], source[srcset].
+  const srcsetTasks: Array<Promise<void>> = [];
   container.querySelectorAll('img[srcset], source[srcset]').forEach((el) => {
     const raw = el.getAttribute('srcset');
     if (!raw) return;
-    const resolved = resolveSrcset(raw, filePath, convertFn);
-    if (resolved !== raw) el.setAttribute('srcset', resolved);
+    srcsetTasks.push(
+      resolveSrcset(raw, filePath).then((resolved) => {
+        if (resolved !== raw) el.setAttribute('srcset', resolved);
+      }),
+    );
   });
 
-  // CSS background-image: inline `style` attributes containing url(...).
+  const styleTasks: Array<Promise<void>> = [];
   container.querySelectorAll<HTMLElement>('[style]').forEach((el) => {
     const style = el.getAttribute('style');
     if (!style || !style.includes('url(')) return;
-    const resolved = resolveCssUrls(style, filePath, convertFn);
-    if (resolved !== style) el.setAttribute('style', resolved);
+    styleTasks.push(
+      resolveCssUrls(style, filePath).then((resolved) => {
+        if (resolved !== style) el.setAttribute('style', resolved);
+      }),
+    );
   });
 
-  // CSS: <style> blocks containing url(...).
+  const styleBlockTasks: Array<Promise<void>> = [];
   container.querySelectorAll('style').forEach((styleEl) => {
     const text = styleEl.textContent;
     if (!text || !text.includes('url(')) return;
-    styleEl.textContent = resolveCssUrls(text, filePath, convertFn);
+    styleBlockTasks.push(
+      resolveCssUrls(text, filePath).then((resolved) => {
+        if (resolved !== text) styleEl.textContent = resolved;
+      }),
+    );
   });
+
+  await Promise.all([...singleAttrTasks, ...srcsetTasks, ...styleTasks, ...styleBlockTasks]);
 }

--- a/src/services/vditorIrSanitizeService.test.ts
+++ b/src/services/vditorIrSanitizeService.test.ts
@@ -773,3 +773,33 @@ describe('repairSplitWrapperHtmlIrPreviews style 写法 (ISS-207)', () => {
     expect(root.querySelectorAll('.folia-ir-html-wrap-hidden').length).toBe(2);
   });
 });
+
+describe('ISS-207 review 加固：style 解析语义', () => {
+  it('align 属性与 style 同存时 align 优先（守卫锁定短路逻辑）', () => {
+    const md = ['<div align="right" style="text-align:center">', '', '优先级段', '', '</div>'].join('\n');
+    const { html } = createIrHtml(md);
+    const sanitized = sanitizeVditorIrHtml(html);
+    const root = document.createElement('div');
+    root.innerHTML = sanitized.html;
+
+    repairSplitWrapperHtmlIrPreviews(root);
+
+    const aligned = Array.from(root.querySelectorAll('.folia-html-align-right'));
+    expect(aligned.map((el) => el.textContent)).toContain('优先级段');
+    expect(root.querySelectorAll('.folia-html-align-center').length).toBe(0);
+  });
+
+  it('多个 text-align 声明取最后一个（CSS 层叠「后者胜」）', () => {
+    const md = ['<div style="text-align:left;text-align: right">', '', '层叠段', '', '</div>'].join('\n');
+    const { html } = createIrHtml(md);
+    const sanitized = sanitizeVditorIrHtml(html);
+    const root = document.createElement('div');
+    root.innerHTML = sanitized.html;
+
+    repairSplitWrapperHtmlIrPreviews(root);
+
+    const aligned = Array.from(root.querySelectorAll('.folia-html-align-right'));
+    expect(aligned.map((el) => el.textContent)).toContain('层叠段');
+    expect(root.querySelectorAll('.folia-html-align-left').length).toBe(0);
+  });
+});

--- a/src/services/vditorIrSanitizeService.ts
+++ b/src/services/vditorIrSanitizeService.ts
@@ -777,7 +777,9 @@ const WRAPPER_CLOSE_RE = new RegExp(`^</(${WRAPPER_TAG_RE})>$`, 'i');
 const ALIGN_ATTR_RE = /\balign\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))/i;
 // ISS-207：`style="text-align: right"` 与 `align` 属性是同一对齐意图的两种
 // 常见写法（GitHub / Typora 均支持），align 未命中时回退解析 style。
-const STYLE_TEXT_ALIGN_RE = /text-align\s*:\s*(?:"\s*)?([a-z]+)/i;
+// post-merge review M2：CSS 层叠语义是「后者胜」，多个 text-align 声明取
+// 最后一个（exec 首个会与浏览器实际渲染背离）。
+const STYLE_TEXT_ALIGN_RE = /text-align\s*:\s*([a-z]+)/gi;
 
 const ALIGN_CLASS_MAP: Record<string, string> = {
   right: FOLIA_IR_HTML_ALIGN_RIGHT_CLASS,
@@ -801,8 +803,13 @@ function parseWrapperOpenMarker(text: string | null): WrapperOpenInfo | null {
   // 的属性值 give-up 保横条，安全失败方向）。
   const styleMatch = /style\s*=\s*(?:"([^"]*)"|'([^']*)')/i.exec(attrs);
   const styleValue = (styleMatch?.[1] ?? styleMatch?.[2] ?? '').toLowerCase();
-  const textAlignMatch = STYLE_TEXT_ALIGN_RE.exec(styleValue);
-  const styledAlign = textAlignMatch?.[1]?.toLowerCase() ?? '';
+  // 取最后一个 text-align 声明（CSS 层叠「后者胜」）；g 标志正则需手动
+  // 重置 lastIndex，避免跨调用状态残留。
+  let styledAlign = '';
+  STYLE_TEXT_ALIGN_RE.lastIndex = 0;
+  for (const match of styleValue.matchAll(STYLE_TEXT_ALIGN_RE)) {
+    styledAlign = match[1]?.toLowerCase() ?? '';
+  }
   return { tag: match[1].toLowerCase(), alignClass: ALIGN_CLASS_MAP[styledAlign] ?? null };
 }
 


### PR DESCRIPTION
## ⚠️ 事故修复:PR #142 的实现代码在 squash merge 时丢失

**事故链**(post-merge review 发现,已复核属实):提交 PR #142 时,`git add` 列表含根目录 `Cargo.lock`(该文件实际在 `src-tauri/` 下),pathspec 不存在导致**整条 add 失败**,stderr 被 `2>/devnull` 吞掉;后续只 add 了 CHANGELOG → `be69205` 只包含 CHANGELOG + src-tauri/Cargo.lock(+base64 孤儿条目)。lib.rs 命令部分因 #143 分支切自残留工作区而"意外"进入了 main,但:

- `Cargo.toml` 的 `base64` 依赖缺失 → **main 的 Rust 编译已损坏**(`lib.rs use base64` 无依赖声明;lock/toml 失配)
- `localImageResolver.ts` 重写 + 23 项测试**完全不在 main**(仍是旧 convertFileSrc 实现)

## 本 PR 补齐(commit 1)+ review 小修(commit 2)

**651d18e** — ISS-206 补全:
- `src-tauri/Cargo.toml`:补 `base64 = "0.22"`(修复编译)
- `localImageResolver.ts`:ISS-206 重写原样回归(invoke `read_media_as_data_url` / 模块级缓存 500 + in-flight 去重 / 全媒体面 / 失败保留原 src)
- `localImageResolver.test.ts`:23 项 invoke mock 断言

**6e4fb36** — ISS-207 review 小修(PR #141 报告 M2/M3):
- 多个 `text-align` 声明取**最后一个**(CSS 层叠「后者胜」;exec 取首个会与浏览器渲染背离);g 正则重置 lastIndex
- 去掉值内引号容忍组(不对称)
- 补 align+style 同存优先级守卫测试 + 多声明层叠测试

## Test plan

- [x] `cargo build` 通过(编译损坏修复)
- [x] vitest 相关 60/60(sanitize 37 + resolver 23)
- [ ] CI 全绿
- [ ] 合并后重跑真机图片验证(main 树上的最终确认)

关联:PR #142 / #143 / #141,Issue #138 / #140,post-merge review NEEDS-FOLLOWUP 报告(2026-08-27)