### PR TITLE
fix(release): rust-cache 废弃 workdir 改 workspaces——发版 Rust 缓存恢复(ISS-213)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          workdir: src-tauri
+          workspaces: src-tauri
 
       - run: pnpm install
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -74,10 +74,11 @@
 - **发现:** write_binary_export 的 bytes 走 Vec<u8> JSON 数字数组序列化,大 docx（200MB 级）导出有数倍内存峰值,与 read 侧已用 tauri::ipc::Response 的优化不对称。
 - **建议:** 改用 tauri::ipc::Request/ResponseBody 收敛;顺带为 PRESENTATION_RESOURCE_EXTENSIONS 补直接 Rust 单测（review MINOR-2）。
 
-#### ⬜ ISS-213 release.yml 的 rust-cache workdir 同款失效（ISS-212 review 顺带发现,2026-08-29）
+#### 🖥 ISS-213 release.yml 的 rust-cache workdir 同款失效（ISS-212 review 顺带发现,2026-08-29;修复已交付 2026-08-30:分支 fix/iss213-release-rust-cache,PR 待开）
 
 - **发现:** release.yml:40-42 的 `Swatinem/rust-cache@v2` 仍用已废弃的 `workdir` 输入,同 ci.yml MAJOR-1——缓存 key 退化为空串哈希、路径错位,release 构建每次全量冷编译拖慢发版。
 - **建议:** 改 `workspaces: src-tauri`,与 ci.yml 修复同构。
+- **修复交付(2026-08-30,zcode-idle worker):** workdir→workspaces 单点同构修复;YAML 语法/单处 rust-cache/与 ci.yml 输入逐字一致断言通过;workflows 目录 workdir 零残留。运行时缓存 key 恢复需真实 release run(tag push)——NOT_VERIFIED 留下次发版观察。
 
 #### ⬜ ISS-202 CSP 收紧评估：摘 unsafe-eval + img-src 外泄通道收敛
 


### PR DESCRIPTION
## Task ID
ISS-213（docs/TASKS.md「收口 / 演进类」——release.yml 的 rust-cache workdir 同款失效，ISS-212 review 顺带发现）

## agent-id
zcode-idle/2026-08-30/ISS-213

## 分支与 commit
- 分支：`fix/iss213-release-rust-cache`（自 origin/main @ 1bef1f0 派生，safe-push 身份门禁全过）
- commit：`dfe3542` fix(release) 主修复；`8b456ca` docs(tasks) 建议状态写回

## 改动文件
| 文件 | 改动 |
|---|---|
| `.github/workflows/release.yml` | 第 42 行 `workdir: src-tauri` → `workspaces: src-tauri`（单点 1 行） |
| `docs/TASKS.md` | ISS-213 状态 ⬜→🖥 建议写回 + 修复交付注记（随本分支提交，合并与否由维护者裁决） |

## 背景与根因
`Swatinem/rust-cache@v2` 的 `workdir` 输入已废弃——ISS-212（PR #157）在 ci.yml 已实证同款失效：缓存 key 退化为空串哈希（da39a3ee）、路径错位，导致每次全量冷编译。release.yml:40-42 是 review 顺带发现的同款残留，发版链路（macOS aarch64/x86_64 + Windows 三矩阵）每次打 tag 都全量冷编译拖慢发版。本 PR 按 ISS-213 任务卡建议与 ci.yml 修复逐字同构。

## 验收命令与原始结果
1. **YAML 语法 + 结构断言**（python3 yaml.safe_load）：`ALL PASS: YAML valid, single rust-cache, workspaces input, isomorphic with ci.yml`——release.yml 恰好 1 处 rust-cache，with 块为 `{'workspaces': 'src-tauri'}`，与 ci.yml 修复后的输入逐字一致。
2. **workdir 残留扫描**：`grep -rn workdir .github/workflows/` → 零匹配（workflows 目录无任何残留）。
3. **推送身份门禁**：`safe-push.sh` → `IDENTITY_GATE_COMMIT_OK` ×2 + `SAFE_PUSH_OK`（base=origin/main，2 commits，author/committer 全程一致）。
4. **CI**：本 PR 已触发 ci.yml（typecheck/lint/test + cargo test），以后续 CI 状态为准。

## NOT_VERIFIED
- **运行时缓存 key 恢复**：release.yml 仅 tag push 触发，无法在 PR 内实跑。修复后首次真实发版时应观察到缓存 key 从空串哈希恢复为真实 lockfile 哈希（对照 ISS-212 在 ci.yml 的实证：da39a3ee → 真实 lockfile 哈希）与构建时间显著下降——留下次发版观察。
- 不涉及任何应用代码/依赖，无真机回归面。

## 建议的任务状态写回
ISS-213 → 修复已交付待 review（🖥，已随本分支写入 docs/TASKS.md）；合并后由维护者按惯例标 ✅ 并补记 PR 号。

## 风险与遗留
- 改动为 CI 基础设施单行替换，风险极低；`workspaces` 语义在 rust-cache@v2 为官方支持的正确输入（ci.yml 已在生产使用同一写法）。
- 遗留：无。相邻未动事项——ISS-202（CSP 收紧，部分等产品口径）与 ISS-215（PR #161 review 中）均不在本卡范围。