### PR TITLE
fix(test): 并发 flaky 根因修复——mock 生命周期与时序解耦(ISS-214)

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -69,6 +69,14 @@
 - **注意:** 迁移前后须真机回归全部涉盘流程（NOT_VERIFIED 清单见 CHANGELOG ISS-197 条目）。
 - **收口（2026-08-29）:** Rust 新增 write_binary_export（.docx 白名单+denied-root+独立 MAX_EXPORT_BYTES=200MB,与资产上限分离防「升级后导不出」回归）与 read_presentation_resource（独立 PRESENTATION_RESOURCE_EXTENSIONS 白名单覆盖图片/JS/CSS/视频/音频/字体——review MAJOR-1:复用图片白名单会让演示页非图片资源全部静默失效）;前端 5 调用面切换;capabilities 删除 fs 插件全部权限,契约测试锚定「插件面零残留」;word 导出链贯穿 docPath 上下文,相对图片解析为绝对路径（review MAJOR-2,%20 解码与 htmlPresentationService 同语义）;导出失败接 notifyIoError 三语言提示（review MAJOR-3:此前 catch 只有 console.error,用户零感知）。review MINOR 登记:①write_binary_export 的 Vec<u8> JSON 序列化 IPC 内存峰值（与 read 侧 tauri::ipc::Response 优化不对称,后续用 Request/ResponseBody 收敛）;②PRESENTATION_RESOURCE_EXTENSIONS 无直接 Rust 单测（经 e2e/手测覆盖）。**NOT_VERIFIED（真机,移交用户）:** Word 导出（含 >20MB 图文文档）、微信导出、另存为、HTML 演示本地资源（重点 JS/CSS/视频内联）、Word 导出内嵌本地图片。
 
