### PR TITLE
fix(app): ISS-209 重读窗口抑制 autosave——防降级恢复空 content 覆盖磁盘

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -956,17 +956,6 @@ export function AppLayout() {
     });
   }, [isTauriRuntime, settings.autoUpdateCheck, autoUpdateCheckStarted, startBackgroundUpdateDownload]);
 
-  useEffect(() => {
-    if (!settings.autoSave || !file.path || !file.dirty || file.fileType === 'docx') return;
-    const timeout = window.setTimeout(() => {
-      void import('../services/fileService')
-        .then(({ saveFile }) => saveFile(file))
-        .then((updated) => updateActiveFile(() => updated))
-        .catch((e) => console.error('Auto-save failed:', e));
-    }, 800);
-    return () => window.clearTimeout(timeout);
-  }, [file, settings.autoSave, updateActiveFile]);
-
   // ISS-188：监听文件外部修改 → 自动 reload / 提示手动 reload。
   //
   // 数据流：Rust notify::recommended_watcher → src-tauri/src/lib.rs 发出
@@ -1142,6 +1131,22 @@ export function AppLayout() {
     && !!activeTab.file.path
     && !activeTab.file.content
     && !(activeTab.file.fileType === 'docx' && activeTab.file.docxHtml);
+
+  // ISS-209 / Issue #149:重读窗口(reloading)内禁止 autosave——降级恢复 tab
+  // 持久化时带 dirty=true 且 content='',若 800ms tick 在磁盘内容回填前触发,
+  // saveFile(file) 会以空 content 覆盖磁盘文件。reloading 由 activeTab 派生,
+  // 重读完成自然解除。本 effect 须位于 reloading 定义之后(const 无前向引用)。
+  useEffect(() => {
+    if (reloading) return;
+    if (!settings.autoSave || !file.path || !file.dirty || file.fileType === 'docx') return;
+    const timeout = window.setTimeout(() => {
+      void import('../services/fileService')
+        .then(({ saveFile }) => saveFile(file))
+        .then((updated) => updateActiveFile(() => updated))
+        .catch((e) => console.error('Auto-save failed:', e));
+    }, 800);
+    return () => window.clearTimeout(timeout);
+  }, [file, settings.autoSave, updateActiveFile, reloading]);
 
   useEffect(() => {
     if (!isTauriRuntime) return;

--- a/src/app/AppLayoutAutoReload.test.tsx
+++ b/src/app/AppLayoutAutoReload.test.tsx
@@ -572,3 +572,65 @@ describe('AppLayout ISS-189 dirty 抑制窗口集成', () => {
     expect(tab1?.file.content).toBe('tab-1 初始');
   });
 });
+// ISS-209 / Issue #149:降级恢复 tab(draftPersisted=false + content='' + dirty=true)
+// 的重读窗口内,autosave 800ms tick 不得触发 saveFile——否则以空 content 覆盖
+// 磁盘文件(数据丢失)。修法:autosave 守卫加 reloading 条件。
+describe('AppLayout ISS-209 降级恢复 autosave 竞态', () => {
+  let host: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    host = document.createElement('div');
+    document.body.append(host);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    host.remove();
+  });
+
+  function activateDegradedTab(path: string): void {
+    sessionState.tabs = [{
+      id: 'tab-1',
+      editorMode: 'wysiwyg',
+      rightPanelMode: 'none',
+      draftPersisted: false,
+      isPlaceholder: false,
+      file: {
+        path,
+        name: path.split('/').pop() ?? 'degraded.md',
+        content: '',
+        dirty: true,
+        lastSavedContent: '',
+        fileType: 'markdown',
+      },
+    }];
+    sessionState.activeTabId = 'tab-1';
+    sessionState.updateCount = 0;
+  }
+
+  it('重读窗口内 autosave tick 不触发 saveFile(防空 content 覆盖磁盘)', async () => {
+    activateDegradedTab('/Users/demo/degraded.md');
+    fileServiceMock.saveFile.mockClear();
+    let root: Root | null = null;
+
+    await act(async () => {
+      root = createRoot(host);
+      root.render(<AppLayout />);
+      await flushPromises();
+    });
+
+    // autosave 800ms tick 落在重读窗口内(不推进 openPath 的 resolve)
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+      await flushPromises();
+    });
+
+    // 修复前:dirty=true → saveFile(file) 以 content='' 落盘 → 清空磁盘
+    expect(fileServiceMock.saveFile).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+});

--- a/src/app/AppLayoutAutoReload.test.tsx
+++ b/src/app/AppLayoutAutoReload.test.tsx
@@ -580,12 +580,17 @@ describe('AppLayout ISS-209 降级恢复 autosave 竞态', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    // review MINOR-1 变异验证:settingsService 默认 autoSave:false,不开启则
+    // autosave effect 无条件早退、守卫删掉测试也 PASS(空转覆盖)。必须显式
+    // 开启 autosave 才能让本用例真正锁死「重读窗口内 tick 不触发 saveFile」。
+    localStorage.setItem('folia-settings', JSON.stringify({ autoSave: true }));
     host = document.createElement('div');
     document.body.append(host);
   });
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    localStorage.removeItem('folia-settings');
     host.remove();
   });
 


### PR DESCRIPTION
## Summary

落地 [ISS-209 / Issue #149](https://github.com/cat-xierluo/Folia/issues/149)(PR #148 review MINOR-1):降级恢复 tab 带 `dirty=true` + `content=''` 时,autosave 800ms tick 若在重读 effect 完成前触发,`saveFile(file)` 会**以空 content 覆盖磁盘文件**。main 既有同类窗口(ISS-42),#148 的降级机制扩大了暴露面。

## Fix

autosave effect 守卫追加 `reloading`(既有派生状态:`draftPersisted=false + content 空`,与重读 effect 完全同源)——重读窗口内 tick 不排程,重读完成自然解除,**零新增状态**。effect 物理移至 `reloading` 定义之后(const 无前向引用)。docx tab 本就免疫(autosave 早退)。

## Test plan

- [x] TDD 红→绿:+1(降级 tab + dirty + autosave 开启 → 推进 800ms → `saveFile` 不被调用;修前红)
- [x] 778/778;typecheck/lint 0 error
- [x] 既有 8 项 AutoReload 测试无回归(重排 effect 未破坏时序)

Closes #149