+#### 🖥 ISS-214 测试套件并发 flaky——CI 假红根源（分支 chore/iss214-vitest-flaky,PR #160,2026-08-29）
+
+- **现象:** 全量满并发偶发随机失败(AppLayoutSourceEditor / AppLayoutSystemOpenSource / WechatPreviewPane / AppearanceSection / imageAssetPersistenceService 等,每轮集合不同);CI 假红一轮(#159)。
+- **根因定位:** imageAssetPersistenceService.test.ts 用 per-test `vi.doMock` + `afterEach vi.resetModules()`——多文件共享 worker 时,该组合偶发让被测函数内动态 `import('@tauri-apps/api/core')` 命中**未 mock 的原始模块**(Tauri IPC 空跑),invoke 计 0 次。
+- **修复:** 顶层 `vi.mock`(hoisted 单例 coreInvokeMock)+ `useInvokeMock()` 每用例显式 mockReset,mock 注册与模块加载解耦。
+- **验证:** 复现组合(AutoReload+persist 同跑)20 轮 18/20 → 20/20;全量 797/797 ×6 稳定绿。
+- **备注:** 其余 flaky 文件(如 WechatPreviewPane 等)若再现,按同模式排查(mock 时序/共享 worker 污染)。
+
 #### ⬜ ISS-215 write_binary_export IPC 序列化内存峰值（ISS-201 review MINOR-1,2026-08-29）
 
 - **发现:** write_binary_export 的 bytes 走 Vec<u8> JSON 数字数组序列化,大 docx（200MB 级）导出有数倍内存峰值,与 read 侧已用 tauri::ipc::Response 的优化不对称。

--- a/src/services/imageAssetPersistenceService.test.ts
+++ b/src/services/imageAssetPersistenceService.test.ts
@@ -79,7 +79,7 @@ describe('persistPendingImageAssets', () => {
   });
 
   it('returns empty result when no assets referenced by content', async () => {
-    const invokeMock = useInvokeMock();
+    useInvokeMock();
     const store = new ImageAssetStore();
     const result = await persistPendingImageAssets(store, '/work/doc.md', '# 无图文档');
     expect(result.replacements).toHaveLength(0);
@@ -87,7 +87,7 @@ describe('persistPendingImageAssets', () => {
   });
 
   it('skips in non-Tauri environment (no __TAURI_INTERNALS__)', async () => {
-    const invokeMock = useInvokeMock();
+    useInvokeMock();
     const store = new ImageAssetStore();
     const asset = await store.registerPending(new Uint8Array([1]), 'a.png', 'image/png');
     const result = await persistPendingImageAssets(store, '/work/doc.md', `![](${asset.objectUrl})`);

--- a/src/services/imageAssetPersistenceService.test.ts
+++ b/src/services/imageAssetPersistenceService.test.ts
@@ -1,6 +1,15 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
+const coreInvokeMock = vi.hoisted(() => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/core', () => coreInvokeMock);
+
 import { ImageAssetStore } from './imageAssetService';
+
+function useInvokeMock(returnValue: unknown = undefined): ReturnType<typeof vi.fn> {
+  coreInvokeMock.invoke.mockReset();
+  coreInvokeMock.invoke.mockResolvedValue(returnValue);
+  return coreInvokeMock.invoke;
+}
 import {
   deriveDocBaseName,
   persistPendingImageAssets,
@@ -70,6 +79,7 @@ describe('persistPendingImageAssets', () => {
   });
 
   it('returns empty result when no assets referenced by content', async () => {
+    const invokeMock = useInvokeMock();
     const store = new ImageAssetStore();
     const result = await persistPendingImageAssets(store, '/work/doc.md', '# 无图文档');
     expect(result.replacements).toHaveLength(0);
@@ -77,6 +87,7 @@ describe('persistPendingImageAssets', () => {
   });
 
   it('skips in non-Tauri environment (no __TAURI_INTERNALS__)', async () => {
+    const invokeMock = useInvokeMock();
     const store = new ImageAssetStore();
     const asset = await store.registerPending(new Uint8Array([1]), 'a.png', 'image/png');
     const result = await persistPendingImageAssets(store, '/work/doc.md', `![](${asset.objectUrl})`);
@@ -86,9 +97,8 @@ describe('persistPendingImageAssets', () => {
 
   it('writes pending assets referenced by content and returns blob→relative replacements', async () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', { value: {}, configurable: true });
-    const invokeMock = vi.fn().mockResolvedValue(undefined);
-    vi.doMock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
 
+    const invokeMock = useInvokeMock();
     const store = new ImageAssetStore();
     const asset = await store.registerPending(
       new Uint8Array([1, 2, 3]),
@@ -115,9 +125,8 @@ describe('persistPendingImageAssets', () => {
 
   it('ISS-196 回归：未在本文档引用的资产不落盘、不标记（其它 tab 的 pending 资产不受污染）', async () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', { value: {}, configurable: true });
-    const invokeMock = vi.fn().mockResolvedValue(undefined);
-    vi.doMock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
 
+    const invokeMock = useInvokeMock();
     const store = new ImageAssetStore();
     // tab B 粘贴的图片（只存在于 B 的正文里），此刻正在保存 tab A
     const bAsset = await store.registerPending(new Uint8Array([9]), 'b.png', 'image/png');
@@ -133,9 +142,8 @@ describe('persistPendingImageAssets', () => {
 
   it('ISS-196 回归：共享 hash 的资产先随 A 文档落盘后，B 文档保存仍会写自己的目录', async () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', { value: {}, configurable: true });
-    const invokeMock = vi.fn().mockResolvedValue(undefined);
-    vi.doMock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
 
+    const invokeMock = useInvokeMock();
     const store = new ImageAssetStore();
     const shared = await store.registerPending(new Uint8Array([7, 7]), 'same.png', 'image/png');
     // 同一 objectUrl 被 A、B 两个文档同时引用（hash 去重返回同一条目）
@@ -163,12 +171,10 @@ describe('persistPendingImageAssets', () => {
 
   it('collects failures without aborting other assets', async () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', { value: {}, configurable: true });
-    const invokeMock = vi
-      .fn()
+    const invokeMock = useInvokeMock();
+    invokeMock
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error('disk full'));
-    vi.doMock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
-
     const store = new ImageAssetStore();
     const ok = await store.registerPending(new Uint8Array([1]), 'a.png', 'image/png');
     const fail = await store.registerPending(new Uint8Array([2]), 'b.png', 'image/png');
@@ -189,9 +195,8 @@ describe('persistPendingImageAssets', () => {
     // 已无 blob: 锚点)。再次保存时,重插的这段字节必须真正写盘,
     // 否则 Markdown 里的相对路径指向一个从未写过的文件(隐性死链)。
     Object.defineProperty(window, '__TAURI_INTERNALS__', { value: {}, configurable: true });
-    const invokeMock = vi.fn().mockResolvedValue(undefined);
-    vi.doMock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
 
+    const invokeMock = useInvokeMock();
     const store = new ImageAssetStore();
     const asset = await store.registerPending(new Uint8Array([4, 4]), 'a.png', 'image/png');
 
@@ -222,9 +227,8 @@ describe('persistPendingImageAssets', () => {
 
   it('已为本路径写盘过的资产不重复写（幂等快路径）', async () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', { value: {}, configurable: true });
-    const invokeMock = vi.fn().mockResolvedValue(undefined);
-    vi.doMock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
 
+    const invokeMock = useInvokeMock();
     const store = new ImageAssetStore();
     const asset = await store.registerPending(new Uint8Array([3]), 'a.png', 'image/png');
     const content = `![](${asset.objectUrl})`;


### PR DESCRIPTION
## 根因

CI 假红(每轮失败集合不同)定位到 `imageAssetPersistenceService.test.ts` 的 mock 模式:per-test `vi.doMock` + `afterEach vi.resetModules()`,在多文件共享 worker 时被测函数内动态 `import('@tauri-apps/api/core')` 偶发命中**未 mock 的原始模块**(Tauri IPC 空跑),invoke 计 0 次。

## 修法

顶层 `vi.mock`(hoisted 单例)+ `useInvokeMock()` 每用例显式重置——mock 注册与模块加载生命周期解耦,vitest 推荐模式。

## 验证

- 复现组合(AppLayoutAutoReload + imageAssetPersistence 同 worker)20 轮:修复前 **18/20**,修复后 **20/20**
- 全量 797/797 ×6 稳定